### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/timonkrebs/MemoizR/security/code-scanning/2](https://github.com/timonkrebs/MemoizR/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so token scope is least-privilege and self-documented.

Best fix here (without changing functionality): add a root-level block after `on:` (or after `name:`) with:

- `contents: read`

This is sufficient for `actions/checkout` and build/test steps that only read repository contents. No imports, methods, or dependencies are needed since this is YAML configuration only.

File to edit: `.github/workflows/dotnet.yml`  
Region: near top-level keys (`name`, `on`, `jobs`), before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
