### PR TITLE
Add untrack functionality

### DIFF
--- a/MemoizR.Tests/UntrackTests.cs
+++ b/MemoizR.Tests/UntrackTests.cs
@@ -1,0 +1,43 @@
+namespace MemoizR.Tests;
+
+public class UntrackTests
+{
+    [Fact]
+    public async Task TestUntrack()
+    {
+        var f = new MemoFactory();
+        var v1 = f.CreateSignal(1);
+        var invocationCount = 0;
+        var m1 = f.CreateMemoizR(async () =>
+        {
+            invocationCount++;
+            return await f.Untrack(async () => await v1.Get()) * 2;
+        });
+
+        Assert.Equal(2, await m1.Get());
+        Assert.Equal(1, invocationCount);
+
+        await v1.Set(2);
+
+        // m1 should not be dirty because v1 was untracked, so it should return the cached value.
+        Assert.Equal(2, await m1.Get());
+        Assert.Equal(1, invocationCount);
+
+        // Now v2 is tracked normally
+        var v2 = f.CreateSignal(10);
+        var m2 = f.CreateMemoizR(async () =>
+        {
+            return await m1.Get() + await v2.Get();
+        });
+
+        Assert.Equal(12, await m2.Get());
+
+        await v1.Set(3);
+        // m1 still not dirty
+        Assert.Equal(12, await m2.Get());
+
+        await v2.Set(20);
+        // m2 is dirty because of v2
+        Assert.Equal(22, await m2.Get());
+    }
+}

--- a/MemoizR/Context.cs
+++ b/MemoizR/Context.cs
@@ -103,4 +103,32 @@ public class Context
             return key;
         }
     }
+
+    public T Untrack<T>(Func<T> fn)
+    {
+        var listener = ReactionScope.CurrentReaction;
+        ReactionScope.CurrentReaction = null;
+        try
+        {
+            return fn();
+        }
+        finally
+        {
+            ReactionScope.CurrentReaction = listener;
+        }
+    }
+
+    public async Task<T> Untrack<T>(Func<Task<T>> fn)
+    {
+        var listener = ReactionScope.CurrentReaction;
+        ReactionScope.CurrentReaction = null;
+        try
+        {
+            return await fn();
+        }
+        finally
+        {
+            ReactionScope.CurrentReaction = listener;
+        }
+    }
 }

--- a/MemoizR/MemoFactory.cs
+++ b/MemoizR/MemoFactory.cs
@@ -113,4 +113,14 @@ public sealed class MemoFactory
             Label = label
         };
     }
+
+    public T Untrack<T>(Func<T> fn)
+    {
+        return Context.Untrack(fn);
+    }
+
+    public Task<T> Untrack<T>(Func<Task<T>> fn)
+    {
+        return Context.Untrack(fn);
+    }
 }


### PR DESCRIPTION
Added `Untrack` methods to `Context` and `MemoFactory` to allow reading values without collecting dependencies.
Added `UntrackTests` to verify the functionality.
Verified the changes by running tests (adjusting to .NET 10.0 for the local environment).

Fixes #14

---
*PR created automatically by Jules for task [6891569619002637232](https://jules.google.com/task/6891569619002637232) started by @timonkrebs*