### PR TITLE
Dedup the tracked-read path; add safety-net tests for the scan/Distinct refactors

### DIFF
--- a/MemoizR.Tests/ReactiveTests.cs
+++ b/MemoizR.Tests/ReactiveTests.cs
@@ -1019,4 +1019,32 @@ public class ReactiveTests
         Assert.Equal(111, last);
         GC.KeepAlive(r);
     }
+
+    // Prep for the ScanParentsForDirty extraction: the CacheCheck parent scan in
+    // ReactionBase.UpdateIfNecessary must resolve a reaction back to Clean WITHOUT running its
+    // action when a re-checked upstream memo turns out unchanged. Here s changes (0 -> 2) but
+    // m = s % 2 stays 0, so the scheduled debounced update scans m, finds it unchanged, and must
+    // not fire. Pins the reaction-side copy of the scan that the extraction would unify (the
+    // memo-side copy is pinned by GraphRewiringTests.Memo_EqualButNotSameRecomputedValue_*).
+    [Fact(Timeout = 10000)]
+    public async Task Reaction_UpstreamMemoRecomputesEqualValue_DoesNotRerun()
+    {
+        var f = new MemoFactory();
+        var s = f.CreateSignal(0);
+        var m = f.CreateMemoizR(async () => await s.Get() % 2); // distinct s collapse to one parity
+        var invocations = 0;
+        var r = f.BuildReaction().CreateReaction(m, _ => invocations++);
+
+        await TestHelpers.WaitForConvergenceAsync(() => invocations == 1); // eager initial run
+        Assert.Equal(1, invocations);
+
+        await s.Set(2);        // m re-checks to 2 % 2 == 0 (unchanged) -> the scan must resolve Clean
+        await Task.Delay(150); // negative assertion: a real quiescence window, not a poll
+        Assert.Equal(1, invocations);
+
+        await s.Set(3);        // m = 3 % 2 == 1 (changed) -> the reaction must run again
+        await TestHelpers.WaitForConvergenceAsync(() => invocations == 2);
+        Assert.Equal(2, invocations);
+        GC.KeepAlive(r);
+    }
 }

--- a/MemoizR.Tests/StructuredConcurrencyTests.cs
+++ b/MemoizR.Tests/StructuredConcurrencyTests.cs
@@ -581,4 +581,43 @@ public class StructuredConcurrencyTests
         await v1.Set(9); // v1 -> race.Stale (the inlined IMemoizR.Stale); must not throw
         Assert.Equal(9, await race.Get()); // race recomputes with the new resolver value
     }
+
+    // Prep for hoisting the (identical) HandleSubscriptions into StructuredJobBase: it wires the
+    // node's Sources from the parallel children's captures via allSources.Distinct(), so a source
+    // read by MORE THAN ONE child must end up wired exactly once. Pins the dedup the hoist must
+    // preserve -- and that a single observer entry still invalidates correctly.
+    [Fact(Timeout = 10000)]
+    public async Task ConcurrentMap_TwoChildrenReadSameSignal_WiresItOnce_AndInvalidates()
+    {
+        var f = new MemoFactory();
+        var s = f.CreateSignal(1);
+        var map = f.CreateConcurrentMap(
+            async _ => await s.Get(),
+            async _ => await s.Get() + 100);
+
+        Assert.Equal([1, 101], await map.Get());
+        Assert.Equal(1, map.Sources.Count(src => ReferenceEquals(src, s))); // deduped, not [s, s]
+
+        await s.Set(2);
+        Assert.Equal([2, 102], await map.Get());
+    }
+
+    // ConcurrentMapReduce sibling of the dedup pin above (its reduce job has the same
+    // HandleSubscriptions). Its children share the parent flow scope rather than forced per-child
+    // scopes -- the other half of the structured wiring design.
+    [Fact(Timeout = 10000)]
+    public async Task ConcurrentMapReduce_TwoChildrenReadSameSignal_WiresItOnce_AndInvalidates()
+    {
+        var f = new MemoFactory();
+        var s = f.CreateSignal(1);
+        var sum = f.CreateConcurrentMapReduce(
+            async _ => await s.Get(),
+            async _ => await s.Get());
+
+        Assert.Equal(2, await sum.Get()); // 1 + 1
+        Assert.Equal(1, sum.Sources.Count(src => ReferenceEquals(src, s))); // deduped, not [s, s]
+
+        await s.Set(5);
+        Assert.Equal(10, await sum.Get()); // 5 + 5
+    }
 }

--- a/MemoizR/EagerRelativeSignal.cs
+++ b/MemoizR/EagerRelativeSignal.cs
@@ -35,6 +35,10 @@ public sealed class EagerRelativeSignal<T> : MemoHandlR<T>, IStateGetR<T>
         }
     }
 
-    // Identical tracked read to Signal.Get -- shared on the MemoHandlR base.
-    public Task<T> Get() => ReadTracked();
+    // Tracked read shared with Signal.Get via MemoHandlR.TrackDependency.
+    public async Task<T> Get()
+    {
+        await TrackDependency();
+        return Value;
+    }
 }

--- a/MemoizR/EagerRelativeSignal.cs
+++ b/MemoizR/EagerRelativeSignal.cs
@@ -35,30 +35,6 @@ public sealed class EagerRelativeSignal<T> : MemoHandlR<T>, IStateGetR<T>
         }
     }
 
-    public async Task<T> Get()
-    {
-        // An unpinned flow can have no capturing reaction (its scope would be freshly minted),
-        // so the read needs no scope at all.
-        if (!Context.HasFlowScope)
-        {
-            return Value;
-        }
-
-        var scope = Context.GetOrCreateScope();
-        if (scope.CurrentReaction == null)
-        {
-            return Value;
-        }
-
-        // Tracked read: register the dependency under this flow's ContextLock. Like Signal.Get,
-        // the per-node mutex is not taken -- CheckDependenciesTheSame is already serialized by
-        // Context.Lock, and a signal has no recompute for the mutex to guard (ADR 0002).
-        using (await scope.ContextLock.UpgradeableLockAsync())
-        {
-            Context.CheckDependenciesTheSame(this);
-        }
-        GC.KeepAlive(scope); // strong root: the lock identity must outlive the tracked read
-
-        return Value;
-    }
+    // Identical tracked read to Signal.Get -- shared on the MemoHandlR base.
+    public Task<T> Get() => ReadTracked();
 }

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -226,25 +226,28 @@ public abstract class MemoHandlR<T> : SignalHandlR
     {
     }
 
-    // The tracked-read path shared verbatim by Signal.Get and EagerRelativeSignal.Get: a plain
-    // signal read that, when a reaction is capturing, registers itself as that reaction's
-    // dependency. MemoBase overrides Get with its own cached fast path, so this stays a leaf-signal
-    // helper rather than the base Get. The per-node mutex is deliberately NOT taken --
+    // The dependency-tracking half of the leaf-signal read path, shared by Signal.Get and
+    // EagerRelativeSignal.Get: when a reaction is capturing, register this node as one of its
+    // dependencies. Returns nothing -- each Get reads Value itself, so the two keep their own
+    // return nullability (Signal is Task<T?>, EagerRelativeSignal is Task<T>) with no invariant
+    // Task<T>/Task<T?> conversion warning, and no extra allocation (the untracked fast path
+    // returns the cached completed Task). The per-node mutex is deliberately NOT taken --
     // CheckDependenciesTheSame is already serialized by Context.Lock, and a signal has no recompute
-    // for the mutex to guard (ADR 0002).
-    private protected async Task<T> ReadTracked()
+    // for the mutex to guard (ADR 0002). MemoBase overrides Get with its own cached fast path, so
+    // this stays a leaf-signal helper.
+    private protected async Task TrackDependency()
     {
         // An unpinned flow can have no capturing reaction (its scope would be freshly minted),
         // so the read needs no scope at all.
         if (!Context.HasFlowScope)
         {
-            return Value;
+            return;
         }
 
         var scope = Context.GetOrCreateScope();
         if (scope.CurrentReaction == null)
         {
-            return Value;
+            return;
         }
 
         using (await scope.ContextLock.UpgradeableLockAsync())
@@ -252,8 +255,6 @@ public abstract class MemoHandlR<T> : SignalHandlR
             Context.CheckDependenciesTheSame(this);
         }
         GC.KeepAlive(scope); // strong root: the lock identity must outlive the tracked read
-
-        return Value;
     }
 
     private sealed class ValueBox(T value)

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -226,6 +226,36 @@ public abstract class MemoHandlR<T> : SignalHandlR
     {
     }
 
+    // The tracked-read path shared verbatim by Signal.Get and EagerRelativeSignal.Get: a plain
+    // signal read that, when a reaction is capturing, registers itself as that reaction's
+    // dependency. MemoBase overrides Get with its own cached fast path, so this stays a leaf-signal
+    // helper rather than the base Get. The per-node mutex is deliberately NOT taken --
+    // CheckDependenciesTheSame is already serialized by Context.Lock, and a signal has no recompute
+    // for the mutex to guard (ADR 0002).
+    private protected async Task<T> ReadTracked()
+    {
+        // An unpinned flow can have no capturing reaction (its scope would be freshly minted),
+        // so the read needs no scope at all.
+        if (!Context.HasFlowScope)
+        {
+            return Value;
+        }
+
+        var scope = Context.GetOrCreateScope();
+        if (scope.CurrentReaction == null)
+        {
+            return Value;
+        }
+
+        using (await scope.ContextLock.UpgradeableLockAsync())
+        {
+            Context.CheckDependenciesTheSame(this);
+        }
+        GC.KeepAlive(scope); // strong root: the lock identity must outlive the tracked read
+
+        return Value;
+    }
+
     private sealed class ValueBox(T value)
     {
         public readonly T Value = value;

--- a/MemoizR/Signal.cs
+++ b/MemoizR/Signal.cs
@@ -43,29 +43,6 @@ public sealed class Signal<T> : MemoHandlR<T>, IStateGetR<T?>
         }
     }
 
-    public async Task<T?> Get()
-    {
-        // An unpinned flow can have no capturing reaction (its scope would be freshly minted),
-        // so the read needs no scope at all.
-        if (!Context.HasFlowScope)
-        {
-            return Value;
-        }
-
-        var scope = Context.GetOrCreateScope();
-        if (scope.CurrentReaction == null)
-        {
-            return Value;
-        }
-
-        // Only one thread should evaluate the graph at a time. otherwise the context could get messed up.
-        // This should lead to perf gains because memoization can be utilized more efficiently.
-        using (await scope.ContextLock.UpgradeableLockAsync())
-        {
-            Context.CheckDependenciesTheSame(this);
-        }
-        GC.KeepAlive(scope); // strong root: the lock identity must outlive the tracked read
-
-        return Value;
-    }
+    // Identical tracked read to EagerRelativeSignal.Get -- shared on the MemoHandlR base.
+    public Task<T?> Get() => ReadTracked();
 }

--- a/MemoizR/Signal.cs
+++ b/MemoizR/Signal.cs
@@ -43,6 +43,11 @@ public sealed class Signal<T> : MemoHandlR<T>, IStateGetR<T?>
         }
     }
 
-    // Identical tracked read to EagerRelativeSignal.Get -- shared on the MemoHandlR base.
-    public Task<T?> Get() => ReadTracked();
+    // Tracked read shared with EagerRelativeSignal.Get via MemoHandlR.TrackDependency; each reads
+    // its own Value, so the nullable (Signal) / non-nullable (EagerRelativeSignal) return is exact.
+    public async Task<T?> Get()
+    {
+        await TrackDependency();
+        return Value;
+    }
 }


### PR DESCRIPTION
Follow-up to #133. Two commits, only these two ahead of `main`.

## 1. Share the tracked-read path (`0e1b136`)
Removing the `EagerRelativeSignal` node mutex in #133 made its `Get` byte-identical to `Signal.Get`. Both now delegate to a single `MemoHandlR<T>.ReadTracked()` (`private protected`; `MemoBase` keeps its own cached-fast-path `Get`). Pure extraction — same scope resolution, ContextLock, dependency capture, and scope rooting — and it drops the stale *"only one thread should evaluate"* comment `Signal.Get` carried (a signal never took that lock). Net −17 source lines, one source of truth.

## 2. Characterization tests for the next two refactors (`2567bb3`)
Pin current behavior so the remaining dedups can be made safely (no library change):

- **`Reaction_UpstreamMemoRecomputesEqualValue_DoesNotRerun`** — the reaction-side `CacheCheck` parent scan must resolve back to Clean *without* running the action when a re-checked memo turns out unchanged (`s` changes `0→2` but `m = s % 2` stays `0`). Covers the copy of the scan a future shared `ScanParentsForDirty` would unify; the memo-side copy is already pinned by `GraphRewiringTests.Memo_EqualButNotSameRecomputedValue_DoesNotDirtyObservers`.
- **`ConcurrentMap_/ConcurrentMapReduce_TwoChildrenReadSameSignal_WiresItOnce_AndInvalidates`** — a source read by multiple parallel children is wired exactly once (`allSources.Distinct()`) and still invalidates. Covers both job types (forced per-child scopes vs shared parent scope), so hoisting the identical `HandleSubscriptions` into `StructuredJobBase` has a safety net.

## Notes for review
- The one thing worth a compiler's eye: `Signal.Get`'s `public Task<T?> Get() => ReadTracked();` returns `ReadTracked()`'s `Task<T>` — an identity conversion for an unconstrained `T`, so it should compile clean, but it's the bit I couldn't verify locally (no SDK in the dev environment).
- The behavioral change from #133 (the `EagerRelativeSignal` mutex removal) already passed the cross-OS build + Coyote systematic suite on that PR; this PR only refactors the now-identical read path and adds tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9Dr7SLipxb4Wn6PF7LbVg)_