### PR TITLE
Harden structured race completion

### DIFF
--- a/MemoizR.StructuredConcurrency/ConcurrentRace.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentRace.cs
@@ -77,7 +77,8 @@ public sealed class ConcurrentRace<T, I> : MemoHandlR<T>, IMemoizR, IStateGetR<T
         try
         {
             State = CacheState.Evaluating;
-            Value = await new StructuredRaceJob<T, I>(action, fns, Context.CancellationTokenSource!).Run(Context.CancellationTokenSource!.Token);
+            using var job = new StructuredRaceJob<T, I>(action, fns, Context.CancellationTokenSource!);
+            Value = await job.Run(Context.CancellationTokenSource!.Token);
             State = CacheState.CacheClean;
         }
         catch

--- a/MemoizR.StructuredConcurrency/StructuredRaceJob.cs
+++ b/MemoizR.StructuredConcurrency/StructuredRaceJob.cs
@@ -1,12 +1,14 @@
 ﻿namespace MemoizR.StructuredConcurrency;
 
-public sealed class StructuredRaceJob<T, R> : StructuredJobBase<T>
+public sealed class StructuredRaceJob<T, R> : StructuredJobBase<T>, IDisposable
 {
     private readonly Func<Task<R>> action;
     private readonly IReadOnlyCollection<Func<IStructuredResourceGroup, R, Task<T>>> fns;
     private readonly CancellationTokenSource innerCancellationTokenSource;
     private readonly CancellationTokenSource groupCancellationTokenSource;
-    private bool finished;
+    // Cross-task winner flag: once any racer succeeds, slower siblings may observe cancellation
+    // or fault during teardown, but they must not turn a completed race into a failed one.
+    private volatile bool finished;
 
     public StructuredRaceJob(Func<Task<R>> action,
         IReadOnlyCollection<Func<IStructuredResourceGroup, R, Task<T>>> fns, CancellationTokenSource cancellationTokenSource)
@@ -55,11 +57,19 @@ public sealed class StructuredRaceJob<T, R> : StructuredJobBase<T>
                 }
                 catch
                 {
-                    groupCancellationTokenSource.Cancel();
-                    throw;
+                    if (!finished)
+                    {
+                        groupCancellationTokenSource.Cancel();
+                        throw;
+                    }
                 }
             }, innerCancellationTokenSource.Token)
             ));
 
+    }
+
+    public void Dispose()
+    {
+        innerCancellationTokenSource.Dispose();
     }
 }

--- a/MemoizR.Tests/StructuredConcurrencyTests.cs
+++ b/MemoizR.Tests/StructuredConcurrencyTests.cs
@@ -85,6 +85,35 @@ public class StructuredConcurrencyTests
         Assert.Equal(1, await c1.Get());
     }
 
+    [Fact(Timeout = 1000)]
+    public async Task Race_LateLoserFaultAfterWinner_DoesNotFailCompletedRace()
+    {
+        var f = new MemoFactory();
+
+        var race = f.CreateConcurrentRace(
+            () => Task.FromResult(1),
+            async (c, r) =>
+            {
+                await Task.Delay(10, c.Token);
+                return r;
+            },
+            async (c, _) =>
+            {
+                try
+                {
+                    await Task.Delay(3000, c.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new InvalidOperationException("late loser teardown fault");
+                }
+
+                return 0;
+            });
+
+        Assert.Equal(1, await race.Get());
+    }
+
     // Timing-sensitive: asserts on debounced async reactions after fixed delays. Retry like
     // the other flaky reactive tests (xRetry) instead of relying on a knife-edge timeout.
     [RetryFact(3, 200)]


### PR DESCRIPTION
### Motivation

- Prevent a late-faulting race loser (one that faults while being cancelled after a winner finished) from turning a completed race into a failure.
- Ensure the per-race linked `CancellationTokenSource` is disposed deterministically after the job finishes to avoid resource leaks.

### Description

- Make `StructuredRaceJob<T,R>` implement `IDisposable`, and dispose the per-race linked `CancellationTokenSource` in `Dispose()` via `innerCancellationTokenSource.Dispose()`.
- Introduce a volatile `finished` flag and document it so that loser tasks can tell whether a winner already completed and avoid failing the whole race after that point.
- Only cancel the group token and rethrow a child exception when `finished` is not set, so teardown faults from late losers are ignored once a winner succeeded.
- Use `using var job = new StructuredRaceJob<...>(...)` in `ConcurrentRace.Update()` so the job's linked token source is disposed after the run.
- Add a regression test `Race_LateLoserFaultAfterWinner_DoesNotFailCompletedRace` that asserts a late loser teardown fault does not break a successful race result.

### Testing

- Ran `git diff --check` to validate no whitespace/patch problems and the working tree diffs were clean.
- Attempted to run `dotnet test MemoizR.sln` but `dotnet` is not available in the environment, so unit tests could not be executed here.
- Added an automated regression test (`Race_LateLoserFaultAfterWinner_DoesNotFailCompletedRace`) which exercises the new winner/loser behavior; its outcome was not executed due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30622a6d54832397d41983d5a32eb3)