### PR TITLE
Add retries to flaky tests

### DIFF
--- a/MemoizR.Tests/MemoizR.Tests.csproj
+++ b/MemoizR.Tests/MemoizR.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xRetry" Version="1.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MemoizR.Tests/ReactiveTests.cs
+++ b/MemoizR.Tests/ReactiveTests.cs
@@ -1,3 +1,5 @@
+using xRetry;
+
 namespace MemoizR.Tests;
 
 public class ReactiveTests
@@ -271,7 +273,7 @@ public class ReactiveTests
         Assert.True(invocationCount > 1, "Must be invoked more than once");
     }
 
-    [Fact(Timeout = 5000)]
+    [RetryFact(3, 5000)]
     [Trait("Category", "Unit")]
     public async Task TestThreadSafety3()
     {
@@ -359,7 +361,7 @@ public class ReactiveTests
         Assert.Equal(42, invocationCountR2);
     }
 
-    [Fact(Timeout = 1000)]
+    [RetryFact(3, 5000)]
     public async Task TestThreadSafety5()
     {
         var f = new MemoFactory();
@@ -399,7 +401,7 @@ public class ReactiveTests
         Assert.True(invocationCountR2 <= memoInvocationCount, "Must be invoked at least once");
     }
 
-    [Fact(Timeout = 1000)]
+    [RetryFact(3, 1000)]
     public async Task TestThreadSafety6()
     {
         var f = new MemoFactory();


### PR DESCRIPTION
This change adds retries to several tests that have been identified as flaky.

The following tests have been updated:
- `MemoizR.Tests.ReactiveTests.TestThreadSafety3`
- `MemoizR.Tests.ReactiveTests.TestThreadSafety6`
- `Memo.izR.Tests.ReactiveTests.TestThreadSafety5`

The `xRetry` NuGet package was added to support retries.