### PR TITLE
Fix silent exception swallowing during resource disposal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-13 - [Fix Silent Swallowing of Exceptions During Resource Disposal]
+**Vulnerability:** Structured concurrency `DisposeResources` ignored/swallowed all exceptions thrown by resource `Dispose()` or `DisposeAsync()` calls instead of aggregating them.
+**Learning:** Silently failing to clean up resources (which could result in connection leaks, unreleased locks, file descriptor leaks) poses a Denial of Service or security impact depending on what resource failed to clean up.
+**Prevention:** Always accumulate disposal exceptions during teardown and throw an `AggregateException` to ensure developers are aware of cleanup failures and can handle them appropriately.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2024-06-13 - [Fix Silent Swallowing of Exceptions During Resource Disposal]
+## 2026-06-13 - [Fix Silent Swallowing of Exceptions During Resource Disposal]
 **Vulnerability:** Structured concurrency `DisposeResources` ignored/swallowed all exceptions thrown by resource `Dispose()` or `DisposeAsync()` calls instead of aggregating them.
 **Learning:** Silently failing to clean up resources (which could result in connection leaks, unreleased locks, file descriptor leaks) poses a Denial of Service or security impact depending on what resource failed to clean up.
 **Prevention:** Always accumulate disposal exceptions during teardown and throw an `AggregateException` to ensure developers are aware of cleanup failures and can handle them appropriately.

--- a/MemoizR.StructuredConcurrency/StructuredJobBase.cs
+++ b/MemoizR.StructuredConcurrency/StructuredJobBase.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using Nito.AsyncEx;
 
 namespace MemoizR.StructuredConcurrency;
@@ -51,6 +52,11 @@ public abstract class StructuredJobBase<T>
         // allocating a second full set of unwrap wrappers over the same children -- and could
         // even await never-started cold tasks if AddConcurrentWork itself had thrown.
         var completion = Task.CompletedTask;
+        // The job-body fault (if any) is captured here rather than thrown straight away, so that
+        // resource disposal still runs afterwards and a disposal fault can be COMBINED with it
+        // instead of replacing it. Throwing directly out of the disposal `finally` used to mask
+        // the original job failure -- the diagnosability problem this method now guards against.
+        ExceptionDispatchInfo? jobException = null;
         try
         {
             using (await mutex.LockAsync())
@@ -85,12 +91,11 @@ public abstract class StructuredJobBase<T>
 
             await completion;
             HandleSubscriptions();
-            return result!;
         }
-        catch
+        catch (Exception bodyException)
         {
             // Surface every fault aggregated. `await Task.WhenAll` only rethrows the first
-            // exception, so we wait for completion and then throw the full AggregateException.
+            // exception, so we wait for completion and then capture the full AggregateException.
             // We use an explicit try/catch rather than ConfigureAwaitOptions.SuppressThrowing,
             // which the Coyote rewriter does not honour (under instrumentation it rethrew a
             // single unwrapped exception, breaking AggregateException expectations).
@@ -100,17 +105,40 @@ public abstract class StructuredJobBase<T>
             }
             catch
             {
-                // Ignored: rethrown aggregated below.
+                // Ignored: surfaced via completion.Exception below.
             }
-            if (completion.Exception != null)
-            {
-                throw completion.Exception;
-            }
-            throw;
+            // The parallel children fault `completion`; anything else (AddConcurrentWork, the
+            // mutex, HandleSubscriptions) only surfaces as bodyException.
+            jobException = ExceptionDispatchInfo.Capture(completion.Exception ?? bodyException);
         }
-        finally
+
+        // Dispose on BOTH the success and failure paths -- but deliberately outside a `finally`,
+        // so a disposal fault can be merged with an in-flight job fault rather than overwriting it
+        // (a throwing `finally` silently discards the exception that is already propagating).
+        Exception? disposalException = null;
+        try
         {
             await resourceGroup.DisposeResources();
         }
+        catch (Exception ex)
+        {
+            disposalException = ex;
+        }
+
+        if (jobException != null && disposalException != null)
+        {
+            // Both the job and its cleanup failed: report both, flattening the two nested
+            // AggregateExceptions into one level so callers see a single flat list of causes.
+            throw new AggregateException(jobException.SourceException, disposalException).Flatten();
+        }
+        if (disposalException != null)
+        {
+            // Job succeeded but cleanup failed: surface the disposal fault as-is.
+            ExceptionDispatchInfo.Throw(disposalException);
+        }
+        // Re-throw a job-only fault preserving its original stack trace, or return the computed
+        // result when nothing failed.
+        jobException?.Throw();
+        return result!;
     }
 }

--- a/MemoizR.StructuredConcurrency/StructuredResourceGroup.cs
+++ b/MemoizR.StructuredConcurrency/StructuredResourceGroup.cs
@@ -39,6 +39,8 @@ public sealed class StructuredResourceGroup : IStructuredResourceGroup
 
         resourcesToDispose.Reverse();
 
+        List<Exception>? exceptions = null;
+
         foreach (var resource in resourcesToDispose)
         {
             try
@@ -52,12 +54,14 @@ public sealed class StructuredResourceGroup : IStructuredResourceGroup
                     disposable.Dispose();
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Exceptions during disposal are typically ignored in structured concurrency
-                // or aggregated. For now, we'll follow the pattern of ignoring them to avoid
-                // masking the original exception.
+                (exceptions ??= new()).Add(ex);
             }
+        }
+        if (exceptions != null)
+        {
+            throw new AggregateException(exceptions);
         }
     }
 }

--- a/MemoizR.Tests/ResourceManagementTests.cs
+++ b/MemoizR.Tests/ResourceManagementTests.cs
@@ -140,6 +140,31 @@ public class ResourceManagementTests
         Assert.Equal("dispose 1", ex.InnerExceptions[1].Message);
     }
 
+    [Fact]
+    public async Task TestJobAndDisposalExceptionsAreCombined()
+    {
+        // When the job body AND resource disposal both fail, the disposal fault must be combined
+        // with the original job fault -- not allowed to replace it (which a throwing `finally`
+        // would do, masking the root cause).
+        var f = new MemoFactory();
+
+        var resource = new ActionDisposable(() => throw new InvalidOperationException("dispose failure"));
+
+        var c1 = f.CreateConcurrentMapReduce(
+            (IStructuredResourceGroup r) =>
+            {
+                r.AddResource(resource);
+                return Task.FromException<int>(new InvalidOperationException("job failure"));
+            },
+            async c => { await Task.Delay(50, c.Token); return 1; });
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(async () => await c1.Get());
+
+        var inner = ex.Flatten().InnerExceptions;
+        Assert.Contains(inner, e => e.Message == "job failure");
+        Assert.Contains(inner, e => e.Message == "dispose failure");
+    }
+
     private class ActionDisposable : IDisposable
     {
         private readonly Action action;

--- a/MemoizR.Tests/ResourceManagementTests.cs
+++ b/MemoizR.Tests/ResourceManagementTests.cs
@@ -117,6 +117,29 @@ public class ResourceManagementTests
         Assert.True(resource2.IsDisposed);
     }
 
+
+    [Fact]
+    public async Task TestResourceDisposalExceptionsAreAggregated()
+    {
+        var f = new MemoFactory();
+
+        var resource1 = new ActionDisposable(() => throw new InvalidOperationException("dispose 1"));
+        var resource2 = new ActionDisposable(() => throw new InvalidOperationException("dispose 2"));
+
+        var c1 = f.CreateConcurrentMapReduce(
+            r =>
+            {
+                r.AddResource(resource1);
+                r.AddResource(resource2);
+                return Task.FromResult(1);
+            });
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(async () => await c1.Get());
+        Assert.Equal(2, ex.InnerExceptions.Count);
+        Assert.Equal("dispose 2", ex.InnerExceptions[0].Message);
+        Assert.Equal("dispose 1", ex.InnerExceptions[1].Message);
+    }
+
     private class ActionDisposable : IDisposable
     {
         private readonly Action action;

--- a/MemoizR.Tests/ResourceManagementTests.cs
+++ b/MemoizR.Tests/ResourceManagementTests.cs
@@ -135,9 +135,12 @@ public class ResourceManagementTests
             });
 
         var ex = await Assert.ThrowsAsync<AggregateException>(async () => await c1.Get());
+        // Both disposal failures must be surfaced. The LIFO disposal ORDER is a separate contract
+        // verified by TestResourceDisposalOrder, so this aggregation test stays order-independent
+        // (and would survive disposal ever being parallelized).
         Assert.Equal(2, ex.InnerExceptions.Count);
-        Assert.Equal("dispose 2", ex.InnerExceptions[0].Message);
-        Assert.Equal("dispose 1", ex.InnerExceptions[1].Message);
+        Assert.Contains(ex.InnerExceptions, e => e.Message == "dispose 1");
+        Assert.Contains(ex.InnerExceptions, e => e.Message == "dispose 2");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where exceptions thrown during resource disposal were silently swallowed instead of being properly aggregated and reported to callers. This could mask cleanup failures and lead to resource leaks.

## Key Changes

- **StructuredResourceGroup.DisposeResources()**: Modified to accumulate all exceptions thrown during resource disposal and throw them as an `AggregateException` instead of silently ignoring them. This ensures disposal failures are visible to callers.

- **StructuredJobBase.Run()**: Refactored exception handling to properly combine job failures with disposal failures:
  - Capture job exceptions using `ExceptionDispatchInfo` instead of throwing immediately
  - Move resource disposal outside the `finally` block to prevent disposal exceptions from masking job exceptions
  - When both job and disposal fail, merge them into a single flattened `AggregateException`
  - Preserve original stack traces using `ExceptionDispatchInfo.Throw()`

- **Tests**: Added two new test cases:
  - `TestResourceDisposalExceptionsAreAggregated()`: Verifies multiple disposal exceptions are properly aggregated
  - `TestJobAndDisposalExceptionsAreCombined()`: Verifies that when both job and disposal fail, both exceptions are reported together

## Implementation Details

The core issue was that throwing exceptions from a `finally` block silently discards any exception already propagating, masking the root cause. The fix moves disposal outside `finally` and explicitly manages exception state:

1. Job exceptions are captured via `ExceptionDispatchInfo` rather than thrown immediately
2. Disposal exceptions are caught and stored separately
3. Both exception types are then combined and thrown in the correct order, ensuring no information is lost

This approach maintains proper exception semantics while ensuring all failures are visible to callers for proper error handling and diagnostics.

https://claude.ai/code/session_01Ag1QA3wzbSE6pjSuXHSSKA