### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace weak random number generation with Guid for async context tracking

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-10 - Replace Weak Random Number Generation with Guid
+**Vulnerability:** Weak random number generation (`Random.Shared.NextDouble()`) was used to generate unique identifiers for asynchronous execution and locking scopes. This is predictable and lacks proper collision resistance.
+**Learning:** In highly concurrent code using `AsyncLocal` contexts, predictable identifiers can theoretically allow cross-talk or lock-hijacking if scopes collide or are successfully guessed.
+**Prevention:** Always use a cryptographically strong unique identifier such as `Guid.NewGuid()` when needing uniqueness guarantees in asynchronous flow scopes, rather than `Random.Shared.NextDouble()`.

--- a/MemoizR.StructuredAsyncLock/AsyncAsymmetricLock.cs
+++ b/MemoizR.StructuredAsyncLock/AsyncAsymmetricLock.cs
@@ -27,10 +27,10 @@ public sealed class AsyncAsymmetricLock
     // so the monitor already provides the fences and atomicity. No `volatile` is needed.
     private int locksHeld;
     private int upgradedLocksHeld;
-    private double lockScope;
-    private static readonly AsyncLocal<double> AsyncLocalScope = new();
+    private Guid lockScope;
+    private static readonly AsyncLocal<Guid> AsyncLocalScope = new();
 
-    internal double LockScope
+    internal Guid LockScope
     {
         get
         {
@@ -74,7 +74,7 @@ public sealed class AsyncAsymmetricLock
     /// Asynchronously acquires the lock as a exclusive. Returns a disposable that releases the lock when disposed.
     /// </summary>
     /// <returns>A disposable that releases the lock when disposed.</returns>
-    private Task<IDisposable> RequestExclusiveLockAsync(double lockScope)
+    private Task<IDisposable> RequestExclusiveLockAsync(Guid lockScope)
     {
         if (LockScope == lockScope && LocksHeld < 0)
         {
@@ -110,16 +110,13 @@ public sealed class AsyncAsymmetricLock
     /// <returns>A disposable that releases the lock when disposed.</returns>
     public Task<IDisposable> ExclusiveLockAsync()
     {
-        double lockScope;
+        Guid lockScope;
         lock (Lock)
         {
             lockScope = AsyncLocalScope.Value;
-            if (lockScope == 0)
+            if (lockScope == Guid.Empty)
             {
-                do
-                {
-                    lockScope = Random.Shared.NextDouble();
-                } while (lockScope == 0);
+                lockScope = Guid.NewGuid();
                 AsyncLocalScope.Value = lockScope;
             }
             // Return a plain Task<IDisposable> rather than the custom AwaitableDisposable
@@ -135,7 +132,7 @@ public sealed class AsyncAsymmetricLock
     /// </summary>
     /// <param name="cancellationToken">The cancellation token used to cancel the lock. If this is already set, then this method will attempt to take the lock immediately (succeeding if the lock is currently available).</param>
     /// <returns>A disposable that releases the lock when disposed.</returns>
-    private Task<IDisposable> RequestUpgradeableLockAsync(double lockScope)
+    private Task<IDisposable> RequestUpgradeableLockAsync(Guid lockScope)
     {
         if (LocksHeld == 0 && UpgradedLocksHeld == 0)
         {
@@ -158,16 +155,13 @@ public sealed class AsyncAsymmetricLock
     /// <returns>A disposable that releases the lock when disposed.</returns>
     public Task<IDisposable> UpgradeableLockAsync()
     {
-        double lockScope;
+        Guid lockScope;
         lock (Lock)
         {
             lockScope = AsyncLocalScope.Value;
-            if (lockScope == 0)
+            if (lockScope == Guid.Empty)
             {
-                do
-                {
-                    lockScope = Random.Shared.NextDouble();
-                } while (lockScope == 0);
+                lockScope = Guid.NewGuid();
                 AsyncLocalScope.Value = lockScope;
             }
             return RequestUpgradeableLockAsync(lockScope);
@@ -211,7 +205,7 @@ public sealed class AsyncAsymmetricLock
             Interlocked.Decrement(ref locksHeld);
             if (LocksHeld == 0)
             {
-                LockScope = 0;
+                LockScope = Guid.Empty;
             }
             ReleaseWaiters();
         }
@@ -229,7 +223,7 @@ public sealed class AsyncAsymmetricLock
                 Interlocked.Decrement(ref upgradedLocksHeld);
                 if (UpgradedLocksHeld == 0 && LocksHeld == 0)
                 {
-                    LockScope = 0;
+                    LockScope = Guid.Empty;
                 }
             }
             else

--- a/MemoizR.StructuredAsyncLock/Nito/AsyncWaitQueue.cs
+++ b/MemoizR.StructuredAsyncLock/Nito/AsyncWaitQueue.cs
@@ -18,14 +18,14 @@ internal interface IAsyncWaitQueue<T>
     /// Creates a new entry and queues it to this wait queue. The returned task must support both synchronous and asynchronous waits.
     /// </summary>
     /// <returns>The queued task.</returns>
-    Task<T> Enqueue(double lockScope);
+    Task<T> Enqueue(Guid lockScope);
 
     /// <summary>
     /// Removes a single entry in the wait queue and completes it. This method may only be called if <see cref="IsEmpty"/> is <c>false</c>. The task continuations for the completed task must be executed asynchronously.
     /// </summary>
     /// <param name="result">The result used to complete the wait queue entry. If this isn't needed, use <c>default(T)</c>.</param>
     /// <returns>The lock scope associated with the completed entry.</returns>
-    double Dequeue(T? result = default);
+    Guid Dequeue(T? result = default);
 }
 
 /// <summary>
@@ -36,7 +36,7 @@ internal interface IAsyncWaitQueue<T>
 [DebuggerTypeProxy(typeof(DefaultAsyncWaitQueue<>.DebugView))]
 internal sealed class DefaultAsyncWaitQueue<T> : IAsyncWaitQueue<T>
 {
-    private readonly Deque<(TaskCompletionSource<T>, double)> _queue = new();
+    private readonly Deque<(TaskCompletionSource<T>, Guid)> _queue = new();
 
     private int Count
     {
@@ -48,14 +48,14 @@ internal sealed class DefaultAsyncWaitQueue<T> : IAsyncWaitQueue<T>
         get { return Count == 0; }
     }
 
-    Task<T> IAsyncWaitQueue<T>.Enqueue(double lockScope)
+    Task<T> IAsyncWaitQueue<T>.Enqueue(Guid lockScope)
     {
         var tcs = TaskCompletionSourceExtensions.CreateAsyncTaskSource<T>();
         _queue.AddToBack((tcs, lockScope));
         return tcs.Task;
     }
 
-    double IAsyncWaitQueue<T>.Dequeue(T? result)
+    Guid IAsyncWaitQueue<T>.Dequeue(T? result)
     {
         var res = _queue.RemoveFromFront();
 

--- a/MemoizR.Tests/RegressionTests.cs
+++ b/MemoizR.Tests/RegressionTests.cs
@@ -25,7 +25,7 @@ public class RegressionTests
 
         Assert.Equal(0, asyncLock.LocksHeld);
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
     }
 
     // Scope keys are generated with a thread-safe RNG (Random.Shared). Previously a static

--- a/MemoizR.Tests/StructuredAsyncLockTests.cs
+++ b/MemoizR.Tests/StructuredAsyncLockTests.cs
@@ -10,7 +10,7 @@ public class AsyncAsymmetricLockTests
         // Arrange
         var asyncLock = new AsyncAsymmetricLock();
         var cancellationTokenSource = new CancellationTokenSource();
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
 
         // Act
         using (var disposable = await asyncLock.ExclusiveLockAsync())
@@ -20,7 +20,7 @@ public class AsyncAsymmetricLockTests
             Assert.NotNull(disposable);
             Assert.Equal(1, asyncLock.LocksHeld);
             Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-            Assert.NotEqual(0, lockScope);
+            Assert.NotEqual(Guid.Empty, lockScope);
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
@@ -34,7 +34,7 @@ public class AsyncAsymmetricLockTests
     {
         // Arrange
         var asyncLock = new AsyncAsymmetricLock();
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
 
         // Act
         using (var disposable = await asyncLock.UpgradeableLockAsync())
@@ -44,7 +44,7 @@ public class AsyncAsymmetricLockTests
             Assert.NotNull(disposable);
             Assert.Equal(0, asyncLock.LocksHeld);
             Assert.Equal(1, asyncLock.UpgradedLocksHeld);
-            Assert.NotEqual(0, lockScope);
+            Assert.NotEqual(Guid.Empty, lockScope);
 
             using (var disposable2 = await asyncLock.UpgradeableLockAsync())
             {
@@ -61,7 +61,7 @@ public class AsyncAsymmetricLockTests
 
         Assert.Equal(0, asyncLock.LocksHeld);
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
     }
 
     [Fact(Timeout = 500)]
@@ -76,7 +76,7 @@ public class AsyncAsymmetricLockTests
         // Assert
         Assert.Equal(0, asyncLock.LocksHeld);
         Assert.Equal(1, asyncLock.UpgradedLocksHeld);
-        Assert.NotEqual(0, asyncLock.LockScope);
+        Assert.NotEqual(Guid.Empty, asyncLock.LockScope);
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
@@ -97,7 +97,7 @@ public class AsyncAsymmetricLockTests
         var lockScope = asyncLock.LockScope;
         Assert.Equal(1, asyncLock.LocksHeld);
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.NotEqual(0, lockScope);
+        Assert.NotEqual(Guid.Empty, lockScope);
 
         using (var disposable = await asyncLock.UpgradeableLockAsync())
         {
@@ -117,7 +117,7 @@ public class AsyncAsymmetricLockTests
 
         Assert.Equal(1, asyncLock.LocksHeld);
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.NotEqual(0, lockScope);
+        Assert.NotEqual(Guid.Empty, lockScope);
     }
 
     [Fact(Timeout = 10000)]
@@ -126,7 +126,7 @@ public class AsyncAsymmetricLockTests
         // Arrange
         var asyncLock = new AsyncAsymmetricLock();
 
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
 
         var task1 = SimulateGet(asyncLock);
         await Task.Delay(10);
@@ -147,7 +147,7 @@ public class AsyncAsymmetricLockTests
         await Task.WhenAll([task1, task2, task3, .. tasks]);
         Assert.Equal(0, asyncLock.LocksHeld);
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
     }
 
     private async Task SimulateGet(AsyncAsymmetricLock asyncLock)
@@ -159,15 +159,15 @@ public class AsyncAsymmetricLockTests
             Assert.NotNull(upgradeableDisposable2);
             Assert.Equal(0, asyncLock.LocksHeld);
             Assert.Equal(1, asyncLock.UpgradedLocksHeld);
-            Assert.NotEqual(0, asyncLock.LockScope);
+            Assert.NotEqual(Guid.Empty, asyncLock.LockScope);
             await Task.Delay(5);
         }
     }
 
     private async Task SimulateReaction(AsyncAsymmetricLock asyncLock)
     {
-        var oldLockScope = asyncLock.LockScope == 0 ? 42 : asyncLock.LockScope;
-        double lockScope = 0;
+        var oldLockScope = asyncLock.LockScope == Guid.Empty ? Guid.NewGuid() : asyncLock.LockScope;
+        Guid lockScope = Guid.Empty;
 
         // Act
         using (var exclusive = await asyncLock.ExclusiveLockAsync())
@@ -175,7 +175,7 @@ public class AsyncAsymmetricLockTests
             // Assert
             await Task.Delay(5);
             lockScope = asyncLock.LockScope;
-            Assert.NotEqual(0, lockScope);
+            Assert.NotEqual(Guid.Empty, lockScope);
             Assert.NotEqual(oldLockScope, lockScope);
             Assert.Equal(1, asyncLock.LocksHeld);
             Assert.Equal(0, asyncLock.UpgradedLocksHeld);
@@ -277,7 +277,7 @@ public class AsyncAsymmetricLockTests
         Assert.Equal(100, counter);                  // mutual exclusion held => no lost updates
         Assert.Equal(0, asyncLock.LocksHeld);        // every acquire released => no leak
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.Equal(0, asyncLock.LockScope);        // fully drained => no lost wake-up / deadlock
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);        // fully drained => no lost wake-up / deadlock
     }
 
     [Fact(Timeout = 10000)]
@@ -301,7 +301,7 @@ public class AsyncAsymmetricLockTests
         Assert.Equal(100, counter);
         Assert.Equal(0, asyncLock.LocksHeld);
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
     }
 
     // --- Regression: releasing a lock must not corrupt the releasing flow's own scope ---
@@ -360,6 +360,6 @@ public class AsyncAsymmetricLockTests
         await Task.WhenAll(holderTask, waiterTask);
         Assert.Equal(0, asyncLock.LocksHeld);
         Assert.Equal(0, asyncLock.UpgradedLocksHeld);
-        Assert.Equal(0, asyncLock.LockScope);
+        Assert.Equal(Guid.Empty, asyncLock.LockScope);
     }
 }

--- a/MemoizR/Context.cs
+++ b/MemoizR/Context.cs
@@ -17,11 +17,11 @@ public class ReactionScope
 public class Context
 {
     private Lock Lock { get; } = new();
-    private static readonly AsyncLocal<double> AsyncLocalScope = new();
+    private static readonly AsyncLocal<Guid> AsyncLocalScope = new();
 
     /** current capture context for identifying sources (other memoizR elements)
     * - active while evaluating a memoizR function body  */
-    private Dictionary<double, WeakReference<ReactionScope>> AsyncReactionScopes = new();
+    private Dictionary<Guid, WeakReference<ReactionScope>> AsyncReactionScopes = new();
 
     public ReactionScope ReactionScope
     {
@@ -29,7 +29,7 @@ public class Context
         {
             lock (Lock)
             {
-                var key = AsyncLocalScope.Value == 0 ? Random.Shared.NextDouble() : AsyncLocalScope.Value;
+                var key = AsyncLocalScope.Value == Guid.Empty ? Guid.NewGuid() : AsyncLocalScope.Value;
                 ReactionScope reactionScope;
                 if (!AsyncReactionScopes.TryGetValue(key, out var reactionScopeRef))
                 {
@@ -53,11 +53,11 @@ public class Context
     {
         lock (Lock)
         {
-            if (AsyncLocalScope.Value != 0)
+            if (AsyncLocalScope.Value != Guid.Empty)
             {
                 return;
             }
-            var key = Random.Shared.NextDouble();
+            var key = Guid.NewGuid();
             AsyncLocalScope.Value = key;
             AsyncReactionScopes.Add(key, new(new()));
         }
@@ -93,11 +93,11 @@ public class Context
         }
     }
 
-    internal double ForceNewScope()
+    internal Guid ForceNewScope()
     {
         lock (Lock)
         {
-            var key = Random.Shared.NextDouble();
+            var key = Guid.NewGuid();
             AsyncLocalScope.Value = key;
             AsyncReactionScopes.Add(key, new(new()));
             return key;


### PR DESCRIPTION
Replaced `Random.Shared.NextDouble()` with `Guid.NewGuid()` across the codebase to generate unique context tracking and lock identifiers. This fixes a medium severity vulnerability where predictable, non-cryptographically secure random values were used to map concurrent execution scopes, which can lead to collisions or scope hijacking in highly concurrent async scenarios. Tests were updated and run to verify stability.

---
*PR created automatically by Jules for task [1575880442013088575](https://jules.google.com/task/1575880442013088575) started by @timonkrebs*