### PR TITLE
⚡ Bolt: optimize LINQ array allocations in hot paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Array operations with WeakReferences
+**Learning:** When optimizing array manipulations involving `WeakReference`s, avoid two-pass algorithms (e.g., counting then allocating) because the garbage collector can collect targets between the passes, resulting in invalid counts and subsequent `NullReferenceException`s.
+**Action:** Use a single-pass iteration with a temporary array sized to the maximum possible length, and truncate it afterward (`Array.Resize` or `Array.Copy`).

--- a/MemoizR.StructuredConcurrency/StructuredJobBase.cs
+++ b/MemoizR.StructuredConcurrency/StructuredJobBase.cs
@@ -31,9 +31,9 @@ public abstract class StructuredJobBase<T>
     {
         lock (Lock)
         {
-            foreach (var source in owner.Sources.Take(scope.CurrentGetsIndex))
+            for (var i = 0; i < scope.CurrentGetsIndex && i < owner.Sources.Length; i++)
             {
-                allSources.Add(source);
+                allSources.Add(owner.Sources[i]);
             }
             foreach (var source in scope.CurrentGets)
             {

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -77,7 +77,23 @@ public abstract class SignalHandlR : IMemoHandlR
         lock (Lock)
         {
             // Dead weak references are swept opportunistically while we are rebuilding anyway.
-            Observers = [.. Observers.Where(x => x.TryGetTarget(out var o) && !ReferenceEquals(o, observer))];
+            var temp = new WeakReference<IMemoizR>[Observers.Length];
+            var j = 0;
+            for (int i = 0; i < Observers.Length; i++)
+            {
+                if (Observers[i].TryGetTarget(out var o) && !ReferenceEquals(o, observer))
+                {
+                    temp[j++] = Observers[i];
+                }
+            }
+
+            if (j == Observers.Length)
+            {
+                return;
+            }
+
+            Array.Resize(ref temp, j);
+            Observers = temp;
         }
     }
 
@@ -99,13 +115,21 @@ public abstract class SignalHandlR : IMemoHandlR
         IMemoHandlR[] newSources;
         if (scope.CurrentGets.Length > 0)
         {
-            newSources = Sources.Length > 0 && scope.CurrentGetsIndex > 0
-                ? [.. Sources.Take(scope.CurrentGetsIndex), .. scope.CurrentGets]
-                : scope.CurrentGets;
+            if (Sources.Length > 0 && scope.CurrentGetsIndex > 0)
+            {
+                newSources = new IMemoHandlR[scope.CurrentGetsIndex + scope.CurrentGets.Length];
+                Array.Copy(Sources, newSources, scope.CurrentGetsIndex);
+                Array.Copy(scope.CurrentGets, 0, newSources, scope.CurrentGetsIndex, scope.CurrentGets.Length);
+            }
+            else
+            {
+                newSources = scope.CurrentGets;
+            }
         }
         else if (Sources.Length > 0 && scope.CurrentGetsIndex < Sources.Length)
         {
-            newSources = [.. Sources.Take(scope.CurrentGetsIndex)];
+            newSources = new IMemoHandlR[scope.CurrentGetsIndex];
+            Array.Copy(Sources, newSources, scope.CurrentGetsIndex);
         }
         else
         {


### PR DESCRIPTION
💡 What: Replaced LINQ methods (`.Where()`, `.Take()`) and IEnumerable allocations in critical paths within `MemoHandlR.cs` and `StructuredJobBase.cs` with manual array allocations (`Array.Resize()`, `Array.Copy()`) and single-pass `for` loops.

🎯 Why: In a highly reactive dependency graph, hot paths repeatedly iterate collections (`Observers`, `Sources`). Using LINQ allocates closures and `IEnumerator`s under the hood which generates unnecessary GC pressure during computations.

📊 Impact: Reduces array-related allocations during dependency rewiring by removing interface dispatch/enumerator overhead.

🔬 Measurement: Evaluated with existing test suite covering threading and graph reactivity. The optimizations maintain logical correctness while switching from `.Where` / `.Take` slices to direct indices.

---
*PR created automatically by Jules for task [17216016604967126822](https://jules.google.com/task/17216016604967126822) started by @timonkrebs*