### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix swallowed exceptions during resource disposal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-13 - [Fix Silent Swallowing of Exceptions During Resource Disposal]
+**Vulnerability:** Structured concurrency `DisposeResources` ignored/swallowed all exceptions thrown by resource `Dispose()` or `DisposeAsync()` calls instead of aggregating them.
+**Learning:** Silently failing to clean up resources (which could result in connection leaks, unreleased locks, file descriptor leaks) poses a Denial of Service or security impact depending on what resource failed to clean up.
+**Prevention:** Always accumulate disposal exceptions during teardown and throw an `AggregateException` to ensure developers are aware of cleanup failures and can handle them appropriately.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2024-06-13 - [Fix Silent Swallowing of Exceptions During Resource Disposal]
+## 2026-06-13 - [Fix Silent Swallowing of Exceptions During Resource Disposal]
 **Vulnerability:** Structured concurrency `DisposeResources` ignored/swallowed all exceptions thrown by resource `Dispose()` or `DisposeAsync()` calls instead of aggregating them.
 **Learning:** Silently failing to clean up resources (which could result in connection leaks, unreleased locks, file descriptor leaks) poses a Denial of Service or security impact depending on what resource failed to clean up.
 **Prevention:** Always accumulate disposal exceptions during teardown and throw an `AggregateException` to ensure developers are aware of cleanup failures and can handle them appropriately.

--- a/MemoizR.StructuredConcurrency/StructuredResourceGroup.cs
+++ b/MemoizR.StructuredConcurrency/StructuredResourceGroup.cs
@@ -39,6 +39,8 @@ public sealed class StructuredResourceGroup : IStructuredResourceGroup
 
         resourcesToDispose.Reverse();
 
+        List<Exception>? exceptions = null;
+
         foreach (var resource in resourcesToDispose)
         {
             try
@@ -52,12 +54,14 @@ public sealed class StructuredResourceGroup : IStructuredResourceGroup
                     disposable.Dispose();
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Exceptions during disposal are typically ignored in structured concurrency
-                // or aggregated. For now, we'll follow the pattern of ignoring them to avoid
-                // masking the original exception.
+                (exceptions ??= new()).Add(ex);
             }
+        }
+        if (exceptions != null)
+        {
+            throw new AggregateException(exceptions);
         }
     }
 }

--- a/MemoizR.Tests/ResourceManagementTests.cs
+++ b/MemoizR.Tests/ResourceManagementTests.cs
@@ -117,6 +117,29 @@ public class ResourceManagementTests
         Assert.True(resource2.IsDisposed);
     }
 
+
+    [Fact]
+    public async Task TestResourceDisposalExceptionsAreAggregated()
+    {
+        var f = new MemoFactory();
+
+        var resource1 = new ActionDisposable(() => throw new InvalidOperationException("dispose 1"));
+        var resource2 = new ActionDisposable(() => throw new InvalidOperationException("dispose 2"));
+
+        var c1 = f.CreateConcurrentMapReduce(
+            r =>
+            {
+                r.AddResource(resource1);
+                r.AddResource(resource2);
+                return Task.FromResult(1);
+            });
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(async () => await c1.Get());
+        Assert.Equal(2, ex.InnerExceptions.Count);
+        Assert.Equal("dispose 2", ex.InnerExceptions[0].Message);
+        Assert.Equal("dispose 1", ex.InnerExceptions[1].Message);
+    }
+
     private class ActionDisposable : IDisposable
     {
         private readonly Action action;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix swallowed exceptions during resource disposal

🚨 Severity: MEDIUM
💡 Vulnerability: The `StructuredResourceGroup.DisposeResources` method silently caught and ignored any exceptions thrown when closing/disposing `IDisposable` and `IAsyncDisposable` resources.
🎯 Impact: This could lead to silent failures where critical resources (e.g. database connections, file handles, async locks) fail to release, potentially causing resource starvation, application hangs, or Denial of Service vulnerabilities because the failure is never surfaced to the caller.
🔧 Fix: Updated the disposal loop to accumulate any exceptions thrown during resource disposal and throw an `AggregateException` containing them, ensuring errors are reported to the caller while still attempting to close all registered resources.
✅ Verification: Created a unit test `TestResourceDisposalExceptionsAreAggregated` to verify that disposal exceptions from multiple resources are aggregated and correctly thrown. Ran the full test suite and validated the behavior.

---
*PR created automatically by Jules for task [14212106508964473221](https://jules.google.com/task/14212106508964473221) started by @timonkrebs*