### PR TITLE
Support resources in structured concurrency

### DIFF
--- a/MemoizR.StructuredConcurrency/ConcurrentMap.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentMap.cs
@@ -3,11 +3,11 @@ namespace MemoizR.StructuredConcurrency;
 public sealed class ConcurrentMap<T> : MemoHandlR<IEnumerable<T>>, IMemoizR, IStateGetR<IEnumerable<T>>
 {
     private CacheState State { get; set; } = CacheState.CacheClean;
-    private IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns;
+    private IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns;
 
     CacheState IMemoizR.State { get => State; set => State = value; }
 
-    internal ConcurrentMap(IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns, Context context) : base(context)
+    internal ConcurrentMap(IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns, Context context) : base(context)
     {
         this.fns = fns;
         this.State = CacheState.CacheDirty;
@@ -119,7 +119,7 @@ public sealed class ConcurrentMap<T> : MemoHandlR<IEnumerable<T>>, IMemoizR, ISt
         try
         {
             State = CacheState.Evaluating;
-            Value = (await new StructuredResultsJob<T>(fns, Context!, this).Run()).Select(x => x.Value);;
+            Value = (await new StructuredResultsJob<T>(fns, Context!, this).Run(Context.CancellationTokenSource!.Token)).Select(x => x.Value);
             State = CacheState.CacheClean;
         }
         catch

--- a/MemoizR.StructuredConcurrency/ConcurrentMapReduce.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentMapReduce.cs
@@ -3,12 +3,12 @@ namespace MemoizR.StructuredConcurrency;
 public sealed class ConcurrentMapReduce<T> : MemoHandlR<T>, IMemoizR, IStateGetR<T>
 {
     private CacheState State { get; set; } = CacheState.CacheClean;
-    private IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns;
+    private IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns;
     private readonly Func<T, T, T?> reduce;
 
     CacheState IMemoizR.State { get => State; set => State = value; }
 
-    internal ConcurrentMapReduce(IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns, Func<T, T, T?> reduce, Context context) : base(context)
+    internal ConcurrentMapReduce(IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns, Func<T, T, T?> reduce, Context context) : base(context)
     {
         this.fns = fns;
         this.reduce = reduce;
@@ -121,7 +121,7 @@ public sealed class ConcurrentMapReduce<T> : MemoHandlR<T>, IMemoizR, IStateGetR
         try
         {
             State = CacheState.Evaluating;
-            Value = await new StructuredReduceJob<T>(fns, reduce, Context, this).Run();
+            Value = await new StructuredReduceJob<T>(fns, reduce, Context, this).Run(Context.CancellationTokenSource!.Token);
             State = CacheState.CacheClean;
 
             // if the sources have changed, update source & observer links
@@ -179,10 +179,6 @@ public sealed class ConcurrentMapReduce<T> : MemoHandlR<T>, IMemoizR, IStateGetR
                 }
             }
         }
-
-        // We've rerun with the latest values from all of our Sources.
-        // This means that we no longer need to update until a signal changes
-        State = CacheState.CacheClean;
     }
 
     private void RemoveParentObservers(int index)

--- a/MemoizR.StructuredConcurrency/ConcurrentRace.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentRace.cs
@@ -4,13 +4,13 @@ public sealed class ConcurrentRace<T, I> : MemoHandlR<T>, IMemoizR, IStateGetR<T
 {
     private CacheState State { get; set; } = CacheState.CacheDirty;
     Func<Task<I>> action;
-    private IReadOnlyCollection<Func<CancellationTokenSource, I, Task<T>>> fns;
+    private IReadOnlyCollection<Func<IStructuredResourceGroup, I, Task<T>>> fns;
 
     CacheState IMemoizR.State { get => State; set => State = value; }
 
     internal ConcurrentRace(
         Func<Task<I>> action,
-        IReadOnlyCollection<Func<CancellationTokenSource, I, Task<T>>> fns, 
+        IReadOnlyCollection<Func<IStructuredResourceGroup, I, Task<T>>> fns,
         Context context) : base(context)
     {
         this.action = action;
@@ -65,7 +65,7 @@ public sealed class ConcurrentRace<T, I> : MemoHandlR<T>, IMemoizR, IStateGetR<T
         try
         {
             State = CacheState.Evaluating;
-            Value = await new StructuredRaceJob<T, I>(action ,fns, Context.CancellationTokenSource!).Run();
+            Value = await new StructuredRaceJob<T, I>(action ,fns, Context.CancellationTokenSource!).Run(Context.CancellationTokenSource!.Token);
             State = CacheState.CacheClean;
 
             // if the sources have changed, update source & observer links

--- a/MemoizR.StructuredConcurrency/IStructuredResourceGroup.cs
+++ b/MemoizR.StructuredConcurrency/IStructuredResourceGroup.cs
@@ -1,0 +1,8 @@
+namespace MemoizR.StructuredConcurrency;
+
+public interface IStructuredResourceGroup
+{
+    CancellationToken Token { get; }
+    void AddResource(IDisposable resource);
+    void AddResource(IAsyncDisposable resource);
+}

--- a/MemoizR.StructuredConcurrency/StructuredConcurrencyFactory.cs
+++ b/MemoizR.StructuredConcurrency/StructuredConcurrencyFactory.cs
@@ -4,12 +4,12 @@ using MemoizR.StructuredConcurrency;
 namespace MemoizR;
 public static class StructuredConcurrencyFactory
 {
-    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, params Func<CancellationTokenSource, Task<T>>[] fns) where T : INumber<T>
+    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, params Func<IStructuredResourceGroup, Task<T>>[] fns) where T : INumber<T>
     {
         return CreateConcurrentMapReduce(memoFactory, "Numeric Concurrent Reduce", fns);
     }
 
-    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, string label, params Func<CancellationTokenSource, Task<T>>[] fns) where T : INumber<T>
+    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, string label, params Func<IStructuredResourceGroup, Task<T>>[] fns) where T : INumber<T>
     {
         return new(fns, (v, a) => v + a, memoFactory.Context)
         {
@@ -17,12 +17,12 @@ public static class StructuredConcurrencyFactory
         };
     }
 
-    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, Func<T, T?, T> reduce, params Func<CancellationTokenSource, Task<T>>[] fns)
+    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, Func<T, T?, T> reduce, params Func<IStructuredResourceGroup, Task<T>>[] fns)
     {
         return CreateConcurrentMapReduce(memoFactory, "Concurrent Reduce", reduce, fns);
     }
 
-    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, string label, Func<T, T?, T> reduce, params Func<CancellationTokenSource, Task<T>>[] fns)
+    public static ConcurrentMapReduce<T> CreateConcurrentMapReduce<T>(this MemoFactory memoFactory, string label, Func<T, T?, T> reduce, params Func<IStructuredResourceGroup, Task<T>>[] fns)
     {
         return new(fns, reduce, memoFactory.Context)
         {
@@ -30,12 +30,12 @@ public static class StructuredConcurrencyFactory
         };
     }
 
-    public static ConcurrentRace<T, R> CreateConcurrentRace<T, R>(this MemoFactory memoFactory, Func<Task<R>> resolver, params Func<CancellationTokenSource, R, Task<T>>[] fns)
+    public static ConcurrentRace<T, R> CreateConcurrentRace<T, R>(this MemoFactory memoFactory, Func<Task<R>> resolver, params Func<IStructuredResourceGroup, R, Task<T>>[] fns)
     {
         return CreateConcurrentRace(memoFactory, "Concurrent Race", resolver, fns);
     }
 
-    public static ConcurrentRace<T, R> CreateConcurrentRace<T, R>(this MemoFactory memoFactory, string label, Func<Task<R>> resolver, params Func<CancellationTokenSource, R, Task<T>>[] fns)
+    public static ConcurrentRace<T, R> CreateConcurrentRace<T, R>(this MemoFactory memoFactory, string label, Func<Task<R>> resolver, params Func<IStructuredResourceGroup, R, Task<T>>[] fns)
     {
         return new(resolver, fns, memoFactory.Context)
         {
@@ -43,12 +43,12 @@ public static class StructuredConcurrencyFactory
         };
     }
 
-    public static ConcurrentMap<T> CreateConcurrentMap<T>(this MemoFactory memoFactory, params Func<CancellationTokenSource, Task<T>>[] fns)
+    public static ConcurrentMap<T> CreateConcurrentMap<T>(this MemoFactory memoFactory, params Func<IStructuredResourceGroup, Task<T>>[] fns)
     {
         return CreateConcurrentMap(memoFactory, "Concurrent Map", fns);
     }
 
-    public static ConcurrentMap<T> CreateConcurrentMap<T>(this MemoFactory memoFactory, string label, params Func<CancellationTokenSource, Task<T>>[] fns)
+    public static ConcurrentMap<T> CreateConcurrentMap<T>(this MemoFactory memoFactory, string label, params Func<IStructuredResourceGroup, Task<T>>[] fns)
     {
         return new(fns, memoFactory.Context)
         {

--- a/MemoizR.StructuredConcurrency/StructuredJobBase.cs
+++ b/MemoizR.StructuredConcurrency/StructuredJobBase.cs
@@ -1,4 +1,4 @@
-﻿using Nito.AsyncEx;
+using Nito.AsyncEx;
 
 namespace MemoizR.StructuredConcurrency;
 
@@ -8,19 +8,20 @@ public abstract class StructuredJobBase<T>
     protected T? result;
     protected AsyncLock mutex = new();
 
-    protected abstract Task AddConcurrentWork();
+    protected abstract Task AddConcurrentWork(StructuredResourceGroup resourceGroup);
 
     protected virtual void HandleSubscriptions() { }
 
-    public async Task<T> Run()
+    public async Task<T> Run(CancellationToken token)
     {
+        var resourceGroup = new StructuredResourceGroup(token);
         try
         {
             List<Task<Task>> tasks;
             using (mutex.Lock())
             {
                 this.tasks = new();
-                await AddConcurrentWork();
+                await AddConcurrentWork(resourceGroup);
                 tasks = this.tasks;
                 Parallel.ForEach(tasks, (task) => task.Start());
             }
@@ -38,6 +39,10 @@ public abstract class StructuredJobBase<T>
                 throw t.Exception;
             }
             throw;
+        }
+        finally
+        {
+            await resourceGroup.DisposeResources();
         }
     }
 }

--- a/MemoizR.StructuredConcurrency/StructuredRaceJob.cs
+++ b/MemoizR.StructuredConcurrency/StructuredRaceJob.cs
@@ -3,13 +3,13 @@
 public sealed class StructuredRaceJob<T, R> : StructuredJobBase<T>
 {
     private readonly Func<Task<R>> action;
-    private readonly IReadOnlyCollection<Func<CancellationTokenSource, R, Task<T>>> fns;
+    private readonly IReadOnlyCollection<Func<IStructuredResourceGroup, R, Task<T>>> fns;
     private readonly CancellationTokenSource innerCancellationTokenSource;
     private readonly CancellationTokenSource groupCancellationTokenSource;
     private bool finished;
 
     public StructuredRaceJob(Func<Task<R>> action,
-        IReadOnlyCollection<Func<CancellationTokenSource, R, Task<T>>> fns, CancellationTokenSource cancellationTokenSource)
+        IReadOnlyCollection<Func<IStructuredResourceGroup, R, Task<T>>> fns, CancellationTokenSource cancellationTokenSource)
     {
         this.action = action;
         this.fns = fns;
@@ -18,18 +18,34 @@ public sealed class StructuredRaceJob<T, R> : StructuredJobBase<T>
         this.innerCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token);
     }
 
-    protected override async Task AddConcurrentWork()
+    private sealed class RaceResourceGroup : IStructuredResourceGroup
+    {
+        private readonly IStructuredResourceGroup parent;
+        public CancellationToken Token { get; }
+
+        public RaceResourceGroup(IStructuredResourceGroup parent, CancellationToken token)
+        {
+            this.parent = parent;
+            this.Token = token;
+        }
+
+        public void AddResource(IDisposable resource) => parent.AddResource(resource);
+        public void AddResource(IAsyncDisposable resource) => parent.AddResource(resource);
+    }
+
+    protected override async Task AddConcurrentWork(StructuredResourceGroup resourceGroup)
     {
         var inputs = await action();
+        var raceResourceGroup = new RaceResourceGroup(resourceGroup, innerCancellationTokenSource.Token);
         tasks.AddRange(fns.Select(x => new Task<Task>(async () =>
             {
                 try
                 {
-                    result = await x(innerCancellationTokenSource, inputs);
+                    result = await x(raceResourceGroup, inputs);
                     finished = true;
                     innerCancellationTokenSource.Cancel();
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     if (!finished)
                     {

--- a/MemoizR.StructuredConcurrency/StructuredReduceJob.cs
+++ b/MemoizR.StructuredConcurrency/StructuredReduceJob.cs
@@ -4,14 +4,14 @@ public sealed class StructuredReduceJob<T> : StructuredJobBase<T>
 {
     private IList<IMemoHandlR> allSources = [];
 
-    private readonly IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns;
+    private readonly IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns;
     private readonly CancellationTokenSource cancellationTokenSource;
     private readonly Func<T, T, T?> reduce;
     private readonly Context context;
     private readonly ConcurrentMapReduce<T> @this;
     private Lock Lock { get; } = new();
 
-    public StructuredReduceJob(IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns, Func<T, T, T?> reduce, Context context, ConcurrentMapReduce<T> @this)
+    public StructuredReduceJob(IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns, Func<T, T, T?> reduce, Context context, ConcurrentMapReduce<T> @this)
     {
         this.fns = fns;
         this.reduce = reduce;
@@ -20,14 +20,14 @@ public sealed class StructuredReduceJob<T> : StructuredJobBase<T>
         this.cancellationTokenSource = context.CancellationTokenSource!;
     }
 
-    protected override Task AddConcurrentWork()
+    protected override Task AddConcurrentWork(StructuredResourceGroup resourceGroup)
     {
         tasks.AddRange(fns
         .Select(x => new Task<Task>(async () =>
             {
                 try
                 {
-                    var r = await x(cancellationTokenSource);
+                    var r = await x(resourceGroup);
                     lock (Lock)
                     {
                         result = reduce(r, result!);
@@ -64,7 +64,7 @@ public sealed class StructuredReduceJob<T> : StructuredJobBase<T>
                     }
                 }
 
-            }, cancellationTokenSource.Token)
+            }, resourceGroup.Token)
         ));
         return Task.CompletedTask;
     }

--- a/MemoizR.StructuredConcurrency/StructuredResourceGroup.cs
+++ b/MemoizR.StructuredConcurrency/StructuredResourceGroup.cs
@@ -1,0 +1,63 @@
+namespace MemoizR.StructuredConcurrency;
+
+public sealed class StructuredResourceGroup : IStructuredResourceGroup
+{
+    private readonly List<object> resources = new();
+    private readonly Lock mutex = new();
+
+    public CancellationToken Token { get; }
+
+    public StructuredResourceGroup(CancellationToken token)
+    {
+        Token = token;
+    }
+
+    public void AddResource(IDisposable resource)
+    {
+        lock (mutex)
+        {
+            resources.Add(resource);
+        }
+    }
+
+    public void AddResource(IAsyncDisposable resource)
+    {
+        lock (mutex)
+        {
+            resources.Add(resource);
+        }
+    }
+
+    public async Task DisposeResources()
+    {
+        List<object> resourcesToDispose;
+        lock (mutex)
+        {
+            resourcesToDispose = new List<object>(resources);
+            resources.Clear();
+        }
+
+        resourcesToDispose.Reverse();
+
+        foreach (var resource in resourcesToDispose)
+        {
+            try
+            {
+                if (resource is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (resource is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+            catch
+            {
+                // Exceptions during disposal are typically ignored in structured concurrency
+                // or aggregated. For now, we'll follow the pattern of ignoring them to avoid
+                // masking the original exception.
+            }
+        }
+    }
+}

--- a/MemoizR.StructuredConcurrency/StructuredResultsJob.cs
+++ b/MemoizR.StructuredConcurrency/StructuredResultsJob.cs
@@ -7,13 +7,13 @@ public sealed class StructuredResultsJob<T> : StructuredJobBase<ConcurrentDictio
     private IList<IMemoHandlR> allSources = [];
 
 
-    private readonly IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns;
+    private readonly IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns;
     private readonly Context context;
     private readonly ConcurrentMap<T> @this;
     private readonly CancellationTokenSource cancellationTokenSource;
     private Lock Lock { get; } = new();
 
-    public StructuredResultsJob(IReadOnlyCollection<Func<CancellationTokenSource, Task<T>>> fns, Context context, ConcurrentMap<T> @this)
+    public StructuredResultsJob(IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns, Context context, ConcurrentMap<T> @this)
     {
         this.fns = fns;
         this.context = context;
@@ -22,7 +22,7 @@ public sealed class StructuredResultsJob<T> : StructuredJobBase<ConcurrentDictio
         this.cancellationTokenSource = context.CancellationTokenSource!;
     }
 
-    protected override Task AddConcurrentWork()
+    protected override Task AddConcurrentWork(StructuredResourceGroup resourceGroup)
     {
         tasks.AddRange(fns
         .Select((x, i) => new Task<Task>(async () =>
@@ -31,7 +31,7 @@ public sealed class StructuredResultsJob<T> : StructuredJobBase<ConcurrentDictio
                 context.ReactionScope.CurrentReaction = @this;
                 try
                 {
-                    result!.TryAdd(i, await x(cancellationTokenSource));
+                    result!.TryAdd(i, await x(resourceGroup));
                 }
                 catch
                 {
@@ -64,7 +64,7 @@ public sealed class StructuredResultsJob<T> : StructuredJobBase<ConcurrentDictio
                     }
                 }
 
-            }, cancellationTokenSource.Token)
+            }, resourceGroup.Token)
         ));
         return Task.CompletedTask;
     }

--- a/MemoizR.Tests/ResourceManagementTests.cs
+++ b/MemoizR.Tests/ResourceManagementTests.cs
@@ -1,0 +1,126 @@
+using MemoizR.StructuredConcurrency;
+
+namespace MemoizR.Tests;
+
+public class ResourceManagementTests
+{
+    private class TestResource : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private class AsyncTestResource : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task TestResourceDisposal()
+    {
+        var f = new MemoFactory();
+        var resource1 = new TestResource();
+        var resource2 = new AsyncTestResource();
+
+        var c1 = f.CreateConcurrentMapReduce(
+            async r =>
+            {
+                r.AddResource(resource1);
+                r.AddResource(resource2);
+                await Task.Delay(10);
+                return 1;
+            },
+            async r =>
+            {
+                await Task.Delay(10);
+                return 2;
+            });
+
+        Assert.Equal(3, await c1.Get());
+        Assert.True(resource1.IsDisposed);
+        Assert.True(resource2.IsDisposed);
+    }
+
+    [Fact]
+    public async Task TestResourceDisposalOnFailure()
+    {
+        var f = new MemoFactory();
+        var resource = new TestResource();
+
+        var c1 = f.CreateConcurrentMapReduce(
+            async r =>
+            {
+                r.AddResource(resource);
+                await Task.Delay(10);
+                throw new Exception("Test failure");
+            },
+            async r =>
+            {
+                await Task.Delay(100);
+                return 2;
+            });
+
+        await Assert.ThrowsAsync<AggregateException>(async () => await c1.Get());
+        Assert.True(resource.IsDisposed);
+    }
+
+    [Fact]
+    public async Task TestResourceDisposalOrder()
+    {
+        var f = new MemoFactory();
+        var disposalOrder = new List<int>();
+
+        var resource1 = new ActionDisposable(() => disposalOrder.Add(1));
+        var resource2 = new ActionDisposable(() => disposalOrder.Add(2));
+
+        var c1 = f.CreateConcurrentMapReduce(
+            async r =>
+            {
+                r.AddResource(resource1);
+                r.AddResource(resource2);
+                return 1;
+            });
+
+        await c1.Get();
+        Assert.Equal(new[] { 2, 1 }, disposalOrder);
+    }
+
+    [Fact]
+    public async Task TestRaceResourceDisposal()
+    {
+        var f = new MemoFactory();
+        var resource1 = new TestResource();
+        var resource2 = new TestResource();
+
+        var c1 = f.CreateConcurrentRace(
+            async () => "input",
+            async (r, i) =>
+            {
+                r.AddResource(resource1);
+                await Task.Delay(10);
+                return 1;
+            },
+            async (r, i) =>
+            {
+                r.AddResource(resource2);
+                await Task.Delay(1000);
+                return 2;
+            });
+
+        await c1.Get();
+        Assert.True(resource1.IsDisposed);
+        Assert.True(resource2.IsDisposed);
+    }
+
+    private class ActionDisposable : IDisposable
+    {
+        private readonly Action action;
+        public ActionDisposable(Action action) => this.action = action;
+        public void Dispose() => action();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ var c1 = f.CreateConcurrentMapReduce(
 var x = await c1.Get();
 ```
 
+### Resources
+
+A concurrent job can own resources. These resources will be disposed by the job after all its work is done.
+
+```cs
+var groupTask = f.CreateConcurrentMapReduce(async group =>
+{
+    group.AddResource(myDisposableResource);
+
+    return await myDisposableResource.DoWorkAsync(group.Token);
+});
+await groupTask.Get(); // First, waits for all tasks to complete; then, disposes myDisposableResource.
+```
+
+All exceptions raised by disposal of any resource are ignored.
+
 ### Reactivity
 ```cs
 var f = new MemoFactory();


### PR DESCRIPTION
This change adds support for automatic resource management within structured concurrency jobs, similar to Stephen Cleary's StructuredConcurrency library. Concurrent tasks can now register `IDisposable` and `IAsyncDisposable` objects that are guaranteed to be cleaned up when the job finishes, even in the event of failures. This is achieved by passing an `IStructuredResourceGroup` to concurrent delegates, which also provides access to the cancellation token.

Fixes #22

---
*PR created automatically by Jules for task [11452861593221020276](https://jules.google.com/task/11452861593221020276) started by @timonkrebs*