### PR TITLE
Data-race safety part A (#145): SE-0412 statics rule, Sending<T> transfer, subclass-smuggling guards, default-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `MemoFactoryOptions.ValidateWrittenValues` validates each written instance's runtime type on
   `Set` as the runtime counterpart.
 
+### Changed (BREAKING)
+- Swift-6-parity default-on (issue #145 part A4): `MemoFactory` now applies the Sendable
+  creation checks BY DEFAULT — creating a signal/memo/concurrent node over a non-Sendable value
+  type throws unless `MemoFactoryOptions.DisableSendableChecks` (the migration escape hatch) is
+  set; `StrictSendableChecks` remains as an explicit statement of intent. The MZR001–003
+  analyzers escalate from Warning to Error by default (downgrade per project via
+  `.editorconfig` during migration). Known friction: memos composed over `ConcurrentMap`
+  results are typed `IEnumerable<T>` (an interface, rejected by principle) — compose over an
+  immutable type or opt out per factory.
+
 ### Changed
 - Reactions now evaluate their separate-parameter dependencies in parallel on the thread pool; with an executor registered (e.g. via `AddSynchronizationContext`/`AddWpfDispatcher`/`AddExecutor`), only the action (with the already-evaluated values) is marshalled to it, and `CreateAdvancedReaction` keeps running its whole body on the executor (#13)
 - `ReactionBuilder`'s public constructor takes `IExecutor?` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   never collide on an id. A runnable two-peer bridge sample (stale/pull protocol, glitch
   barrier, late-delivery dropping, reset detection) lives in samples/DistributedGraphSample.
 
+- Toward full Swift-6-parity (issue #145, part A): a real SE-0412 analog — MZR004 flags
+  statics in MemoizR-using files that are mutable slots or of non-Sendable type, while
+  MemoizR's own nodes, factories and executors are now `[Sendable]` (internally synchronized
+  by design), so node/factory statics are the sanctioned pattern; `Sending<T>` transfer
+  semantics for non-Sendable values (the SE-0430 analog: `[Sendable]` wrapper accepted by
+  strict mode, single-consumption `Receive()`, MZR005 flags sender-side use-after-transfer);
+  MZR006 (Info) hints at non-sealed classes at creation sites (subclass smuggling), and
+  `MemoFactoryOptions.ValidateWrittenValues` validates each written instance's runtime type on
+  `Set` as the runtime counterpart.
+
 ### Changed
 - Reactions now evaluate their separate-parameter dependencies in parallel on the thread pool; with an executor registered (e.g. via `AddSynchronizationContext`/`AddWpfDispatcher`/`AddExecutor`), only the action (with the already-evaluated values) is marshalled to it, and `CreateAdvancedReaction` keeps running its whole body on the executor (#13)
 - `ReactionBuilder`'s public constructor takes `IExecutor?` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,9 +98,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   set; `StrictSendableChecks` remains as an explicit statement of intent. The MZR001–003
   analyzers escalate from Warning to Error by default (downgrade per project via
   `.editorconfig` during migration), and MZR001/MZR006 honor the same escape hatch the runtime
-  does: creations on a factory whose construction visibly carries `DisableSendableChecks` (an
-  inline receiver or a same-file local/field/property initializer) are exempt, so the
-  per-factory opt-out works at build time without a project-wide suppression. Known friction:
+  does: creations on a factory whose construction visibly and definitely carries
+  `DisableSendableChecks` (an inline receiver, or the same-file initializer of a local/readonly
+  field/get-only property that is never reassigned, with a compile-time-constant options
+  argument) are exempt, so the per-factory opt-out works at build time without a project-wide
+  suppression. Known friction:
   memos composed over `ConcurrentMap` results are typed `IEnumerable<T>` (an interface,
   rejected by principle) — compose over an immutable type or opt out per factory.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   strict mode, single-consumption `Receive()`, MZR005 flags sender-side use-after-transfer);
   MZR006 (Info) hints at non-sealed classes at creation sites (subclass smuggling), and
   `MemoFactoryOptions.ValidateWrittenValues` validates each written instance's runtime type on
-  `Set` as the runtime counterpart.
+  `Set` as the runtime counterpart (signal writes, and the instance's OWN type only — the
+  MZR006 hint suggests the option solely where that guard can fire, and says so for surfaces
+  nested inside Sendable containers).
 
 ### Changed (BREAKING)
 - Swift-6-parity default-on (issue #145 part A4): `MemoFactory` now applies the Sendable
@@ -95,9 +97,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   type throws unless `MemoFactoryOptions.DisableSendableChecks` (the migration escape hatch) is
   set; `StrictSendableChecks` remains as an explicit statement of intent. The MZR001–003
   analyzers escalate from Warning to Error by default (downgrade per project via
-  `.editorconfig` during migration). Known friction: memos composed over `ConcurrentMap`
-  results are typed `IEnumerable<T>` (an interface, rejected by principle) — compose over an
-  immutable type or opt out per factory.
+  `.editorconfig` during migration), and MZR001/MZR006 honor the same escape hatch the runtime
+  does: creations on a factory whose construction visibly carries `DisableSendableChecks` (an
+  inline receiver or a same-file local/field/property initializer) are exempt, so the
+  per-factory opt-out works at build time without a project-wide suppression. Known friction:
+  memos composed over `ConcurrentMap` results are typed `IEnumerable<T>` (an interface,
+  rejected by principle) — compose over an immutable type or opt out per factory.
 
 ### Changed
 - Reactions now evaluate their separate-parameter dependencies in parallel on the thread pool; with an executor registered (e.g. via `AddSynchronizationContext`/`AddWpfDispatcher`/`AddExecutor`), only the action (with the already-evaluated values) is marshalled to it, and `CreateAdvancedReaction` keeps running its whole body on the executor (#13)

--- a/MemoizR.Analyzers.Tests/AnalyzerTestHarness.cs
+++ b/MemoizR.Analyzers.Tests/AnalyzerTestHarness.cs
@@ -22,12 +22,19 @@ internal static class AnalyzerTestHarness
         return [.. paths.Distinct().Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))];
     }
 
-    public static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source, DiagnosticAnalyzer analyzer)
+    public static Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source, DiagnosticAnalyzer analyzer)
     {
-        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        return AnalyzeAsync([source], analyzer);
+    }
+
+    // Multi-file overload: some rules are scoped per FILE (MZR004's using-directive mandate),
+    // so proving cross-file behavior (a centralized GlobalUsings.cs) needs separate trees.
+    public static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string[] sources, DiagnosticAnalyzer analyzer)
+    {
+        var trees = sources.Select(source => CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest))).ToArray();
         var compilation = CSharpCompilation.Create(
             "AnalyzerTestSnippet",
-            [tree],
+            trees,
             References.Value,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
 

--- a/MemoizR.Analyzers.Tests/MemoizR.Analyzers.Tests.csproj
+++ b/MemoizR.Analyzers.Tests/MemoizR.Analyzers.Tests.csproj
@@ -15,6 +15,7 @@
     <!-- The snippets compile against the REAL MemoizR assemblies, so the analyzers' symbol
          matching is validated against the actual API, not hand-written stubs. -->
     <ProjectReference Include="..\MemoizR\MemoizR.csproj" />
+    <ProjectReference Include="..\MemoizR.Blazor\MemoizR.Blazor.csproj" />
     <ProjectReference Include="..\MemoizR.Reactive\MemoizR.Reactive.csproj" />
     <ProjectReference Include="..\MemoizR.StructuredConcurrency\MemoizR.StructuredConcurrency.csproj" />
   </ItemGroup>

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -619,6 +619,31 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task RefAliasedFactoryLocal_DoesNotKeepTheInitializerOptOut()
+    {
+        // `ref var r = ref f` lets any later write repoint the local without naming it, so a
+        // ref escape revokes the initializer's authority like a direct reassignment.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks);
+                    ref var r = ref f;
+                    r = new MemoFactory();
+                    f.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR001", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task ConditionallyLaxOptions_AreNotADefiniteOptOut()
     {
         // On the false path the factory is strict and the creation throws at runtime: a mere

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -619,6 +619,73 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task FluentlyConfiguredOptOutFactory_IsStillExempt()
+    {
+        // AddExecutor/AddTimeProvider mutate and return the SAME factory, so the opt-out
+        // evidence sits one hop up the fluent chain -- the runtime uses the opted-out factory
+        // and accepts the value, and the build must agree.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using System.Threading;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks)
+                        .AddExecutor(new SynchronizationContextExecutor(new SynchronizationContext()))
+                        .CreateSignal(new List<int>());
+
+                    var lax = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks);
+                    lax.AddTimeProvider(TimeProvider.System).CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task PartialTypeFactoryField_IsNotTrusted_TheOtherFileMayReassignIt()
+    {
+        // A readonly field's initializer can be overwritten by a static constructor, and a
+        // partial type can keep that constructor in ANOTHER file: members of types split
+        // across files are not trusted, whatever the visible initializer says.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(
+            [
+                """
+                using System.Collections.Generic;
+                using MemoizR;
+
+                public partial class C
+                {
+                    private static readonly MemoFactory Lax = new(options: MemoFactoryOptions.DisableSendableChecks);
+
+                    public void M()
+                    {
+                        Lax.CreateSignal(new List<int>());
+                    }
+                }
+                """,
+                """
+                public partial class C
+                {
+                    static C()
+                    {
+                        Lax = new MemoizR.MemoFactory(); // strict: the initializer never survives
+                    }
+                }
+                """,
+            ],
+            new SendableTypeArgumentAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR001", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task RefAliasedFactoryLocal_DoesNotKeepTheInitializerOptOut()
     {
         // `ref var r = ref f` lets any later write repoint the local without naming it, so a

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -619,6 +619,30 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task BlazorFluentOptOutFactory_IsStillExempt()
+    {
+        // AddBlazorDispatcher mirrors AddWpfDispatcher: it returns the SAME factory via
+        // AddExecutor, so the opt-out evidence one hop up the chain still holds.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+            using Microsoft.AspNetCore.Components;
+
+            public class C
+            {
+                public void M(Dispatcher dispatcher)
+                {
+                    new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks)
+                        .AddBlazorDispatcher(dispatcher)
+                        .CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task FluentlyConfiguredOptOutFactory_IsStillExempt()
     {
         // AddExecutor/AddTimeProvider mutate and return the SAME factory, so the opt-out

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -595,6 +595,53 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task ReassignedFactoryLocal_DoesNotInheritTheInitializerOptOut()
+    {
+        // The initializer opted out, but the local was since repointed at a strict factory:
+        // the runtime WILL throw on this creation, so the build must keep saying so.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks);
+                    f = new MemoFactory();
+                    f.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR001", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ConditionallyLaxOptions_AreNotADefiniteOptOut()
+    {
+        // On the false path the factory is strict and the creation throws at runtime: a mere
+        // MENTION of the flag in a non-constant options expression is not definite evidence.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool useLax)
+                {
+                    new MemoFactory(options: useLax ? MemoFactoryOptions.DisableSendableChecks : MemoFactoryOptions.None)
+                        .CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR001", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task OtherOptions_AndUnresolvableReceivers_StayChecked()
     {
         // Conservative direction: only POSITIVE evidence of DisableSendableChecks exempts a

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -562,6 +562,64 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task DisableSendableChecks_Factory_IsExemptWhereverItsConstructionIsVisible()
+    {
+        // The runtime accepts this exact per-factory escape hatch; under the Error default the
+        // build must accept it too. Positive evidence counts through every documented shape:
+        // an inline receiver, a local initializer (including flag combinations), and a
+        // same-file static field initializer -- for instance methods and the structured
+        // extension methods alike.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using MemoizR;
+
+            public class C
+            {
+                private static readonly MemoFactory Lax = new(options: MemoFactoryOptions.DisableSendableChecks);
+
+                public void M()
+                {
+                    new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks).CreateSignal(new List<int>());
+
+                    var lax = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks | MemoFactoryOptions.DisableSendableChecks);
+                    lax.CreateSignal(new List<int>());
+                    lax.CreateConcurrentMap<List<int>>(async _ => new List<int>()); // extension-method receiver
+
+                    Lax.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OtherOptions_AndUnresolvableReceivers_StayChecked()
+    {
+        // Conservative direction: only POSITIVE evidence of DisableSendableChecks exempts a
+        // creation. Other flags do not, and a factory the analyzer cannot see behind (here a
+        // parameter) keeps the checks on even if its construction elsewhere opted out.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(MemoFactory fromElsewhere)
+                {
+                    var strict = new MemoFactory(options: MemoFactoryOptions.ValidateWrittenValues);
+                    strict.CreateSignal(new List<int>());
+                    fromElsewhere.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR001", d.Id));
+    }
+
+    [Fact]
     public async Task ConcurrentMap_ElementType_IsChecked()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -619,6 +619,26 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task ParenthesizedOptOutReceivers_KeepTheOptOut()
+    {
+        // Parentheses are pure syntax: the receiver operation is the creation itself.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    (new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks)).CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task BlazorFluentOptOutFactory_IsStillExempt()
     {
         // AddBlazorDispatcher mirrors AddWpfDispatcher: it returns the SAME factory via

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -648,6 +648,31 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task FluentlyConfiguredFactory_StoredInALocal_KeepsTheOptOut()
+    {
+        // The initializer's value is the fluent call's result -- which IS the factory the
+        // initializer created (AddTimeProvider returns its receiver) -- so the peeling applies
+        // to initializers exactly like direct receivers.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var lax = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks)
+                        .AddTimeProvider(TimeProvider.System);
+                    lax.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task GenericPassthroughsReturningAFactory_AreNotFollowed()
     {
         // Untrack<T> returns its DELEGATE's result -- here a strict factory -- so following it

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -648,6 +648,80 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task GenericPassthroughsReturningAFactory_AreNotFollowed()
+    {
+        // Untrack<T> returns its DELEGATE's result -- here a strict factory -- so following it
+        // back to the lax receiver would hide an error the runtime throws. Only the named
+        // fluent methods (which return their own receiver) are followed.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks)
+                        .Untrack(() => new MemoFactory())
+                        .CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR001", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task InArguments_DoNotRevokeTheOptOut()
+    {
+        // `in` is a read-only pass: the callee cannot repoint the local, so the initializer
+        // still proves which factory runs the creation.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var lax = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks);
+                    Inspect(in lax);
+                    lax.CreateSignal(new List<int>());
+                }
+
+                private static void Inspect(in MemoFactory factory)
+                {
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NullForgivingFactoryReceiver_KeepsTheOptOut()
+    {
+        // `lax!.CreateSignal(...)` is the same lax factory; the null-forgiving operator must
+        // not hide the receiver from the opt-out resolution.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    MemoFactory? lax = new(options: MemoFactoryOptions.DisableSendableChecks);
+                    lax!.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task PartialTypeFactoryField_IsNotTrusted_TheOtherFileMayReassignIt()
     {
         // A readonly field's initializer can be overwritten by a static constructor, and a

--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -725,6 +725,52 @@ public class SendableTypeArgumentAnalyzerTests
     }
 
     [Fact]
+    public async Task VirtualFactoryProperty_IsNotTrusted_DispatchMayLandElsewhere()
+    {
+        // A derived override can hand back a strict factory the base initializer never saw:
+        // only a getter that cannot dispatch elsewhere may vouch for its initializer.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Base
+            {
+                public virtual MemoFactory Lax { get; } = new(options: MemoFactoryOptions.DisableSendableChecks);
+
+                public void M()
+                {
+                    Lax.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR001", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ConditionalAccessReceiver_KeepsTheOptOut()
+    {
+        // `lax?.CreateSignal(...)` either does not run or runs on the lax factory -- the
+        // conditional-access placeholder must resolve to the visible initializer either way.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    MemoFactory? lax = new(options: MemoFactoryOptions.DisableSendableChecks);
+                    lax?.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task NullForgivingFactoryReceiver_KeepsTheOptOut()
     {
         // `lax!.CreateSignal(...)` is the same lax factory; the null-forgiving operator must

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -13,6 +13,25 @@ public class StaticStateAnalyzerTests
         => AnalyzerTestHarness.AnalyzeAsync(source, new StaticStateAnalyzer());
 
     [Fact]
+    public async Task StaticAbstractInterfaceContracts_OwnNoSlot()
+    {
+        // A static abstract member is only a CONTRACT: the interface holds no storage, so
+        // there is nothing shared to flag -- the implementing types own (and answer for)
+        // the actual slots.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public interface IState<T>
+            {
+                static abstract List<int> Items { get; set; }
+            }
+            """);
+
+        Assert.Empty(diagnostics.Where(d => d.Id == "MZR004"));
+    }
+
+    [Fact]
     public async Task MutableStaticSlots_AreFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -282,6 +282,85 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task UnmanagedTypeParameters_AreSendableForEveryInstantiation()
+    {
+        // `where T : unmanaged` guarantees a no-reference value type however the generic is
+        // closed: reads hand out copies that can alias nothing, so the slot needs no
+        // creation-site check. A plain `struct` constraint gives no such guarantee -- a struct
+        // can carry references to mutable objects.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class UnmanagedCache<T> where T : unmanaged
+            {
+                private static readonly T Zero = default;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Zero;
+                }
+            }
+
+            public class StructCache<T> where T : struct
+            {
+                private static readonly T Zero = default;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Zero;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task NestedTypes_ResubstitutedThroughContainingArguments_AreStillWalked()
+    {
+        // Outer<int>.Holder and Outer<T>.Holder share a DECLARATION but differ through the
+        // containing type's arguments: after walking the first, the second must still be
+        // inspected, or the outer T (a List<int> in C<List<int>>) hides on Holder.Value.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Outer<U>
+            {
+                public sealed class Holder
+                {
+                    public U? Value { get; init; }
+                }
+            }
+
+            public class C<T>
+            {
+                private sealed class Pair
+                {
+                    public Outer<int>.Holder? A { get; init; }
+
+                    public Outer<T>.Holder? B { get; init; }
+                }
+
+                private static readonly Pair Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task PolymorphicRecursion_WithAStoredParameter_IsRejectedNotAssumed()
     {
         // The divergent chain's SECOND level substitutes Value to List<int>: the classifier

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -125,6 +125,37 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task NestedTypeParameterStatics_AreUnverifiable_TrustedNodesAreTheShield()
+    {
+        // The classifier accepts type parameters recursively (right for MZR001), so
+        // ImmutableArray<T> would pass while C<List<int>>.Cache is a process-wide immutable
+        // wrapper over a mutable graph with no later check. A [Sendable]-trusted node is the
+        // one shield: Signal<T> is internally synchronized for any T, and the closed T IS
+        // checked later, at the CreateSignal call that built the instance.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Immutable;
+            using MemoizR;
+
+            public class C<T>
+            {
+                private static readonly ImmutableArray<T> Cache = ImmutableArray<T>.Empty;
+                private static readonly Signal<T>? Node = null;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache.Length + (Node is null ? 0 : 1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Cache'", diagnostic.GetMessage());
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task GlobalUsings_PutEveryFileInScope()
     {
         // Centralized `global using MemoizR;` (a separate GlobalUsings.cs) puts MemoizR in

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.CodeAnalysis;
+
+namespace MemoizR.Analyzers.Tests;
+
+// Contracts of MZR004 (the SE-0412 analog): in files that use MemoizR, a static must be an
+// immutable slot of a Sendable type -- mutable slots (non-readonly fields, settable properties,
+// events) and readonly slots of mutable types are flagged; consts, Sendable readonly statics,
+// and MemoizR nodes/factories (which are [Sendable] by design) are not. Files without a MemoizR
+// using directive are out of the rule's mandate.
+public class StaticStateAnalyzerTests
+{
+    private static Task<System.Collections.Immutable.ImmutableArray<Diagnostic>> AnalyzeAsync(string source)
+        => AnalyzerTestHarness.AnalyzeAsync(source, new StaticStateAnalyzer());
+
+    [Fact]
+    public async Task MutableStaticSlots_AreFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int counter; // mutable slot, even though int is Sendable
+                public static string Label { get; set; } = ""; // settable slot
+                public static event Action? Changed; // subscription surface
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    counter++;
+                    Label = "x";
+                    Changed?.Invoke();
+                }
+            }
+            """);
+
+        Assert.Equal(3, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'counter'"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'Label'"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'Changed'"));
+    }
+
+    [Fact]
+    public async Task ReadonlyStaticOfMutableType_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static readonly List<int> Cache = new(); // readonly slot, mutable object
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    Cache.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Cache'", diagnostic.GetMessage());
+        Assert.Contains("List", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SendableStatics_AndConsts_AndNodes_AreNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Immutable;
+            using MemoizR;
+
+            public class C
+            {
+                private const int Limit = 3;
+                private static readonly string Name = "x";
+                private static readonly ImmutableArray<int> Seeds = ImmutableArray.Create(1, 2);
+
+                // The library's own model: nodes and factories are [Sendable] by design, so the
+                // fix suggestion ("lift it into a Signal") itself passes the rule.
+                private static readonly MemoFactory Factory = new();
+                private static readonly Signal<int> Counter = Factory.CreateSignal(0);
+
+                public void M()
+                {
+                    _ = Limit + Name.Length + Seeds.Length;
+                    _ = Counter.Get();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task FilesWithoutMemoizRUsing_AreOutOfScope()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+
+            public class Unrelated
+            {
+                public static List<int> Anything = new(); // mutable static, but not MemoizR's mandate
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+}

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -216,6 +216,59 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task ComputedStaticGetters_AreNotState()
+    {
+        // An expression-bodied getter owns no static slot: each call returns a fresh value,
+        // and a getter handing out OTHER static state is flagged at that state's declaration.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public static List<int> NewList => new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = NewList;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ReadonlyStaticOfANonSealedSendableType_GetsTheSmugglingHint()
+    {
+        // The declared type passes the slot rule, but a mutable subclass behind the upcast is
+        // process-wide state with no creation site where MZR006 would otherwise hint and no
+        // runtime write validation ever seeing the slot: the Info hint fires at the static.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public record OpenPerson(string Name);
+
+            public class C
+            {
+                private static readonly OpenPerson Cache = new("a");
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Contains("OpenPerson", diagnostic.GetMessage());
+        Assert.Contains("static slot publishes unchecked", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task FilesWithoutMemoizRUsing_AreOutOfScope()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -156,6 +156,38 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task OuterGenericParameters_InNestedMemberTypes_AreUnverifiable()
+    {
+        // A nested type carries the OUTER T on its members, not in its own argument list:
+        // C<List<int>>.Cache is still a process-wide object graph over a mutable list, so the
+        // member walk must find the T the shared classifier would exempt.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C<T>
+            {
+                private sealed class Holder
+                {
+                    public T? Value { get; init; }
+                }
+
+                private static readonly Holder Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Cache'", diagnostic.GetMessage());
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task TypeParameters_BuriedArbitrarilyDeep_AreStillFound()
     {
         // The walk has no depth cliff: a declared type reference is a finite tree, so the

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -97,6 +97,39 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task GlobalUsings_PutEveryFileInScope()
+    {
+        // Centralized `global using MemoizR;` (a separate GlobalUsings.cs) puts MemoizR in
+        // scope for every file, so the per-FILE using check must not exempt such projects: the
+        // static's own file has no using directive at all here.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(
+            [
+                """
+                global using MemoizR;
+                """,
+                """
+                using System.Collections.Generic;
+
+                public class C
+                {
+                    private static readonly List<int> Cache = new();
+
+                    public void M()
+                    {
+                        var f = new MemoFactory();
+                        Cache.Add(1);
+                    }
+                }
+                """,
+            ],
+            new StaticStateAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Cache'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task FilesWithoutMemoizRUsing_AreOutOfScope()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -251,6 +251,37 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task PolymorphicRecursion_Terminates_AndTheClosedSlotIsAccepted()
+    {
+        // Box<T> exposing Box<List<T>> constructs a FRESH closed symbol per level: the member
+        // walk (once per declaration) and the classifier's same-definition path cap must both
+        // terminate. The closed Box<int> stores only Boxes -- all readonly, no mutable leaf --
+        // so MZR004 accepts the slot.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public sealed class Box<T>
+            {
+                public Box<List<T>>? Next { get; init; }
+            }
+
+            public class C
+            {
+                private static readonly Box<int> Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "MZR004");
+    }
+
+    [Fact]
     public async Task TypeParameters_BuriedArbitrarilyDeep_AreStillFound()
     {
         // The walk has no depth cliff: a declared type reference is a finite tree, so the

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -285,9 +285,10 @@ public class StaticStateAnalyzerTests
     public async Task UnmanagedTypeParameters_AreSendableForEveryInstantiation()
     {
         // `where T : unmanaged` guarantees a no-reference value type however the generic is
-        // closed: reads hand out copies that can alias nothing, so the slot needs no
-        // creation-site check. A plain `struct` constraint gives no such guarantee -- a struct
-        // can carry references to mutable objects.
+        // closed (reads hand out copies that can alias nothing), and `where T : Enum`
+        // guarantees immutable values or immutable boxes: neither slot needs a creation-site
+        // check. A plain `struct` constraint gives no such guarantee -- a struct can carry
+        // references to mutable objects.
         var diagnostics = await AnalyzeAsync("""
             using MemoizR;
 
@@ -305,6 +306,17 @@ public class StaticStateAnalyzerTests
             public class StructCache<T> where T : struct
             {
                 private static readonly T Zero = default;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Zero;
+                }
+            }
+
+            public class EnumCache<T> where T : System.Enum
+            {
+                private static readonly T? Zero = default;
 
                 public void M()
                 {

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -282,6 +282,39 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task PolymorphicRecursion_WithAStoredParameter_IsRejectedNotAssumed()
+    {
+        // The divergent chain's SECOND level substitutes Value to List<int>: the classifier
+        // must inspect the first re-instantiation's members before cutting.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public sealed class Box<T>
+            {
+                public Box<List<T>>? Next { get; init; }
+
+                public T? Value { get; init; }
+            }
+
+            public class C
+            {
+                private static readonly Box<int> Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("List", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task PolymorphicRecursion_Terminates_AndTheClosedSlotIsAccepted()
     {
         // Box<T> exposing Box<List<T>> constructs a FRESH closed symbol per level: the member

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -156,6 +156,33 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task TypeParameters_BuriedArbitrarilyDeep_AreStillFound()
+    {
+        // The walk has no depth cliff: a declared type reference is a finite tree, so the
+        // recursion terminates on its own -- a cap would have had to fail open (a parameter
+        // one level past it silently trusted) or misreport deep concrete types.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Immutable;
+            using MemoizR;
+
+            public class C<T>
+            {
+                private static readonly ImmutableArray<ImmutableArray<ImmutableArray<ImmutableArray<ImmutableArray<ImmutableArray<T>>>>>> Cache = default;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task GlobalUsings_PutEveryFileInScope()
     {
         // Centralized `global using MemoizR;` (a separate GlobalUsings.cs) puts MemoizR in

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -188,6 +188,69 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task InheritedMemberTypes_CarryTheOuterParameter_AndAreUnverifiable()
+    {
+        // The member walk follows the base chain like the classifier: an inherited member
+        // stores the outer T exactly like a declared one.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C<T>
+            {
+                private class Base
+                {
+                    public T? Value { get; init; }
+                }
+
+                private sealed class Holder : Base
+                {
+                }
+
+                private static readonly Holder Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Cache'", diagnostic.GetMessage());
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ComputedMemberProperties_StoreNothing_AndDoNotPoisonTheSlot()
+    {
+        // `public T New => default!` holds no slot: the holder static contains no T reference,
+        // the member-level analog of the top-level computed-getter exemption.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C<T>
+            {
+                private sealed class Holder
+                {
+                    public T New => default!;
+                }
+
+                private static readonly Holder Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task TypeParameters_BuriedArbitrarilyDeep_AreStillFound()
     {
         // The walk has no depth cliff: a declared type reference is a finite tree, so the

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -373,6 +373,48 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task SiblingInstantiations_DoNotExhaustTheMemberWalk()
+    {
+        // Two safe sibling instantiations of the same nested declaration are not recursion:
+        // the third, carrying the outer T through its containing type, must still be walked.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Outer<U>
+            {
+                public sealed class Holder
+                {
+                    public U? Value { get; init; }
+                }
+            }
+
+            public class C<T>
+            {
+                private sealed class Triple
+                {
+                    public Outer<int>.Holder? A { get; init; }
+
+                    public Outer<string>.Holder? B { get; init; }
+
+                    public Outer<T>.Holder? C { get; init; }
+                }
+
+                private static readonly Triple Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task PolymorphicRecursion_WithAStoredParameter_IsRejectedNotAssumed()
     {
         // The divergent chain's SECOND level substitutes Value to List<int>: the classifier

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -251,6 +251,37 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task FiniteDeepGenericNesting_IsStillFullyChecked()
+    {
+        // Hand-written nesting repeats the definition but SHRINKS at every level: the
+        // divergence cut must not fire, so the classifier reaches the List at the bottom.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public sealed class WrapBox<T>
+            {
+                public T? Value { get; init; }
+            }
+
+            public class C
+            {
+                private static readonly WrapBox<WrapBox<WrapBox<WrapBox<WrapBox<List<int>>>>>> Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("List", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task PolymorphicRecursion_Terminates_AndTheClosedSlotIsAccepted()
     {
         // Box<T> exposing Box<List<T>> constructs a FRESH closed symbol per level: the member

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -611,6 +611,26 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task SetOnlyStaticProperties_AreSettableSlots()
+    {
+        // A settable static property is a process-wide write surface no matter where the
+        // value lands -- the get+set arm never required a backing slot, and dropping the
+        // getter does not make the surface less writable.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public static int Sink { set { _ = value; } }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("settable", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task FilesWithoutMemoizRUsing_AreOutOfScope()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/StaticStateAnalyzerTests.cs
@@ -97,6 +97,34 @@ public class StaticStateAnalyzerTests
     }
 
     [Fact]
+    public async Task TypeParameterStatics_AreUnverifiable_AndFlagged()
+    {
+        // MZR001 trusts unbound type parameters because the closed instantiation is checked at
+        // its own creation site; a static has no such site -- every closed C<T> mints a fresh
+        // process-wide slot (C<List<int>>.Cache is a shared mutable object graph) no rule ever
+        // sees again -- so here T is unverifiable, not trusted.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C<T> where T : new()
+            {
+                private static readonly T Cache = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    _ = Cache;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Cache'", diagnostic.GetMessage());
+        Assert.Contains("type parameter", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task GlobalUsings_PutEveryFileInScope()
     {
         // Centralized `global using MemoizR;` (a separate GlobalUsings.cs) puts MemoizR in

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -35,6 +35,57 @@ public class SubclassSmugglingAnalyzerTests
     }
 
     [Fact]
+    public async Task NonSealedElementInsideASendableContainer_IsHinted()
+    {
+        // The smuggle surface hides inside the green-listed container: ImmutableArray<OpenBase>
+        // passes MZR001, but each element can still be a mutable subclass behind the upcast.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Immutable;
+            using MemoizR;
+
+            public record OpenPerson(string Name);
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(ImmutableArray.Create(new OpenPerson("a")));
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Contains("OpenPerson", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task MemoCreations_DoNotPromiseTheSignalOnlyRuntimeGuard()
+    {
+        // ValidateWrittenValues checks SIGNAL writes only; the hint on memo creations must not
+        // suggest a guard that does not apply there.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public record OpenPerson(string Name);
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () => new OpenPerson("a"));
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Contains("signal writes only", diagnostic.GetMessage());
+        Assert.DoesNotContain("enable MemoFactoryOptions.ValidateWrittenValues", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task SealedValueAndGreenListedTypes_AreQuiet()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -7,6 +7,28 @@ namespace MemoizR.Analyzers.Tests;
 // framework types (Uri is not sealed) stay quiet.
 public class SubclassSmugglingAnalyzerTests
 {
+    [Fact]
+    public async Task NonSendableTypeArguments_AreMzr001sTerritory()
+    {
+        // List<int> never passes the creation check: there is no smuggle hole to hint
+        // about on a value MZR001 already rejects.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(new List<int>());
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
     private static Task<System.Collections.Immutable.ImmutableArray<Diagnostic>> AnalyzeAsync(string source)
         => AnalyzerTestHarness.AnalyzeAsync(source, new SubclassSmugglingAnalyzer());
 

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -165,6 +165,35 @@ public class SubclassSmugglingAnalyzerTests
     }
 
     [Fact]
+    public async Task MemberTypes_OfSealedSendableDtos_AreSmuggleSurfaces()
+    {
+        // Box is sealed and structurally Sendable, but its member type carries the hole:
+        // new Box(new MutableChild()) passes MZR001, and ValidateWrittenValues only sees the
+        // runtime type Box -- the member walk must surface OpenPerson with the nested wording.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public record OpenPerson(string Name);
+
+            public sealed record Box(OpenPerson Value);
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(new Box(new OpenPerson("a")));
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Contains("OpenPerson", diagnostic.GetMessage());
+        Assert.DoesNotContain("enable MemoFactoryOptions.ValidateWrittenValues", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task SendableAbstractBase_IsStillASmuggleSurface()
     {
         // [Sendable] lets an abstract base PASS MZR001 (Error), but the attribute is

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.CodeAnalysis;
+
+namespace MemoizR.Analyzers.Tests;
+
+// Contracts of MZR006 (Info): a non-sealed class type at a creation site can smuggle a mutable
+// subclass past the declared-type Sendable checks; sealed types, value types, and green-listed
+// framework types (Uri is not sealed) stay quiet.
+public class SubclassSmugglingAnalyzerTests
+{
+    private static Task<System.Collections.Immutable.ImmutableArray<Diagnostic>> AnalyzeAsync(string source)
+        => AnalyzerTestHarness.AnalyzeAsync(source, new SubclassSmugglingAnalyzer());
+
+    [Fact]
+    public async Task NonSealedClassAtCreationSite_GetsTheInfoHint()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public record OpenPerson(string Name); // records default to non-sealed
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(new OpenPerson("a"));
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Info, diagnostic.Severity);
+        Assert.Contains("OpenPerson", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SealedValueAndGreenListedTypes_AreQuiet()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public sealed record SealedPerson(string Name);
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(new SealedPerson("a"));
+                    f.CreateSignal(1); // value type
+                    f.CreateSignal(new Uri("https://x")); // green-listed framework type, though not sealed
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+}

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -194,6 +194,40 @@ public class SubclassSmugglingAnalyzerTests
     }
 
     [Fact]
+    public async Task InheritedMemberTypes_AreSmuggleSurfacesToo()
+    {
+        // The member walk follows the base chain like the classifier: the hole hides on the
+        // inherited member exactly like on a declared one.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public record OpenPerson(string Name);
+
+            public class BoxBase
+            {
+                public OpenPerson? Value { get; init; }
+            }
+
+            public sealed class Box : BoxBase
+            {
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(new Box());
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Contains("OpenPerson", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task SendableAbstractBase_IsStillASmuggleSurface()
     {
         // [Sendable] lets an abstract base PASS MZR001 (Error), but the attribute is

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -32,6 +32,9 @@ public class SubclassSmugglingAnalyzerTests
         Assert.Equal("MZR006", diagnostic.Id);
         Assert.Equal(DiagnosticSeverity.Info, diagnostic.Severity);
         Assert.Contains("OpenPerson", diagnostic.GetMessage());
+        // The value's own runtime type IS what ValidateWrittenValues checks, so here (and only
+        // here) the hint may suggest it.
+        Assert.Contains("enable MemoFactoryOptions.ValidateWrittenValues", diagnostic.GetMessage());
     }
 
     [Fact]
@@ -58,6 +61,33 @@ public class SubclassSmugglingAnalyzerTests
         var diagnostic = Assert.Single(diagnostics);
         Assert.Equal("MZR006", diagnostic.Id);
         Assert.Contains("OpenPerson", diagnostic.GetMessage());
+        // The signal-write guard checks the written ARRAY's runtime type only; suggesting it
+        // for the nested element would promise a check that can never see it.
+        Assert.DoesNotContain("enable MemoFactoryOptions.ValidateWrittenValues", diagnostic.GetMessage());
+        Assert.Contains("not contents nested inside it", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DisabledChecksFactory_GetsNoSmugglingHint()
+    {
+        // Smuggling is a hole in the Sendable checks; a factory that visibly opted out of them
+        // has nothing to smuggle past, so the hint would be pure noise.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public record OpenPerson(string Name);
+
+            public class C
+            {
+                public void M()
+                {
+                    var lax = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks);
+                    lax.CreateSignal(new OpenPerson("a"));
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
     }
 
     [Fact]

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -305,4 +305,53 @@ public class SubclassSmugglingAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+
+    [Fact]
+    public async Task GreenListedTaskSurfaces_StillHintTheUpcastSmuggle()
+    {
+        // Task needs no accidental user subclass: every Task<TResult> IS one, so a declared
+        // Task surface can smuggle an arbitrary payload past the creation check (which sees
+        // only typeof(Task)). ValidateWrittenValues is the runtime net -- hint it.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal<Task>(Task.FromResult<List<int>>(new List<int>()));
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Contains("Task", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task GenericTaskSurfaces_KeepTheGreenListExemption()
+    {
+        // A declared Task<T> exposes its payload as a TYPE ARGUMENT the walk already
+        // unfolds; the surface itself stays exempt -- user code subclassing Task<T> is not
+        // a plausible failure mode.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Threading.Tasks;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(Task.FromResult(1));
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -165,6 +165,39 @@ public class SubclassSmugglingAnalyzerTests
     }
 
     [Fact]
+    public async Task SendableAbstractBase_IsStillASmuggleSurface()
+    {
+        // [Sendable] lets an abstract base PASS MZR001 (Error), but the attribute is
+        // deliberately not inherited -- the assertion binds the base author, not every
+        // subclass -- so the smuggle hole reopens exactly where the Error rule went quiet.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            [Sendable]
+            public abstract class Base
+            {
+            }
+
+            public sealed class Child : Base
+            {
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal<Base>(new Child());
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Contains("Base", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task SealedValueAndGreenListedTypes_AreQuiet()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SubclassSmugglingAnalyzerTests.cs
@@ -68,6 +68,55 @@ public class SubclassSmugglingAnalyzerTests
     }
 
     [Fact]
+    public async Task SendingTransfers_AreNotSmugglingSurfaces()
+    {
+        // Sending<T> DELIBERATELY wraps a non-Sendable payload for transfer (the SE-0430
+        // analog); hinting about the payload's sealedness would misread the escape hatch as
+        // shared Sendable state.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(Sending.Transfer(new List<int>()));
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task SmuggleSurfaces_BuriedArbitrarilyDeep_AreStillHinted()
+    {
+        // No depth cliff: the declared type tree is finite, so the walk terminates on its own
+        // -- a cap would silently drop the hint exactly for the compositions MZR001 accepts.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Immutable;
+            using MemoizR;
+
+            public record OpenPerson(string Name);
+
+            public class C
+            {
+                public void M(ImmutableArray<ImmutableArray<ImmutableArray<ImmutableArray<ImmutableArray<OpenPerson>>>>> value)
+                {
+                    var f = new MemoFactory();
+                    f.CreateSignal(value);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR006", diagnostic.Id);
+        Assert.Contains("OpenPerson", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task DisabledChecksFactory_GetsNoSmugglingHint()
     {
         // Smuggling is a hole in the Sendable checks; a factory that visibly opted out of them

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -4645,6 +4645,144 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task SendableArguments_AreNotRemappedAtCallSites()
+    {
+        // Move receives a boxed immutable int: nothing mutable reached the receiver, so
+        // the caller's later read is harmless.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    void Move(object x)
+                    {
+                        _ = Sending.Transfer(x);
+                    }
+                    var id = 1;
+                    Move(id);
+                    _ = id;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task LeafWithOperands_ShareTheirSlots()
+    {
+        // The clone shallow-copies box's Value: the receiver-owned clone and the sender's
+        // box now share the same list, so mutating through box is a use.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box(List<int> Value)
+            {
+                public int Other { get; init; }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var box = new Box(list);
+                    var sending = Sending.Transfer(box with { Other = 1 });
+                    box.Value.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'box'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task EnumConstrainedGenericSources_AreHarmless()
+    {
+        // Enum values are copied immutable values: the same exemption the statics rule
+        // grants where T : Enum.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M<T>(T value) where T : System.Enum
+                {
+                    _ = Sending.Transfer(value);
+                    _ = value;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ForeachAdvancement_IsThrowCapable()
+    {
+        // A custom enumerator's MoveNext/Dispose can throw after the body's handoff: the
+        // catch then observes the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(IEnumerable<int> xs)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        foreach (var item in xs)
+                        {
+                            _ = Sending.Transfer(list);
+                        }
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ConditionalDelegateStores_ExpandTheirArms()
+    {
+        // One runtime path stores the reading Touch: the guarded call can run it after the
+        // handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool flag)
+                {
+                    var list = new List<int> { 1 };
+                    void Touch() => list.Add(1);
+                    Action? use = flag ? Touch : null;
+                    var sending = Sending.Transfer(list);
+                    use?.Invoke();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -2691,6 +2691,37 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task CallablesInsideEscapingExpressions_ResolveAgainstTheWholeBody()
+    {
+        // The escaping expression evaluates Use() after the handoff, before the method
+        // exits -- and Use's declaration sits OUTSIDE the return expression, so the lookup
+        // must reach the whole body.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    int Use()
+                    {
+                        list.Add(1);
+                        return 0;
+                    }
+                    return Pair(Sending.Transfer(list), Use());
+                }
+
+                private static Sending<List<int>> Pair(Sending<List<int>> sending, int x) => sending;
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -879,6 +879,136 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task TupleElements_HandedToTransfer_AreTracked()
+    {
+        // Transfer((list, 0)): the tuple carries the same list reference to the receiver.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<(List<int>, int)> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer((list, 0));
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task SwitchExpressionArms_HandedToTransfer_AreTracked()
+    {
+        // One arm hands off `list`: a may-transfer, tracked like a ternary operand.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(bool flag)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(flag switch { true => list, _ => new List<int>() });
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task NameOfMentions_AreNotRuntimeUses()
+    {
+        // nameof(list) is a compile-time constant: no runtime read of the transferred object
+        // occurs, so it must not block the handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    _ = nameof(list);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task UsingStatements_OverExistingLocals_DisposeAfterTheTransfer()
+    {
+        // `using (stream)` over an existing local emits the same scope-end Dispose as a
+        // using declaration: the sender destroys the object the receiver now owns.
+        var diagnostics = await AnalyzeAsync("""
+            using System.IO;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<MemoryStream> M(MemoryStream stream)
+                {
+                    using (stream)
+                    {
+                        return Sending.Transfer(stream);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'stream'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task LocalFunctionDeclarations_DoNotMakeCatchesReachable()
+    {
+        // The declaration after the transfer neither executes nor throws on the try path: the
+        // catch still cannot observe a completed handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        void Helper()
+                        {
+                        }
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task UsingLocals_AreDisposedBySenderAfterTheTransfer()
     {
         // The scope's compiler-generated Dispose runs after the handoff with no source

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -2941,6 +2941,148 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task DelegateCallsInsideCalledFunctions_AreFollowed()
+    {
+        // F() runs the delegate, and the delegate runs the reading lambda: the chain
+        // reaches the transferred value transitively.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => list.Add(1);
+                    void F()
+                    {
+                        use();
+                    }
+                    var sending = Sending.Transfer(list);
+                    F();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task IndexerInitializerValues_AreTransferSources()
+    {
+        // ["x"] = list stores the same reference into the dictionary the receiver now owns.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Dictionary<string, List<int>> { ["x"] = list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task GenericLocalFunctionCalls_ResolveTheirDeclarations()
+    {
+        // Use<int>() carries a constructed symbol; the declaration carries the definition --
+        // the lookup must still connect them.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    void Use<T>()
+                    {
+                        list.Add(1);
+                    }
+                    var sending = Sending.Transfer(list);
+                    Use<int>();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CombinedDelegateStores_AreCallablesToo()
+    {
+        // += multicasts the reading lambda onto the delegate: invoking it after the handoff
+        // runs that lambda.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    use += () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    use();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LocalReturnsBeforeResets_KeepTheResetConditional()
+    {
+        // Reset(true) returns before the assignment: the call completes without rewriting,
+        // and the later Add still touches the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Reset(bool skip)
+                    {
+                        if (skip) return;
+                        list = new List<int>();
+                    }
+                    _ = Sending.Transfer(list);
+                    Reset(true);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -4348,6 +4348,98 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task SendableTupleElements_AreNotTracked()
+    {
+        // The tuple copies id by value and int is deeply immutable: only the list can alias
+        // mutable state with the receiver, so only its use reports.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var id = 1;
+                    var list = new List<int> { 1 };
+                    var sent = Sending.Transfer((id, list));
+                    _ = id;
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task EventAccessors_AreThrowCapable()
+    {
+        // A custom add accessor is user code: it can throw after the completed handoff and
+        // land in the catch, which reads the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public event Action? Changed;
+
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        Changed += Handler;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static void Handler()
+                {
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task DefinitelyRemovedTargets_CannotRun()
+    {
+        // use -= Touch empties the invocation list before the handoff: the null-conditional
+        // call runs nothing.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Touch() => list.Add(1);
+                    Action? use = Touch;
+                    use -= Touch;
+                    var sending = Sending.Transfer(list);
+                    use?.Invoke();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1982,6 +1982,271 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task UncalledNestedDeclarations_DoNotMakeTheCallARead()
+    {
+        // F() runs nothing: the only reference lives in a nested declaration F never
+        // invokes, and declarations do not execute.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void F()
+                    {
+                        void Unused()
+                        {
+                            list.Add(1);
+                        }
+                    }
+                    F();
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task WrapperCalls_ThatReachAReadingFunction_StillReport()
+    {
+        // Outer() -> Use() -> the read runs after the handoff: the chained call is a use.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Outer()
+                    {
+                        Use();
+                    }
+                    void Use()
+                    {
+                        list.Add(1);
+                    }
+                    Outer();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CallsInsideUncalledLocalFunctions_AreNotUses()
+    {
+        // Use() is only invoked from Outer's body, and Outer never runs: neither the
+        // declaration nor the call inside it executes.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Outer()
+                    {
+                        Use();
+                    }
+                    void Use()
+                    {
+                        list.Add(1);
+                    }
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task GeneratedDisposes_TrackTheCapturedObject_NotTheReassignedVariable()
+    {
+        // The using captured the ORIGINAL stream at entry: after the definite reassignment,
+        // scope-end Dispose touches the old object, not the one handed off.
+        var diagnostics = await AnalyzeAsync("""
+            using System.IO;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<MemoryStream> M()
+                {
+                    var stream = new MemoryStream();
+                    using (stream)
+                    {
+                        stream = new MemoryStream();
+                        return Sending.Transfer(stream);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ForeachIteration_AfterADefiniteReassignment_ReadsADifferentList()
+    {
+        // The enumerator iterates the collection captured at loop entry: every iteration
+        // reassigns before transferring, so MoveNext never touches the handed-off object.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list)
+                    {
+                        list = new List<int>();
+                        _ = Sending.Transfer(list);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ArgumentsOfResettingCalls_AreEvaluatedBeforeTheReset()
+    {
+        // Reset(list.Count): the argument reads the transferred value BEFORE the body's
+        // reset runs -- the reset cannot retroactively excuse it.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Reset(int unused)
+                    {
+                        list = new List<int>();
+                    }
+                    Reset(list.Count);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task NonThrowingCodeAfterTheTransfer_DoesNotKeepCatchesAlive()
+    {
+        // Nothing after the completed handoff can throw: the handler can never observe the
+        // wrapper, so its read is unreachable on every transferred path.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        var x = 0;
+                        _ = x;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OutResets_InLocalFunctionBodies_AreReinitializers()
+    {
+        // An out parameter must be assigned before Init returns: calling Reset only ever
+        // rewrites the variable, exactly like a simple assignment.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Reset()
+                    {
+                        Init(out list);
+                    }
+                    Reset();
+                    list.Add(1);
+                    return sending;
+                }
+
+                private static void Init(out List<int> target) => target = new List<int>();
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DeconstructionResets_InLocalFunctionBodies_AreReinitializers()
+    {
+        // A deconstruction target is definitely assigned like a simple-assignment target --
+        // inside a called body too.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Reset()
+                    {
+                        (list, _) = (new List<int>(), 0);
+                    }
+                    Reset();
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -544,6 +544,36 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task SwitchGuardTransfers_AreVisibleToLaterArms()
+    {
+        // A failing `when` guard falls through to later cases with the transfer already done:
+        // the default arm's Add is a real use after transfer, not a sibling-arm exclusion.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(int n)
+                {
+                    var list = new List<int> { 1 };
+                    switch (n)
+                    {
+                        case 0 when Sending.Transfer(list) is null:
+                            break;
+                        default:
+                            list.Add(1);
+                            break;
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task FinallyBlocks_RunAfterAReturnTransfer_AndAreStillScanned()
     {
         // `return Sending.Transfer(list)` exits the method -- but the enclosing finally runs

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1009,6 +1009,159 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task TransferAndOutReinitialization_InOneCall_IsClean()
+    {
+        // The reference inside the transfer argument IS the handoff, not a post-transfer
+        // sibling read: the out assignment then hands the later Add a fresh list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Reset(Sending.Transfer(list), out list);
+                    list.Add(1);
+                }
+
+                private static void Reset(Sending<List<int>> sending, out List<int> value)
+                {
+                    value = new List<int>();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task UsingResources_MerelyMentioningTheVariable_DoNotDisposeIt()
+    {
+        // The using disposes the Scope wrapper, not the transferred list: a resource that
+        // only MENTIONS the variable is no disposal of the handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public sealed class Scope : IDisposable
+            {
+                public Scope(int size)
+                {
+                }
+
+                public void Dispose()
+                {
+                }
+            }
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    using (new Scope(list.Count))
+                    {
+                        return Sending.Transfer(list);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ThrowingReinitializers_KeepEnclosingCatchesAlive()
+    {
+        // Throwing() can throw AFTER the handoff and BEFORE the assignment completes: the
+        // catch still sees the transferred list on that path.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        list = Throwing();
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static List<int> Throwing()
+                {
+                    return new List<int>();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ForeachIteration_ReadsTheCollectionAfterATransferInsideTheLoop()
+    {
+        // The next MoveNext reads the transferred list -- a sender-side use with no source
+        // reference to scan for.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list)
+                    {
+                        _ = Sending.Transfer(list);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ForeachTransfer_FollowedByADefiniteBreak_IsClean()
+    {
+        // The break on the transfer's own conditional level leaves the loop before any
+        // further MoveNext: the handoff is the find-and-transfer pattern.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list)
+                    {
+                        _ = Sending.Transfer(list);
+                        break;
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task UsingLocals_AreDisposedBySenderAfterTheTransfer()
     {
         // The scope's compiler-generated Dispose runs after the handoff with no source

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -186,6 +186,125 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task OutArgument_Reinitializes_AndEndsTracking()
+    {
+        // An out argument is definite assignment the callee cannot read: like `list = ...`, it
+        // gives the variable a fresh value, so the later use is not a use-after-transfer.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    Reset(out list);
+                    list.Add(1);
+                    return sending;
+                }
+
+                private static void Reset(out List<int> value)
+                {
+                    value = new List<int>();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ConditionalOutArgument_DoesNotSilenceTheLaterUse()
+    {
+        // Same sibling-arm rule as a conditional `list = ...`: on the false path the out-call
+        // never ran and the later use still touches the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(bool reset)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    if (reset)
+                    {
+                        Reset(out list);
+                    }
+
+                    list.Add(1);
+                    return sending;
+                }
+
+                private static void Reset(out List<int> value)
+                {
+                    value = new List<int>();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task TransferInsideADeferredCallback_DoesNotPoisonTheOuterFlow()
+    {
+        // The callback may run later or never: outer statements are not sequenced after its
+        // transfer, so the outer Add is not a use-after-transfer.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action M()
+                {
+                    var list = new List<int> { 1 };
+                    Action later = () => { _ = Sending.Transfer(list); };
+                    list.Add(1);
+                    return later;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task UseAfterTransfer_InsideTheSameCallback_IsStillFlagged()
+    {
+        // Within one callback body source order does imply execution order: the callback's own
+        // later use of its own transfer is the ordinary MZR005 case.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action M()
+                {
+                    var list = new List<int> { 1 };
+                    return () =>
+                    {
+                        var sending = Sending.Transfer(list);
+                        list.Add(1);
+                        _ = sending;
+                    };
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task UsesBeforeTransfer_AndReassignedVariables_AreNotFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -490,6 +490,82 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task InlineAssignmentTransfer_IsTracked()
+    {
+        // Transfer(list = new(...)): after the statement the variable aliases the transferred
+        // value, so the later Add is a use-after-transfer like any other.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    List<int> list;
+                    var sending = Sending.Transfer(list = new List<int> { 1 });
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DeconstructionTarget_Reinitializes_AndEndsTracking()
+    {
+        // A deconstruction target is definitely assigned like a simple-assignment target: the
+        // later use touches the fresh value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    (list, _) = (new List<int>(), 0);
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DeconstructionRhsReadingTheTransferredValue_IsFlagged()
+    {
+        // Same caveat as `list = Clone(list)`: the deconstruction's RHS reads the transferred
+        // value to build the replacement -- exactly a use after transfer.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    (list, _) = (new List<int>(list), 0);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task UsesBeforeTransfer_AndReassignedVariables_AreNotFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -650,6 +650,69 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task CatchHandlers_ObserveAThrownTransfer()
+    {
+        // A thrown transfer lands in the try's handlers: the catch runs after the throw
+        // expression evaluated, so its Add touches the handed-off list.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public sealed class E : Exception
+            {
+                public E(Sending<List<int>> payload)
+                {
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        throw new E(Sending.Transfer(list));
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task UsingLocals_AreDisposedBySenderAfterTheTransfer()
+    {
+        // The scope's compiler-generated Dispose runs after the handoff with no source
+        // reference to scan for: the sender destroys the object the receiver now owns.
+        var diagnostics = await AnalyzeAsync("""
+            using System.IO;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<MemoryStream> M()
+                {
+                    using var stream = new MemoryStream();
+                    var sent = Sending.Transfer(stream);
+                    return sent;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'stream'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task FinallyBlocks_RunAfterAReturnTransfer_AndAreStillScanned()
     {
         // `return Sending.Transfer(list)` exits the method -- but the enclosing finally runs

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -3431,6 +3431,151 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task CallsWhoseArgumentsContainTheTransfer_RunTheirBodyAfterIt()
+    {
+        // The callee body runs only after all arguments evaluated -- the handoff included.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Use(Sending<List<int>> unused)
+                    {
+                        list.Add(1);
+                    }
+                    Use(Sending.Transfer(list));
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task DelegateStoresInsideUncalledFunctions_NeverRan()
+    {
+        // Configure is never invoked: its store cannot be the delegate's value at the call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    void Configure()
+                    {
+                        use = () => list.Add(1);
+                    }
+                    var sending = Sending.Transfer(list);
+                    use();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DelegateAliases_SnapshotTheSourceAtTheCopy()
+    {
+        // use copied src BEFORE the reading lambda landed in src: the copy keeps the old
+        // invocation list, so the call runs only the no-op.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Action src = () => { };
+                    Action use = src;
+                    src = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    use();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ThrowingCallsBeforeResets_KeepThePathOpen()
+    {
+        // The caught MayThrow() path skips the reset and resumes after the try: the final
+        // Add still touches the transferred list on that path.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        MayThrow();
+                        list = new List<int>();
+                    }
+                    catch
+                    {
+                    }
+
+                    list.Add(1);
+                }
+
+                private static void MayThrow()
+                {
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task RecordConstructorArguments_AreTransferSources()
+    {
+        // A positional record's primary constructor deterministically stores each parameter
+        // in its same-named slot: the receiver owns a Box carrying the same list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box(List<int> Value);
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box(list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -3696,6 +3696,204 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ParametersReassignedBeforeTheTransfer_NoLongerAliasTheArgument()
+    {
+        // Move transfers its own fresh list: the caller's original was never handed off.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move(List<int> x)
+                    {
+                        x = new List<int>();
+                        _ = Sending.Transfer(x);
+                    }
+                    Move(list);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task StaticFieldReads_MayRunTypeInitializers_AndKeepCatchesAlive()
+    {
+        // The first touch of Holder can run its type initializer, which may throw after the
+        // completed handoff: the catch then observes the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public static class Holder
+            {
+                public static int Value;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        _ = Holder.Value;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task NonResumingCatches_CannotSkipResets()
+    {
+        // The handler rethrows: either the reset ran, or the method exited -- no path
+        // reaches the Add with the old list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        MayThrow();
+                        list = new List<int>();
+                    }
+                    catch
+                    {
+                        throw;
+                    }
+
+                    list.Add(1);
+                }
+
+                private static void MayThrow()
+                {
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DynamicOperations_AreThrowCapable()
+    {
+        // A dynamic dispatch can fail at runtime after the completed handoff: the catch
+        // then observes the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(dynamic dyn)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        dyn.Foo();
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CustomRecordConstructors_DoNotCarryByNameAlone()
+    {
+        // The hand-written constructor ignores its parameter: a matching name proves no
+        // storage -- only the PRIMARY constructor's parameters deterministically store.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box
+            {
+                public List<int>? Value { get; init; }
+
+                public Box(List<int> Value)
+                {
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box(list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NestedMemberInitializers_AreTransferSources()
+    {
+        // Child = { Value = list } writes into the object the transferred Box already
+        // reaches: the receiver owns a graph containing the same list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Inner
+            {
+                public List<int>? Value { get; set; }
+            }
+
+            public class Box
+            {
+                public Inner Child { get; } = new Inner();
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box { Child = { Value = list } });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -2364,6 +2364,333 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ConditionalDelegateInvokes_AreStillUses()
+    {
+        // use?.Invoke() reaches the same lambda through a conditional-access receiver: the
+        // wrapper around the local must not hide the call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action? use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    use?.Invoke();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task SiblingArmDelegateStores_CannotReachTheCall()
+    {
+        // The reading lambda is stored only in the arm the transfer path never runs: the
+        // call in the transfer arm can only see the earlier no-op.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool move)
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    if (move)
+                    {
+                        _ = Sending.Transfer(list);
+                        use();
+                    }
+                    else
+                    {
+                        use = () => list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DelegateStores_AfterTheCall_CannotBeItsValue()
+    {
+        // The reading lambda lands in the local only after the call already ran the earlier
+        // no-op: the CALL is not a use. What remains is the standing escape stance on the
+        // post-transfer lambda itself -- so the report anchors at the lambda's read, not at
+        // use().
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    var sending = Sending.Transfer(list);
+                    use();
+                    use = () => list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Equal("list", diagnostic.Location.SourceTree!.GetText().ToString(diagnostic.Location.SourceSpan));
+    }
+
+    [Fact]
+    public async Task SpreadsOfInlineContainers_CarryTheirElements()
+    {
+        // [.. new[] { list }] enumerates the inline array INTO the new collection: the same
+        // list reference arrives at the receiver.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer<List<int>[]>([.. new[] { list }]);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SpreadsOfPlainVariables_DoNotHandOffTheOperand()
+    {
+        // [..source] copies source's ELEMENTS into the new collection: the source object
+        // itself stays with the sender.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var source = new List<int> { 1 };
+                    var sending = Sending.Transfer<int[]>([.. source]);
+                    source.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CaughtThrows_DoNotEndTheForeachIteration()
+    {
+        // The throw is absorbed inside the loop body: control stays in the foreach and the
+        // next MoveNext still reads the transferred collection.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list)
+                    {
+                        try
+                        {
+                            _ = Sending.Transfer(list);
+                            throw new System.Exception();
+                        }
+                        catch
+                        {
+                        }
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LocallyCaughtThrownTransfers_KeepTheSenderScanAlive()
+    {
+        // The matching catch absorbs the throw: the method resumes after the try, where the
+        // sender still touches the handed-off list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class PayloadException : System.Exception
+            {
+                public PayloadException(Sending<List<int>> payload)
+                {
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        throw new PayloadException(Sending.Transfer(list));
+                    }
+                    catch (PayloadException)
+                    {
+                    }
+
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ArgumentResets_GiveTheBodyAFreshValue()
+    {
+        // The argument reassigns BEFORE the body runs: the captured read inside Use only
+        // ever sees the fresh list, and so does everything after the call.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    void Use(object unused) => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    Use(list = new List<int>());
+                    list.Add(2);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ArgumentResetsBuiltFromTheValue_AreStillUses()
+    {
+        // The replacement is built FROM the transferred value on the way into the call.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    void Use(object unused) => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    Use(list = new List<int>(list));
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CatchlessTryResets_AreDefinite()
+    {
+        // The try body is entered unconditionally and nothing can resume past a failed
+        // reset: reaching the Add means the assignment completed.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    try
+                    {
+                        list = new List<int>();
+                    }
+                    finally
+                    {
+                    }
+
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task TryResetsWithCatches_StayConditional()
+    {
+        // A catch can resume past the failed reset: the Add may still see the transferred
+        // value on that path.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    try
+                    {
+                        list = MayThrow();
+                    }
+                    catch
+                    {
+                    }
+
+                    list.Add(1);
+                    return sending;
+                }
+
+                private static List<int> MayThrow() => new();
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -36,6 +36,31 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ReassignmentWhoseRhsReadsTheTransferredValue_IsFlagged()
+    {
+        // `list = Clone(list)` LOOKS like a fresh value, but the RHS reads the transferred one
+        // to build the replacement -- exactly a use after transfer.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    list = new List<int>(list); // reads the transferred list
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task UsesBeforeTransfer_AndReassignedVariables_AreNotFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -2722,6 +2722,97 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ObjectInitializerFieldStores_AreTransferSources()
+    {
+        // Box.Value is a FIELD: the initializer deterministically stores the same list into
+        // the object the receiver now owns.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Box
+            {
+                public List<int>? Value;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box { Value = list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ObjectInitializerAutoPropertyStores_AreTransferSources()
+    {
+        // An auto-property is a compiler-known slot: the initializer's store is as
+        // deterministic as a field write.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Box
+            {
+                public List<int>? Value { get; set; }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box { Value = list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ObjectInitializerCustomSetters_AreNotDeterministicStores()
+    {
+        // A custom setter may not store what it was handed: only compiler-known slots count
+        // as carrying the reference to the receiver.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Sink
+            {
+                public List<int>? Value
+                {
+                    get => null;
+                    set { }
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Sink { Value = list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -4965,6 +4965,86 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task GotoCaseEdges_MakeSiblingArmsReachable()
+    {
+        // goto default re-enters the sibling arm AFTER the handoff: the arms are not
+        // mutually exclusive on that path.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(int n)
+                {
+                    var list = new List<int> { 1 };
+                    switch (n)
+                    {
+                        case 0:
+                            _ = Sending.Transfer(list);
+                            goto default;
+                        default:
+                            list.Add(1);
+                            break;
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task KeyValuePairCreate_IsACarrierFactory()
+    {
+        // KeyValuePair.Create stores both arguments exactly like its constructor.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(KeyValuePair.Create("k", list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task WithInitializerOverwrites_DropTheOperandSlot()
+    {
+        // The with-initializer definitely replaces Value: the receiver's clone never
+        // retains the constructor's list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box(List<int> Value);
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box(list) with { Value = new List<int>() });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -716,6 +716,131 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task SiblingArmBranches_CannotSkipOnTheTransferPath()
+    {
+        // The else-break never runs on the path that transferred: the reassignment at the end
+        // of the loop body is definite there, so the code after the loop sees a fresh list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool c, bool move)
+                {
+                    var list = new List<int> { 1 };
+                    while (c)
+                    {
+                        if (move)
+                        {
+                            _ = Sending.Transfer(list);
+                        }
+                        else
+                        {
+                            break;
+                        }
+
+                        list = new List<int>();
+                    }
+
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CoalescedTransferOperands_AreTracked()
+    {
+        // On the normal path the coalesce hands off `list` itself: the later Add is a
+        // use-after-transfer even though the argument is not a bare variable reference.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(List<int>? list)
+                {
+                    var sending = Sending.Transfer(list ?? throw new InvalidOperationException());
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CatchHandlers_AfterACompletedTransfer_AreUnreachable()
+    {
+        // Nothing follows the transfer inside the try: a completed handoff skips the handlers,
+        // and a throw from the transfer expression itself means no wrapper escaped.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CatchHandlers_WithThrowingCodeAfterTheTransfer_AreStillScanned()
+    {
+        // The call after the transfer can throw INTO the handler with the wrapper already
+        // escaped: the handler's use stays reportable.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        MayThrow();
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static void MayThrow()
+                {
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task CatchHandlers_ObserveAThrownTransfer()
     {
         // A thrown transfer lands in the try's handlers: the catch runs after the throw

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1162,6 +1162,201 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task EnclosingCalls_CanThrowAfterTheWrapperExists_AndReachTheCatch()
+    {
+        // MayThrow runs AFTER building the wrapper and may throw with the handoff complete:
+        // the catch use is reachable.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        MayThrow(Sending.Transfer(list));
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static void MayThrow(Sending<List<int>> sending)
+                {
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task AssignmentRhsAliases_AreTrackedToo()
+    {
+        // Transfer(list = other): BOTH names alias the handed-off object, so the later use of
+        // the original RHS alias is a use-after-transfer.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(List<int> other)
+                {
+                    List<int> list;
+                    var sending = Sending.Transfer(list = other);
+                    other.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'other'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ThrowingReinitializers_KeepEnclosingFinallysAliveToo()
+    {
+        // The finally runs whether or not Throwing() threw before the assignment completed:
+        // on the throwing path it observes the transferred value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        list = Throwing();
+                    }
+                    finally
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static List<int> Throwing()
+                {
+                    return new List<int>();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ThrowingGetters_OpenTheReinitializationWindowToo()
+    {
+        // A property getter is a method: it can throw after the handoff, before the target is
+        // assigned, so the catch still sees the transferred value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public static List<int> Next => new();
+
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        list = Next;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ReturningCalls_ThatCanThrowAfterTheTransfer_ReachTheCatch()
+    {
+        // The returning call can throw after the wrapper exists, before the method exits: the
+        // local catch runs with the handoff complete.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>>? M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        return MayThrow(Sending.Transfer(list));
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                        return null;
+                    }
+                }
+
+                private static Sending<List<int>> MayThrow(Sending<List<int>> sending)
+                {
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LocalFunctionExits_DoNotEndTheForeachIteration()
+    {
+        // The nested return never runs on the loop path: the next MoveNext still reads the
+        // transferred collection.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list)
+                    {
+                        _ = Sending.Transfer(list);
+                        void F()
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task UsingLocals_AreDisposedBySenderAfterTheTransfer()
     {
         // The scope's compiler-generated Dispose runs after the handoff with no source

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -5448,6 +5448,201 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ForeachCollectionsBuiltFromTheVariable_KeepReadingIt()
+    {
+        // The Where wrapper's enumerator pulls from the SAME list: the next MoveNext after
+        // the handoff is a sender-side read even though the collection expression is not
+        // the bare variable.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using System.Linq;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list.Where(_ => true))
+                    {
+                        var sending = Sending.Transfer(list);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task BranchLocalOverwrites_KillEarlierStores()
+    {
+        // Every path that reaches use() ran the branch's own overwrite first: the stale
+        // pre-branch Touch cannot be what the call invokes.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool flag)
+                {
+                    var list = new List<int> { 1 };
+                    void Touch() { list.Add(1); }
+                    Action use = Touch;
+                    if (flag)
+                    {
+                        use = () => { };
+                        var sending = Sending.Transfer(list);
+                        use();
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CustomAccessorDelegateProperties_AreNotSlots()
+    {
+        // The setter discards and the getter manufactures: nothing stored is ever
+        // returned, so the assignment cannot be what the invocation runs.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private Action Use { get => () => { }; set { } }
+
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Touch() { list.Add(1); }
+                    Use = Touch;
+                    var sending = Sending.Transfer(list);
+                    Use();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task AutoPropertyDelegateSlots_StayTracked()
+    {
+        // An auto-property IS a backing slot: what the setter stored is what the
+        // invocation runs.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private Action? Use { get; set; }
+
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    this.Use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    this.Use!();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task RemovalsCancelInsideCombinedStores()
+    {
+        // use -= Touch strips the reading target out of the combined invocation list:
+        // what remains at the call is the no-op.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Touch() { list.Add(1); }
+                    Action noop = () => { };
+                    Action use = (Action)Touch + noop;
+                    use -= Touch;
+                    var sending = Sending.Transfer(list);
+                    use();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task InertLocalFunctionArguments_AreNotEscapes()
+    {
+        // Ignore never references its parameter: the delegate is dropped, not published
+        // -- nothing can run it after the handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Ignore(Action a) { }
+                    Action use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    Ignore(use);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task LocalFunctionArgumentsThatTouchTheParameter_StayEscapes()
+    {
+        // Run invokes what it was handed: the reading lambda executes after the handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Run(Action a) { a(); }
+                    Action use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    Run(use);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task ImmutableCollectionFactories_AreTransferSources()
     {
         // ImmutableArray.Create(list) stores its ARGUMENTS as elements: the receiver owns

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -305,6 +305,191 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task TransferInOneArm_SiblingArmUses_AreUnreachable()
+    {
+        // The arms are mutually exclusive: no execution path runs the else's Add after the
+        // then's transfer, so there is nothing to flag.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>>? M(bool move)
+                {
+                    var list = new List<int> { 1 };
+                    Sending<List<int>>? sending = null;
+                    if (move)
+                    {
+                        sending = Sending.Transfer(list);
+                    }
+                    else
+                    {
+                        list.Add(1);
+                    }
+
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ConditionalUse_OnAReachablePath_IsStillFlagged()
+    {
+        // Unlike a sibling arm, a branch the transfer precedes entirely IS reachable after it:
+        // the log==true path runs the Add on the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(bool log)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    if (log)
+                    {
+                        list.Add(1);
+                    }
+
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task UsesDominatedByAConditionalReinitialization_AreClean()
+    {
+        // Inside the arm, after the reassignment, every path that reaches the Add sees the
+        // fresh list (reset == false never enters the arm): nothing touches the transferred
+        // value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(bool reset)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    if (reset)
+                    {
+                        list = new List<int>();
+                        list.Add(1);
+                    }
+
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task UsesAfterTheDominatingArm_AreStillFlagged()
+    {
+        // The domination ends with the arm: past the if, the reset == false path still hands
+        // the transferred list to the Add.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(bool reset)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    if (reset)
+                    {
+                        list = new List<int>();
+                        list.Add(1);
+                    }
+
+                    list.Add(2);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task OutArgument_WithASiblingArgumentReadingTheVariable_IsFlagged()
+    {
+        // The out-assignment happens only when the callee runs, AFTER every argument was
+        // evaluated: the second argument still reads the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    Reset(out list, list);
+                    return sending;
+                }
+
+                private static void Reset(out List<int> value, List<int> seed)
+                {
+                    value = new List<int>(seed);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CallbackReassignment_IsDeferred_TheOuterUseIsStillFlagged()
+    {
+        // The callback may never run before the outer Add, so its reassignment cannot end the
+        // outer tracking -- while within the callback's own body it dominates as usual.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    Action later = () =>
+                    {
+                        list = new List<int>();
+                        list.Add(1);
+                    };
+
+                    list.Add(2);
+                    _ = later;
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task UsesBeforeTransfer_AndReassignedVariables_AreNotFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -5045,6 +5045,95 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ParenthesizedTransferOperands_AreStillTransfers()
+    {
+        // Parentheses are pure syntax: the argument operation is the local reference.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer((list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CaughtEnclosingResetFailures_KeepTracking()
+    {
+        // The RHS can throw into the resuming catch BEFORE the assignment completes: after
+        // the try the variable may still hold the transferred value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        list = MayThrow(Sending.Transfer(list));
+                    }
+                    catch
+                    {
+                    }
+
+                    list.Add(1);
+                }
+
+                private static List<int> MayThrow(Sending<List<int>> sending) => new List<int>();
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task GotosLeavingTheSwitch_KeepSiblingArmsExclusive()
+    {
+        // goto after exits the switch entirely: the default arm never runs on the
+        // transferred path.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(int n)
+                {
+                    var list = new List<int> { 1 };
+                    switch (n)
+                    {
+                        case 0:
+                            _ = Sending.Transfer(list);
+                            goto after;
+                        default:
+                            list.Add(1);
+                            break;
+                    }
+
+                    after:
+                    _ = n;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -4440,6 +4440,211 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task UsingDisposal_IsThrowCapable()
+    {
+        // The scope's Dispose runs after the handoff and can throw into the catch, which
+        // then reads the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using System.IO;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        using (var scope = new MemoryStream())
+                        {
+                            _ = Sending.Transfer(list);
+                        }
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task UnconstrainedGenericSources_AreTracked()
+    {
+        // T can be any mutable type at the call site: the generic helper's post-transfer
+        // read is exactly the hazard MZR005 exists for.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M<T>(T value)
+                {
+                    _ = Sending.Transfer(value);
+                    _ = value;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task StructFieldReads_CannotThrow()
+    {
+        // Reading a field off a struct local dereferences nothing: no exception path can
+        // carry the wrapper into the handler.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public struct Point
+            {
+                public int X;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var point = new Point();
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        _ = point.X;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task SiblingArmDelegateStores_CannotEscapeOnTheTransferPath()
+    {
+        // The reading lambda lands in use only on the arm that did NOT transfer: no path
+        // both hands off the list and returns that callable.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action? M(bool move)
+                {
+                    var list = new List<int> { 1 };
+                    Action? use = null;
+                    if (move)
+                    {
+                        _ = Sending.Transfer(list);
+                    }
+                    else
+                    {
+                        use = () => list.Add(1);
+                    }
+
+                    return use;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DuplicateMulticastTargets_SurviveOneRemoval()
+    {
+        // Touch was added twice and removed once: one target remains and reads the
+        // transferred list at the call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Touch() => list.Add(1);
+                    Action? use = Touch;
+                    use += Touch;
+                    use -= Touch;
+                    var sending = Sending.Transfer(list);
+                    use?.Invoke();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task DelegateParameters_EscapeLikeLocals()
+    {
+        // The parameter holds the reading lambda and is returned after the handoff: the
+        // caller can run it against the receiver-owned object.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action M(Action use)
+                {
+                    var list = new List<int> { 1 };
+                    use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    return use;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task FrameworkValueCarrierConstructors_CarryTheirArguments()
+    {
+        // KeyValuePair's constructor deterministically stores both arguments: the receiver
+        // owns a pair containing the same list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new KeyValuePair<string, List<int>>("k", list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -4098,6 +4098,256 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task RedeclaredPositionalProperties_DropTheParameter()
+    {
+        // The explicit Value property has its own initializer: the primary parameter is
+        // never stored, so the receiver's Box does not carry the list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box(List<int> Value)
+            {
+                public List<int> Value { get; init; } = new List<int>();
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box(list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task InspectedDelegates_DoNotEscape()
+    {
+        // A null check neither runs the delegate nor lets it leave the scope.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    if (use != null)
+                    {
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OutResetsBeforeTheTransfer_BreakTheParameterAlias()
+    {
+        // Fresh(out x) rewrites the parameter before the handoff: the callee transferred
+        // its own fresh value, not the caller's list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move(List<int> x)
+                    {
+                        Fresh(out x);
+                        _ = Sending.Transfer(x);
+                    }
+                    Move(list);
+                    list.Add(1);
+                }
+
+                private static void Fresh(out List<int> target) => target = new List<int>();
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task UnmatchedThrowTypes_CannotSkipResets()
+    {
+        // The catch cannot catch InvalidOperationException: the throwing path exits the
+        // method, so every path reaching the Add ran the reset.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool bad)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        if (bad) throw new System.InvalidOperationException();
+                        list = new List<int>();
+                    }
+                    catch (System.ArgumentException)
+                    {
+                    }
+
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OutArguments_DoNotMaskReadingBodies()
+    {
+        // The out write lands only when Reset returns -- AFTER its body read the
+        // transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Reset(out List<int> fresh)
+                    {
+                        list.Add(1);
+                        fresh = new List<int>();
+                    }
+                    _ = Sending.Transfer(list);
+                    Reset(out list);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ThrowCapableSiblingArms_DoNotReachTheCatch()
+    {
+        // MayThrow lives in the arm the transfer path never runs: no exception can carry
+        // the wrapper into the handler.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool move)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        if (move)
+                        {
+                            _ = Sending.Transfer(list);
+                        }
+                        else
+                        {
+                            MayThrow();
+                        }
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static void MayThrow()
+                {
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task WrappingCalls_CanThrowBeforeTheReset_AndKeepThePathOpen()
+    {
+        // MayThrow can fail after the wrapper exists and before the reset: the caught path
+        // resumes with the transferred list still in the variable.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        MayThrow(Sending.Transfer(list));
+                        list = new List<int>();
+                    }
+                    catch
+                    {
+                    }
+
+                    list.Add(1);
+                }
+
+                private static void MayThrow(Sending<List<int>> sending)
+                {
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task RefParameterTransfers_StayMappedToTheCaller()
+    {
+        // x writes through to the caller's slot: the fresh value was transferred AND lives
+        // in list, so the caller's Add touches the handed-off object.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move(ref List<int> x)
+                    {
+                        x = new List<int>();
+                        _ = Sending.Transfer(x);
+                    }
+                    Move(ref list);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -490,6 +490,60 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task TransferInTheCondition_DominatesBothArms()
+    {
+        // The condition runs BEFORE either arm: the then-arm's Add executes after the handoff
+        // on every path that reaches it, so it is not a sibling-arm exclusion.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    if (Sending.Transfer(list) != null)
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task TransferThatExitsTheFlow_HasNoSenderSideContinuation()
+    {
+        // `return Sending.Transfer(list);` never falls through: the fallthrough path never
+        // transferred, so the later Add is unreachable on the path that did.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>>? M(bool move)
+                {
+                    var list = new List<int> { 1 };
+                    if (move)
+                    {
+                        return Sending.Transfer(list);
+                    }
+
+                    list.Add(1);
+                    return null;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task InlineAssignmentTransfer_IsTracked()
     {
         // Transfer(list = new(...)): after the statement the variable aliases the transferred

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -61,6 +61,36 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ConditionalReassignment_DoesNotSilenceTheLaterUse()
+    {
+        // On the `reset == false` path the later Add still touches the transferred list: only a
+        // reassignment that definitely executes may end the tracking.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(bool reset)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    if (reset)
+                    {
+                        list = new List<int>();
+                    }
+
+                    list.Add(2);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task UsesBeforeTransfer_AndReassignedVariables_AreNotFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1595,4 +1595,136 @@ public class UseAfterTransferAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+
+    [Fact]
+    public async Task UncalledLocalFunctionBodies_AreNotUses()
+    {
+        // Declaring a local function executes nothing: with no call, the body's reference
+        // never runs.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Unused()
+                    {
+                        list.Add(1);
+                    }
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task LocalFunctionsThatReinitializeBeforeReading_AreNotUses()
+    {
+        // Calling Reset only ever touches the fresh value: the body reassigns the variable
+        // before any read, so the call is a reinitialization, not a use.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Reset()
+                    {
+                        list = new List<int>();
+                        list.Add(1);
+                    }
+                    Reset();
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ReinitializingAssignmentEnclosingTheTransfer_EndsTracking()
+    {
+        // The assignment wrapping the transfer completes right after its RHS: by the next
+        // statement the variable already holds the fresh value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    list = MakeFresh(Sending.Transfer(list));
+                    list.Add(1);
+                }
+
+                private static List<int> MakeFresh(Sending<List<int>> sending) => new();
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ReadsInsideTheEnclosingReinitializationRhs_AreStillUses()
+    {
+        // The reinitialization only lands AFTER the whole RHS runs: a sibling argument
+        // evaluated after the transfer still reads the handed-off value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    list = Combine(Sending.Transfer(list), list.Count);
+                }
+
+                private static List<int> Combine(Sending<List<int>> sending, int count) => new();
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ArrayInitializerElements_AreTransferSources()
+    {
+        // Transfer(new[] { list }) hands off the array WITH its element: the array carries
+        // the reference exactly like a tuple does.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new[] { list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -4783,6 +4783,188 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task CarrierFactoryCalls_CarryTheirArguments()
+    {
+        // Tuple.Create stores its arguments exactly like the constructor spelling.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(Tuple.Create(list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ThrowingResetBodies_AreNotDefinite_ForCatchingCallers()
+    {
+        // Reset can fail before its reset; the caller's catch resumes with the ORIGINAL
+        // transferred value still in the variable.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Reset()
+                    {
+                        MayThrow();
+                        list = new List<int>();
+                    }
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        Reset();
+                    }
+                    catch
+                    {
+                    }
+
+                    list.Add(1);
+                }
+
+                private static void MayThrow()
+                {
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task TypedThrowFailures_OnlyReachMatchingCatches()
+    {
+        // The only failure after the handoff is an InvalidOperationException: the
+        // ArgumentException handler can never observe the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool flag)
+                {
+                    var list = new List<int> { 1 };
+                    var fresh = new List<int>();
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        list = flag ? fresh : throw new System.InvalidOperationException();
+                    }
+                    catch (System.ArgumentException)
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CombinedDelegateInitializers_ExpandTheirOperands()
+    {
+        // read + noop puts BOTH callables in the invocation list: the call runs the reader
+        // after the handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Action read = () => list.Add(1);
+                    Action use = read + (Action)(() => { });
+                    var sending = Sending.Transfer(list);
+                    use();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task OverwrittenPositionalArguments_AreNotRetained()
+    {
+        // The initializer definitely replaces Value: the transferred Box never keeps the
+        // constructor's list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box(List<int> Value);
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box(list) { Value = new List<int>() });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task SiblingArmLambdaStores_DoNotPropagateToTheOtherArm()
+    {
+        // The transferring lambda lands in use only on the arm that did NOT call it: no
+        // path stores and then invokes before the later Add.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool move)
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    if (move)
+                    {
+                        use = () => { _ = Sending.Transfer(list); };
+                    }
+                    else
+                    {
+                        use();
+                    }
+
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -2247,6 +2247,123 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task DelegateCalls_AfterTheTransfer_AreUses()
+    {
+        // The lambda body sits source-BEFORE the transfer, but invoking the delegate runs it
+        // after: the sender still touches the handed-off list.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    use();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task SiblingLocalFunctionChains_DeclaredBeforeTheTransfer_StillReport()
+    {
+        // Outer() -> Use() -> the read: both declarations sit before the handoff, but the
+        // post-transfer call still reaches the transferred value through the chain.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    void Outer()
+                    {
+                        Use();
+                    }
+                    void Use()
+                    {
+                        list.Add(1);
+                    }
+                    var sending = Sending.Transfer(list);
+                    Outer();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CallsThatOnlyRanBeforeTheTransfer_AreNotUses()
+    {
+        // Outer() ran before the handoff: nothing in its declaration executes afterwards,
+        // wherever the declaration happens to sit in source.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Outer();
+                    var sending = Sending.Transfer(list);
+                    void Outer()
+                    {
+                        Use();
+                    }
+                    void Use()
+                    {
+                        list.Add(1);
+                    }
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CollectionExpressionElements_AreTransferSources()
+    {
+        // Transfer([list]) hands off a collection carrying the same element reference,
+        // exactly like an explicit array creation.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer<List<int>[]>([list]);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -3287,6 +3287,150 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ParameterTransfers_RemapToTheCallersArgument()
+    {
+        // Move(list) hands the caller's list to the parameter the body transfers: at the
+        // call site the tracked variable is the argument, not the callee's alias.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move(List<int> x)
+                    {
+                        _ = Sending.Transfer(x);
+                    }
+                    Move(list);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DeconstructionsWritingTheValueBack_DoNotReset()
+    {
+        // The matched RHS element IS the old list: the deconstruction writes the transferred
+        // reference back, so the later Add still touches it.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    (list, _) = (list, Sending.Transfer(list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task WithExpressionInitializers_AreTransferSources()
+    {
+        // The clone the receiver owns carries the same list in its Value slot.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box
+            {
+                public List<int>? Value { get; init; }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var box = new Box();
+                    var sending = Sending.Transfer(box with { Value = list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task TransfersPropagate_ThroughDelegateCarriedFunctions()
+    {
+        // move() invokes Move through the delegate: the handoff inside it is sequenced
+        // before the caller's Add exactly like a direct call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move()
+                    {
+                        _ = Sending.Transfer(list);
+                    }
+                    Action move = Move;
+                    move();
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ExplicitThrows_KeepCatchesAlive()
+    {
+        // Rethrowing an existing exception allocates nothing, but still runs after the
+        // completed handoff and lands in the handler, which then reads the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(System.Exception ex)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        throw ex;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -5182,4 +5182,299 @@ public class UseAfterTransferAnalyzerTests
         Assert.Equal("MZR005", diagnostic.Id);
         Assert.Contains("'list'", diagnostic.GetMessage());
     }
+
+    [Fact]
+    public async Task FieldStoredDelegates_InvokedThroughTheField_AreUses()
+    {
+        // The reading lambda lives in a FIELD slot: invoking through the field after the
+        // handoff runs it exactly like a local-held delegate would.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private Action? use;
+
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    this.use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    this.use!();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task FieldStoredDelegates_OverwrittenBeforeTheInvocation_AreQuiet()
+    {
+        // The definite overwrite replaces the field's invocation list before the call:
+        // the reading lambda is no longer what `this.use!()` runs.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private Action? use;
+
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    this.use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    this.use = () => { };
+                    this.use!();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task FilteredCatchesOfUnrelatedTypes_CannotSeeAnExplicitThrow()
+    {
+        // C# tests the clause TYPE before running any filter: a filtered catch of an
+        // unrelated type can never receive the InvalidOperationException, so the handler
+        // never observes the transferred value.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sending = Sending.Transfer(list);
+                        throw new InvalidOperationException();
+                    }
+                    catch (ArgumentException) when (MayPass())
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static bool MayPass() => true;
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task FilteredCatchesOfMatchingTypes_StillSeeAnExplicitThrow()
+    {
+        // The type gate passes, so whether the handler runs is down to the filter -- which
+        // may pass: the catch stays reachable and its read reports.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sending = Sending.Transfer(list);
+                        throw new InvalidOperationException();
+                    }
+                    catch (InvalidOperationException) when (MayPass())
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static bool MayPass() => true;
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task EnclosingResetFailures_AtOrBeforeTheHandoff_DoNotOpenTheWindow()
+    {
+        // The only throw-capable operation in the reinitializing RHS is the Transfer call
+        // itself: if it throws, no wrapper escaped; if it succeeds, the local is reset
+        // before the catch could ever run. The handler never sees a transferred value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        list = (Sending.Transfer(list), (List<int>)null!).Item2;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NestedDelegateStores_ExecutedOnlyAfterTheCall_AreNotInTheInvocationList()
+    {
+        // Configure() runs only AFTER use(): the store it carries cannot be in the
+        // delegate's invocation list at the call, which still runs the no-op.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    void Touch() { list.Add(1); }
+                    void Configure() { use = Touch; }
+                    var sending = Sending.Transfer(list);
+                    use();
+                    Configure();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NestedDelegateStores_WhoseCallRanBeforeTheConsumer_StayInTheInvocationList()
+    {
+        // Configure() ran before the handoff: at use() the reading target IS the delegate's
+        // current value.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    void Touch() { list.Add(1); }
+                    void Configure() { use = Touch; }
+                    Configure();
+                    var sending = Sending.Transfer(list);
+                    use();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ConditionalDelegateReturns_AreEscapes()
+    {
+        // The stored reading delegate leaves through a conditional expression: callers can
+        // receive and invoke it after the handoff.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action? M(bool flag)
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    return flag ? use : null;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CoalesceDelegateReturns_AreEscapes()
+    {
+        // `use ?? fallback` publishes the stored reading delegate exactly like a bare
+        // return of it would.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action M(Action fallback)
+                {
+                    var list = new List<int> { 1 };
+                    Action? use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    return use ?? fallback;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LockEntries_AreThrowCapable_AndKeepTheirCatchesReachable()
+    {
+        // The hidden Monitor.Enter can throw (a null gate) after the handoff: the catch
+        // runs while the transferred list is still sender-reachable.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(object? maybeGate)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sending = Sending.Transfer(list);
+                        lock (maybeGate!) { }
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
 }

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -3576,6 +3576,126 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task UserDefinedInitializerAdds_AreNotKnownStores()
+    {
+        // Sink.Add ignores its argument: nothing moved to the receiver, so the later Add on
+        // the list is sender-local.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Sink : System.Collections.IEnumerable
+            {
+                public void Add(List<int> item)
+                {
+                }
+
+                public System.Collections.IEnumerator GetEnumerator() => throw new System.NotImplementedException();
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Sink { list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task UserDefinedIndexerInitializers_AreNotKnownStores()
+    {
+        // A custom indexer setter may drop what it was handed: only framework collections
+        // count as deterministic stores.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Sink
+            {
+                public List<int>? this[int index]
+                {
+                    get => null;
+                    set { }
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Sink { [0] = list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task LocalFunctionMethodGroups_EscapeLikeLambdas()
+    {
+        // Returning Use hands the caller a delegate over the retained alias: it can run
+        // after the method exits, exactly like the equivalent lambda.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action M()
+                {
+                    var list = new List<int> { 1 };
+                    _ = Sending.Transfer(list);
+                    return Use;
+
+                    void Use()
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task SynthesizedTransferCalls_AreNotTheirOwnUses()
+    {
+        // Move() IS the propagated handoff: with nothing after it, the sender never touches
+        // the list again.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move()
+                    {
+                        _ = Sending.Transfer(list);
+                    }
+                    Move();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1357,6 +1357,90 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task SwitchBreaks_DoNotEndTheForeachIteration()
+    {
+        // The break leaves the switch, not the foreach: the next MoveNext still reads the
+        // transferred collection.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(int n)
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list)
+                    {
+                        switch (n)
+                        {
+                            case 0:
+                                _ = Sending.Transfer(list);
+                                break;
+                        }
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LocalFunctionCalls_AfterTheTransfer_AreUses()
+    {
+        // The read inside Use sits source-BEFORE the transfer, but the CALL runs after it:
+        // the sender still touches the handed-off list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    void Use() => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    Use();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LockScopes_ExitOnTheTransferredObject()
+    {
+        // The compiler-generated Monitor.Exit touches the handed-off object at scope end:
+        // same shape as using disposal.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var gate = new List<int> { 1 };
+                    lock (gate)
+                    {
+                        return Sending.Transfer(gate);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'gate'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task UsingLocals_AreDisposedBySenderAfterTheTransfer()
     {
         // The scope's compiler-generated Dispose runs after the handoff with no source

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -574,6 +574,82 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task SwitchValueTransfers_DominateTheArms()
+    {
+        // The switch VALUE evaluates before the selected case -- and here the value IS the
+        // transfer, whose exclusive span end must still count as covering the position.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    switch (Sending.Transfer(list))
+                    {
+                        case var _:
+                            list.Add(1);
+                            break;
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CoalesceAssignmentTransfer_IsTracked()
+    {
+        // The lazy-init handoff aliases the variable to the transferred value on BOTH paths
+        // (already non-null, or just assigned): the later Add is a use-after-transfer.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    List<int>? list = null;
+                    var sending = Sending.Transfer(list ??= new List<int> { 1 });
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task EscapingExpressions_StillReadTheirLaterArguments()
+    {
+        // The return expression evaluates its remaining arguments AFTER the transfer, before
+        // the method exits: the second argument is a use on the transfer path.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public (Sending<List<int>>, List<int>) M()
+                {
+                    var list = new List<int> { 1 };
+                    return (Sending.Transfer(list), list);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task FinallyBlocks_RunAfterAReturnTransfer_AndAreStillScanned()
     {
         // `return Sending.Transfer(list)` exits the method -- but the enclosing finally runs

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -3083,6 +3083,210 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task OverwrittenDelegateTargets_CannotBeTheCallsValue()
+    {
+        // The definite overwrite kills the reading initializer before the handoff: only the
+        // no-op can run at the call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => list.Add(1);
+                    use = () => { };
+                    var sending = Sending.Transfer(list);
+                    use();
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DelegateRemovals_StoreNothing()
+    {
+        // -= removes from the invocation list; the lambda on its right side never becomes a
+        // target of the delegate.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => { };
+                    use -= () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    use();
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DelegateAliases_ResolveToTheirStoredCallables()
+    {
+        // use holds what use2 held: the reading lambda runs at the call through the alias.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use2 = () => list.Add(1);
+                    Action use = use2;
+                    var sending = Sending.Transfer(list);
+                    use();
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ThrowingConversions_KeepCatchesAlive()
+    {
+        // The user-defined conversion can throw after the completed handoff: the catch then
+        // observes the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Source
+            {
+                public static explicit operator Target(Source source) => new Target();
+            }
+
+            public class Target
+            {
+            }
+
+            public class C
+            {
+                public void M(Source source)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        _ = (Target)source;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task FieldReadsOnThis_CannotThrow_AndFreeTheCatch()
+    {
+        // Reading a field through `this` has no exception path: nothing after the completed
+        // handoff can carry the wrapper into the handler.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private int count;
+
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        _ = count;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task EnclosingDeconstructionResets_EndTracking()
+    {
+        // The deconstruction assigns the fresh list right after its RHS evaluated: by the
+        // Add the transferred value is gone from the variable.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    (list, _) = (new List<int>(), Sending.Transfer(list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task TransfersInsideCalledFunctions_ReachTheCallersContinuation()
+    {
+        // Move() performs the handoff before returning: the caller's Add is sequenced after
+        // it exactly like an inline transfer.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move()
+                    {
+                        _ = Sending.Transfer(list);
+                    }
+                    Move();
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -91,6 +91,32 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task NullForgivingTransfer_IsStillATransfer()
+    {
+        // `Sending.Transfer(list!)` hands off the same variable; the null-forgiving operator
+        // must not hide the transfer from the rule.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    List<int>? list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list!);
+                    list.Add(2);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task ReassignmentInACatchHandler_DoesNotSilenceTheLaterUse()
     {
         // The try spans the transfer, but the catch is a SIBLING ARM of it: on the

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1818,6 +1818,170 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ResettingLocalFunctionCalls_AreReinitializers()
+    {
+        // Reset() rewrites the variable on every path through it: after the call the later
+        // Add only ever touches the fresh value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Reset()
+                    {
+                        list = new List<int>();
+                    }
+                    Reset();
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ConditionallyCalledResets_DoNotSilenceTheLaterUse()
+    {
+        // The resetting call may be skipped: the path around it still reads the transferred
+        // value at the Add.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M(bool keep)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Reset()
+                    {
+                        list = new List<int>();
+                    }
+                    if (!keep) Reset();
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task HandlerResets_BeforeAnyRead_KeepTheCatchClean()
+    {
+        // The recovery path overwrites the variable before touching it: the catch never
+        // reads the transferred object, however the reinitializing RHS throws.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        list = MayThrow();
+                    }
+                    catch
+                    {
+                        list = new List<int>();
+                        list.Add(1);
+                    }
+                }
+
+                private static List<int> MayThrow() => new();
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task HandlerRhsReads_AreStillWindowUses()
+    {
+        // The handler's replacement is BUILT FROM the transferred value: that read runs
+        // exactly in the window where the receiver may already own it.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        list = MayThrow();
+                    }
+                    catch
+                    {
+                        list = new List<int>(list);
+                    }
+                }
+
+                private static List<int> MayThrow() => new();
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LocalFunctionResets_InsideATry_KeepTheCatchWindowVisible()
+    {
+        // The body's reset can throw before storing: its catch reads the transferred value,
+        // so calling the function is a use -- the try-nested reset is CONDITIONAL, not a
+        // definite rewrite.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Call()
+                    {
+                        try
+                        {
+                            list = MayThrow();
+                        }
+                        catch
+                        {
+                            list.Add(1);
+                        }
+                    }
+                    Call();
+                    return sending;
+                }
+
+                private static List<int> MayThrow() => new();
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -650,6 +650,72 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task BreaksBetweenTransferAndReassignment_KeepTracking()
+    {
+        // The break exits the loop past the reassignment: on the skip path the code after the
+        // loop still holds the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool cond, bool skip)
+                {
+                    var list = new List<int> { 1 };
+                    while (cond)
+                    {
+                        _ = Sending.Transfer(list);
+                        if (skip)
+                        {
+                            break;
+                        }
+
+                        list = new List<int>();
+                    }
+
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task BreaksThatExitBeforeTheReassignment_SkipNothing()
+    {
+        // The switch closes before the reassignment: its break cannot jump past it, so the
+        // reassignment stays definite and the later use is clean.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(int n)
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    switch (n)
+                    {
+                        case 1:
+                            n++;
+                            break;
+                    }
+
+                    list = new List<int>();
+                    list.Add(1);
+                    _ = sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task CatchHandlers_ObserveAThrownTransfer()
     {
         // A thrown transfer lands in the try's handlers: the catch runs after the throw

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -5448,6 +5448,57 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ImmutableCollectionFactories_AreTransferSources()
+    {
+        // ImmutableArray.Create(list) stores its ARGUMENTS as elements: the receiver owns
+        // an immutable container that still holds the same mutable list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using System.Collections.Immutable;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(ImmutableArray.Create(list));
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CopyingCollectionConversions_StayLeaves()
+    {
+        // list.ToImmutableArray() copies the elements OUT of the source: the source
+        // collection itself is not retained, so later sender-side mutation of it does not
+        // reach the receiver's container.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using System.Collections.Immutable;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list.ToImmutableArray());
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task LockEntries_AreThrowCapable_AndKeepTheirCatchesReachable()
     {
         // The hidden Monitor.Enter can throw (a null gate) after the handoff: the catch

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.CodeAnalysis;
+
+namespace MemoizR.Analyzers.Tests;
+
+// Contracts of MZR005: after a local/parameter is wrapped in Sending<T> (constructor or
+// Sending.Transfer), later uses of that variable in the same method are flagged in source
+// order, stopping at a reassignment. Best-effort by design -- the runtime single-consumption
+// check in Sending<T>.Receive is the receiver-side backstop.
+public class UseAfterTransferAnalyzerTests
+{
+    private static Task<System.Collections.Immutable.ImmutableArray<Diagnostic>> AnalyzeAsync(string source)
+        => AnalyzerTestHarness.AnalyzeAsync(source, new UseAfterTransferAnalyzer());
+
+    [Fact]
+    public async Task UseAfterTransfer_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks);
+                    var list = new List<int> { 1 };
+                    var signal = f.CreateSignal(Sending.Transfer(list));
+                    list.Add(2); // the receiver may already own it on another flow
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task UsesBeforeTransfer_AndReassignedVariables_AreNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    list.Add(2); // before the transfer: fine
+                    var sending = new Sending<List<int>>(list);
+                    list = new List<int>(); // fresh value: the transferred one is gone
+                    list.Add(3);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+}

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -544,6 +544,37 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task FinallyBlocks_RunAfterAReturnTransfer_AndAreStillScanned()
+    {
+        // `return Sending.Transfer(list)` exits the method -- but the enclosing finally runs
+        // AFTER the return expression evaluated, so its Add touches the transferred value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        return Sending.Transfer(list);
+                    }
+                    finally
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task InlineAssignmentTransfer_IsTracked()
     {
         // Transfer(list = new(...)): after the statement the variable aliases the transferred

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -1704,6 +1704,145 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ConditionalReinitializersInLocalFunctions_DoNotEndTracking()
+    {
+        // Use(false) skips the reset and reads the transferred list: only a reassignment
+        // that DEFINITELY runs before any read makes the call safe.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Use(bool reset)
+                    {
+                        if (reset) list = new List<int>();
+                        list.Add(1);
+                    }
+                    Use(false);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ReadsDominatedByALocalFunctionsConditionalReset_AreFresh()
+    {
+        // Every path through the call either resets before the read or skips both: the
+        // transferred value is never touched.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>> M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(list);
+                    void Use(bool reset)
+                    {
+                        if (reset)
+                        {
+                            list = new List<int>();
+                            list.Add(1);
+                        }
+                    }
+                    Use(false);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task YieldReturnTransfers_KeepTheSenderScanAlive()
+    {
+        // yield return hands the wrapper to the caller and RESUMES the same body on the next
+        // MoveNext: the later Add is ordinary sender-side use, not code past a method exit.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public IEnumerable<Sending<List<int>>> M()
+                {
+                    var list = new List<int> { 1 };
+                    yield return Sending.Transfer(list);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task YieldReturns_DoNotEndTheForeachIteration()
+    {
+        // The iterator resumes INSIDE the loop on the next MoveNext: the foreach still reads
+        // the transferred collection.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public IEnumerable<int> M()
+                {
+                    var list = new List<int> { 1 };
+                    foreach (var item in list)
+                    {
+                        _ = Sending.Transfer(list);
+                        yield return item;
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task AnonymousObjectInitializers_AreTransferSources()
+    {
+        // Transfer(new { Value = list }) hands off an object graph containing the same list:
+        // anonymous members deterministically store what they were built from.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new { Value = list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task ArrayInitializerElements_AreTransferSources()
     {
         // Transfer(new[] { list }) hands off the array WITH its element: the array carries

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -91,6 +91,75 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task ReassignmentInACatchHandler_DoesNotSilenceTheLaterUse()
+    {
+        // The try spans the transfer, but the catch is a SIBLING ARM of it: on the
+        // no-exception path the reassignment never ran and the later Add still touches the
+        // transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>>? M()
+                {
+                    var list = new List<int> { 1 };
+                    Sending<List<int>>? sending = null;
+                    try
+                    {
+                        sending = Sending.Transfer(list);
+                    }
+                    catch
+                    {
+                        list = new List<int>();
+                    }
+
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ReassignmentInAFinally_IsDefinite_AndEndsTracking()
+    {
+        // A finally arm ALWAYS executes: unlike a catch, its reassignment is as definite as
+        // straight-line code, so the later use touches the fresh value.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>>? M()
+                {
+                    var list = new List<int> { 1 };
+                    Sending<List<int>>? sending = null;
+                    try
+                    {
+                        sending = Sending.Transfer(list);
+                    }
+                    finally
+                    {
+                        list = new List<int>();
+                    }
+
+                    list.Add(1);
+                    return sending;
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task UsesBeforeTransfer_AndReassignedVariables_AreNotFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -2813,6 +2813,134 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task FieldReads_AreThrowCapable_AndKeepCatchesAlive()
+    {
+        // Reading an instance field off a possibly-null receiver throws after the completed
+        // handoff: the catch observes the transferred list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Holder
+            {
+                public int Count;
+            }
+
+            public class C
+            {
+                public void M(Holder holder)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        var sent = Sending.Transfer(list);
+                        _ = holder.Count;
+                    }
+                    catch
+                    {
+                        list.Add(1);
+                    }
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CollectionInitializerElements_AreTransferSources()
+    {
+        // new List<List<int>> { list } stores the element exactly like a collection
+        // expression: the receiver owns a collection containing the same reference.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new List<List<int>> { list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+        Assert.Contains("'list'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CaughtReturnExpressionFailures_KeepTheSenderScanAlive()
+    {
+        // MayThrow can fail AFTER the wrapper exists, landing in the catch-all: control then
+        // resumes after the try and the sender still touches the handed-off list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Sending<List<int>>? M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        return MayThrow(Sending.Transfer(list));
+                    }
+                    catch
+                    {
+                    }
+
+                    list.Add(1);
+                    return null;
+                }
+
+                private static Sending<List<int>> MayThrow(Sending<List<int>> sending) => sending;
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task CaughtThrowsBeforeResets_KeepThePathOpen()
+    {
+        // On the throwing path the reset never runs, the catch-all resumes, and the final
+        // Add still touches the transferred list: the reset is not definite.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool fail)
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        if (fail) throw new System.Exception();
+                        list = new List<int>();
+                    }
+                    catch
+                    {
+                    }
+
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/UseAfterTransferAnalyzerTests.cs
@@ -3894,6 +3894,210 @@ public class UseAfterTransferAnalyzerTests
     }
 
     [Fact]
+    public async Task WithExpressionOperands_CarryTheirInlineContents()
+    {
+        // The clone copies Value from the inline operand before the initializer applies:
+        // the receiver's Box carries the same list.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public record Box(List<int> Value)
+            {
+                public int Other { get; init; }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box(list) with { Other = 1 });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task TransfersInsideInvokedLambdas_ReachTheCallersContinuation()
+    {
+        // move() runs the lambda that performs the handoff: the caller's Add is sequenced
+        // after it exactly like a local-function call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    Func<Sending<List<int>>> move = () => Sending.Transfer(list);
+                    var sent = move();
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task NestedInitializers_OnComputedMembers_AreNotRetained()
+    {
+        // Child hands out a fresh temporary: the write lands in an object the transferred
+        // Box never retains.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Inner
+            {
+                public List<int>? Value { get; set; }
+            }
+
+            public class Box
+            {
+                public Inner Child => new Inner();
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new Box { Child = { Value = list } });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task AliasPreservingParameterAssignments_KeepThePropagation()
+    {
+        // x = x rewrites nothing: the parameter still aliases the caller's list when the
+        // body transfers it.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    void Move(List<int> x)
+                    {
+                        x = x;
+                        _ = Sending.Transfer(x);
+                    }
+                    Move(list);
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task StoredDelegateEscapes_AfterTheTransfer_AreUses()
+    {
+        // The returned delegate captures the transferred list: the caller can run it
+        // against the receiver-owned object at any time.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public Action M()
+                {
+                    var list = new List<int> { 1 };
+                    Action use = () => list.Add(1);
+                    var sending = Sending.Transfer(list);
+                    return use;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task FrameworkCollectionsOutsideCorelib_StillStore()
+    {
+        // BlockingCollection lives in System.Collections.Concurrent, not the core library:
+        // its Add still deterministically stores the element.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Concurrent;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    var sending = Sending.Transfer(new BlockingCollection<List<int>> { list });
+                    list.Add(1);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task FinallyBlocks_RunBeforeAFailedReset_AndSeeTheTransferredValue()
+    {
+        // A failing MayThrow() runs the finally while the variable still holds the
+        // transferred object.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var list = new List<int> { 1 };
+                    try
+                    {
+                        _ = Sending.Transfer(list);
+                        MayThrow();
+                        list = new List<int>();
+                    }
+                    finally
+                    {
+                        list.Add(1);
+                    }
+                }
+
+                private static void MayThrow()
+                {
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR005", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task AnonymousObjectInitializers_AreTransferSources()
     {
         // Transfer(new { Value = list }) hands off an object graph containing the same list:

--- a/MemoizR.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/MemoizR.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,9 +5,9 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-MZR001  | Concurrency | Warning | Value type shared by the reactive graph is not Sendable
-MZR002  | Concurrency | Warning | Reactive computation mutates state shared with code outside it
-MZR003  | Concurrency | Warning | Signal.Set inside a reactive computation throws at runtime
+MZR001  | Concurrency | Error | Value type shared by the reactive graph is not Sendable
+MZR002  | Concurrency | Error | Reactive computation mutates state shared with code outside it
+MZR003  | Concurrency | Error | Signal.Set inside a reactive computation throws at runtime
 MZR004  | Concurrency | Warning | Static state shared with the reactive graph is not data-race safe
 MZR005  | Concurrency | Warning | Value used after being transferred
 MZR006  | Concurrency | Info | Non-sealed class shared by the reactive graph can smuggle mutable subclass state

--- a/MemoizR.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/MemoizR.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,6 @@ Rule ID | Category | Severity | Notes
 MZR001  | Concurrency | Warning | Value type shared by the reactive graph is not Sendable
 MZR002  | Concurrency | Warning | Reactive computation mutates state shared with code outside it
 MZR003  | Concurrency | Warning | Signal.Set inside a reactive computation throws at runtime
+MZR004  | Concurrency | Warning | Static state shared with the reactive graph is not data-race safe
+MZR005  | Concurrency | Warning | Value used after being transferred
+MZR006  | Concurrency | Info | Non-sealed class shared by the reactive graph can smuggle mutable subclass state

--- a/MemoizR.Analyzers/DiagnosticDescriptors.cs
+++ b/MemoizR.Analyzers/DiagnosticDescriptors.cs
@@ -22,7 +22,9 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "MemoizR publishes a node's value reference tear-free across concurrent flows, but only " +
                      "an immutable or internally synchronized type makes the object behind the reference safe " +
-                     "to share. This is the build-time mirror of MemoFactoryOptions.StrictSendableChecks.",
+                     "to share. This is the build-time mirror of the default-on runtime Sendable checks; " +
+                     "creations on a factory that visibly opts out via MemoFactoryOptions.DisableSendableChecks " +
+                     "are exempt, mirroring the runtime escape hatch.",
         helpLinkUri: HelpUri);
 
     public static readonly DiagnosticDescriptor CapturedMutation = new(

--- a/MemoizR.Analyzers/DiagnosticDescriptors.cs
+++ b/MemoizR.Analyzers/DiagnosticDescriptors.cs
@@ -18,7 +18,7 @@ internal static class DiagnosticDescriptors
         messageFormat: "'{0}' is not Sendable ({1}) — values of this type are shared across concurrently " +
                        "running flows; use an immutable type, or mark it [Sendable] to assert thread safety",
         category: Category,
-        defaultSeverity: DiagnosticSeverity.Warning,
+        defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "MemoizR publishes a node's value reference tear-free across concurrent flows, but only " +
                      "an immutable or internally synchronized type makes the object behind the reference safe " +
@@ -32,7 +32,7 @@ internal static class DiagnosticDescriptors
                        "computations run concurrently on other flows, so this is a data race — lift the state " +
                        "into a Signal or EagerRelativeSignal instead",
         category: Category,
-        defaultSeverity: DiagnosticSeverity.Warning,
+        defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "A memo/reaction/concurrent computation executes on arbitrary flows, concurrently with " +
                      "the code that created it and with other computations. Writing a captured local, a field " +
@@ -94,7 +94,7 @@ internal static class DiagnosticDescriptors
                        "InvalidOperationException at runtime — return the value instead, or schedule the write " +
                        "outside the evaluation",
         category: Category,
-        defaultSeverity: DiagnosticSeverity.Warning,
+        defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "The evaluation lock deliberately converts this impossible same-flow wait into an " +
                      "exception (a write inside a read of the same graph is a feedback loop). This rule turns " +

--- a/MemoizR.Analyzers/DiagnosticDescriptors.cs
+++ b/MemoizR.Analyzers/DiagnosticDescriptors.cs
@@ -40,6 +40,52 @@ internal static class DiagnosticDescriptors
                      "mutation — the very thing the reactive graph exists to replace (the SE-0412 analog).",
         helpLinkUri: HelpUri);
 
+    public static readonly DiagnosticDescriptor MutableStaticState = new(
+        id: "MZR004",
+        title: "Static state shared with the reactive graph is not data-race safe",
+        messageFormat: "Static {0} '{1}' is {2} — statics are reachable from every concurrently running " +
+                       "flow (the SE-0412 analog); make it readonly with a Sendable type, lift it into a " +
+                       "Signal/EagerRelativeSignal (nodes are safe to hold in statics), or mark the type [Sendable]",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Swift 6 rejects every non-isolated mutable global (SE-0412) because globals are " +
+                     "reachable from every isolation domain. The analog here: a mutable static slot, or a " +
+                     "readonly static whose TYPE is mutable, is unsynchronized shared state next to a graph " +
+                     "whose computations run concurrently. Scoped to files that use MemoizR (a using " +
+                     "directive for the MemoizR namespaces).",
+        helpLinkUri: HelpUri);
+
+    public static readonly DiagnosticDescriptor UseAfterTransfer = new(
+        id: "MZR005",
+        title: "Value used after being transferred",
+        messageFormat: "'{0}' is used after being wrapped in Sending<T> — the receiver may already own " +
+                       "and mutate it on another flow; stop using a transferred value (or reassign it first)",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Sending<T> hands a non-Sendable value across flows by TRANSFER (the SE-0430 analog): " +
+                     "the sender promises to stop touching it. This rule flags method-local uses of the " +
+                     "transferred variable after the transfer, in source order, stopping at a reassignment. " +
+                     "It is a best-effort heuristic, not a proof: aliases and loop back-edges can evade it.",
+        helpLinkUri: HelpUri);
+
+    public static readonly DiagnosticDescriptor NonSealedValueType = new(
+        id: "MZR006",
+        title: "Non-sealed class shared by the reactive graph can smuggle mutable subclass state",
+        messageFormat: "'{0}' is not sealed — a mutable subclass behind an upcast passes the creation-time " +
+                       "Sendable checks (Swift requires Sendable classes to be final); consider sealing it, " +
+                       "or enable MemoFactoryOptions.ValidateWrittenValues to check written instances at runtime",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Sendable verdicts are computed from the DECLARED type's structure, so a mutable " +
+                     "subclass smuggled in through an upcast is not caught at creation time (ADR 0003's " +
+                     "documented limitation). Swift closes this by requiring Sendable classes to be final. " +
+                     "Info severity: non-sealed records are idiomatic and the hole needs an actual mutable " +
+                     "subclass to bite.",
+        helpLinkUri: HelpUri);
+
     public static readonly DiagnosticDescriptor SetInsideComputation = new(
         id: "MZR003",
         title: "A graph write inside a reactive computation throws at runtime",

--- a/MemoizR.Analyzers/DiagnosticDescriptors.cs
+++ b/MemoizR.Analyzers/DiagnosticDescriptors.cs
@@ -74,8 +74,7 @@ internal static class DiagnosticDescriptors
         id: "MZR006",
         title: "Non-sealed class shared by the reactive graph can smuggle mutable subclass state",
         messageFormat: "'{0}' is not sealed — a mutable subclass behind an upcast passes the creation-time " +
-                       "Sendable checks (Swift requires Sendable classes to be final); consider sealing it, " +
-                       "or enable MemoFactoryOptions.ValidateWrittenValues to check written instances at runtime",
+                       "Sendable checks (Swift requires Sendable classes to be final); consider sealing it{1}",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true,

--- a/MemoizR.Analyzers/FactoryMethods.cs
+++ b/MemoizR.Analyzers/FactoryMethods.cs
@@ -108,9 +108,10 @@ internal static class FactoryMethods
     // the referenced one) must not be classified as the reactive factory: its APIs publish
     // nothing into a MemoizR graph, so firing MZR001-003 on them would be pure false positives
     // (a build break under warnings-as-errors). Kept in lockstep with the identity checks on
-    // the SendableAttribute and the green-lists in SendableSymbolClassifier. MemoizR.Wpf is in
-    // the set for the fluent opt-out follow (WpfMemoFactory.AddWpfDispatcher); no factory-
-    // method names live there, so it draws no creation/computation classifications.
+    // the SendableAttribute and the green-lists in SendableSymbolClassifier. MemoizR.Wpf and
+    // MemoizR.Blazor are in the set for the fluent opt-out follows (AddWpfDispatcher /
+    // AddBlazorDispatcher); no factory-method names live there, so they draw no
+    // creation/computation classifications.
     internal static bool IsLibraryType(INamedTypeSymbol type)
     {
         if (type.Locations.Any(location => location.IsInSource))
@@ -119,6 +120,6 @@ internal static class FactoryMethods
         }
 
         return type.ContainingAssembly?.Identity.Name is
-            "MemoizR" or "MemoizR.Reactive" or "MemoizR.StructuredConcurrency" or "MemoizR.Wpf";
+            "MemoizR" or "MemoizR.Reactive" or "MemoizR.StructuredConcurrency" or "MemoizR.Wpf" or "MemoizR.Blazor";
     }
 }

--- a/MemoizR.Analyzers/FactoryMethods.cs
+++ b/MemoizR.Analyzers/FactoryMethods.cs
@@ -108,7 +108,9 @@ internal static class FactoryMethods
     // the referenced one) must not be classified as the reactive factory: its APIs publish
     // nothing into a MemoizR graph, so firing MZR001-003 on them would be pure false positives
     // (a build break under warnings-as-errors). Kept in lockstep with the identity checks on
-    // the SendableAttribute and the green-lists in SendableSymbolClassifier.
+    // the SendableAttribute and the green-lists in SendableSymbolClassifier. MemoizR.Wpf is in
+    // the set for the fluent opt-out follow (WpfMemoFactory.AddWpfDispatcher); no factory-
+    // method names live there, so it draws no creation/computation classifications.
     internal static bool IsLibraryType(INamedTypeSymbol type)
     {
         if (type.Locations.Any(location => location.IsInSource))
@@ -117,6 +119,6 @@ internal static class FactoryMethods
         }
 
         return type.ContainingAssembly?.Identity.Name is
-            "MemoizR" or "MemoizR.Reactive" or "MemoizR.StructuredConcurrency";
+            "MemoizR" or "MemoizR.Reactive" or "MemoizR.StructuredConcurrency" or "MemoizR.Wpf";
     }
 }

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -28,8 +29,8 @@ internal static class FactoryOptOut
 
         // Fluent configuration (AddExecutor/AddTimeProvider/...) mutates and returns the SAME
         // factory, so the opt-out evidence sits one hop (or several) up the chain: follow
-        // library-declared MemoFactory-returning calls to their own receiver.
-        while (receiver is IInvocationOperation chained && ReturnsTheLibraryFactory(chained.TargetMethod))
+        // library-declared fluent calls to their own receiver.
+        while (receiver is IInvocationOperation chained && ReturnsItsOwnFluentReceiver(chained.TargetMethod))
         {
             receiver = Unwrap(ReceiverOf(chained));
         }
@@ -57,12 +58,16 @@ internal static class FactoryOptOut
                 : null);
     }
 
-    // A LIBRARY method that returns MemoFactory is the fluent-configuration contract (it
-    // mutates and returns its receiver); a source-declared lookalike could return any factory
-    // it likes and is not followed.
-    private static bool ReturnsTheLibraryFactory(IMethodSymbol method)
+    // The fluent-configuration contract is a NAMED whitelist: these methods mutate and return
+    // their receiver. Return-type matching alone would also follow generic passthroughs --
+    // Untrack<T> returns its DELEGATE's result, which with T = MemoFactory can be any factory
+    // -- so the name set is the authority and the shape checks (non-generic, library-declared,
+    // MemoFactory-returning) are the belt; a source-declared lookalike is not followed either.
+    private static bool ReturnsItsOwnFluentReceiver(IMethodSymbol method)
     {
-        return method.ReturnType is INamedTypeSymbol { Name: "MemoFactory" } factoryType
+        return method.Name is "AddExecutor" or "AddSynchronizationContext" or "AddTimeProvider"
+            && method.Arity == 0
+            && method.ReturnType is INamedTypeSymbol { Name: "MemoFactory" } factoryType
             && factoryType.ContainingNamespace?.ToDisplayString() == "MemoizR"
             && FactoryMethods.IsLibraryType(factoryType)
             && method.ContainingType is { } containingType
@@ -163,7 +168,8 @@ internal static class FactoryOptOut
         return current.Parent switch
         {
             AssignmentExpressionSyntax assignment => ReferenceEquals(assignment.Left, current),
-            ArgumentSyntax argument => argument.RefOrOutKeyword.RawKind != 0,
+            // `in` stays a read: the callee cannot repoint the symbol through a read-only pass.
+            ArgumentSyntax argument => argument.RefOrOutKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword,
             RefExpressionSyntax => true,
             _ => false,
         };

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -25,17 +25,7 @@ internal static class FactoryOptOut
 {
     public static bool DisablesSendableChecks(IInvocationOperation invocation)
     {
-        var receiver = Unwrap(ReceiverOf(invocation));
-
-        // Fluent configuration (AddExecutor/AddTimeProvider/...) mutates and returns the SAME
-        // factory, so the opt-out evidence sits one hop (or several) up the chain: follow
-        // library-declared fluent calls to their own receiver.
-        while (receiver is IInvocationOperation chained && ReturnsItsOwnFluentReceiver(chained.TargetMethod))
-        {
-            receiver = Unwrap(ReceiverOf(chained));
-        }
-
-        return receiver switch
+        return PeelFluentCalls(ReceiverOf(invocation)) switch
         {
             IObjectCreationOperation creation => OptsOut(creation),
             ILocalReferenceOperation local => SymbolOptsOut(local.Local, invocation),
@@ -45,6 +35,22 @@ internal static class FactoryOptOut
                 => ContainingTypeFullyInSight(property.Property, invocation) && SymbolOptsOut(property.Property, invocation),
             _ => false,
         };
+    }
+
+    // Fluent configuration (AddExecutor/AddTimeProvider/...) mutates and returns the SAME
+    // factory, so the opt-out evidence sits one hop (or several) up the chain: follow
+    // library-declared fluent calls to their own receiver. Applied to direct receivers AND to
+    // initializer values (`var lax = new MemoFactory(…).AddExecutor(…);` stores the fluent
+    // call's result, which IS the factory the initializer created).
+    private static IOperation? PeelFluentCalls(IOperation? operation)
+    {
+        var current = Unwrap(operation);
+        while (current is IInvocationOperation chained && ReturnsItsOwnFluentReceiver(chained.TargetMethod))
+        {
+            current = Unwrap(ReceiverOf(chained));
+        }
+
+        return current;
     }
 
     // Instance creations carry the factory in Instance; the structured-concurrency creations
@@ -65,7 +71,7 @@ internal static class FactoryOptOut
     // MemoFactory-returning) are the belt; a source-declared lookalike is not followed either.
     private static bool ReturnsItsOwnFluentReceiver(IMethodSymbol method)
     {
-        return method.Name is "AddExecutor" or "AddSynchronizationContext" or "AddTimeProvider"
+        return method.Name is "AddExecutor" or "AddSynchronizationContext" or "AddTimeProvider" or "AddWpfDispatcher"
             && method.Arity == 0
             && method.ReturnType is INamedTypeSymbol { Name: "MemoFactory" } factoryType
             && factoryType.ContainingNamespace?.ToDisplayString() == "MemoizR"
@@ -114,7 +120,7 @@ internal static class FactoryOptOut
                 _ => null,
             };
 
-            if (initializer is not null && Unwrap(model.GetOperation(initializer)) is IObjectCreationOperation creation)
+            if (initializer is not null && PeelFluentCalls(model.GetOperation(initializer)) is IObjectCreationOperation creation)
             {
                 return creation;
             }

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -74,7 +74,7 @@ internal static class FactoryOptOut
     // MemoFactory-returning) are the belt; a source-declared lookalike is not followed either.
     private static bool ReturnsItsOwnFluentReceiver(IMethodSymbol method)
     {
-        return method.Name is "AddExecutor" or "AddSynchronizationContext" or "AddTimeProvider" or "AddWpfDispatcher"
+        return method.Name is "AddExecutor" or "AddSynchronizationContext" or "AddTimeProvider" or "AddWpfDispatcher" or "AddBlazorDispatcher"
             && method.Arity == 0
             && method.ReturnType is INamedTypeSymbol { Name: "MemoFactory" } factoryType
             && factoryType.ContainingNamespace?.ToDisplayString() == "MemoizR"

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -8,12 +8,18 @@ namespace MemoizR.Analyzers;
 // The build-time side of MemoFactoryOptions.DisableSendableChecks (A4's migration escape
 // hatch): a creation on a factory that VISIBLY opts out must not fail the very checks its
 // runtime disabled, or the documented per-factory opt-out would be unusable under the Error
-// default without a project-wide suppression. Resolution is best-effort and conservative in
-// the safe direction -- the factory's construction must be in sight (an inline receiver, or a
-// local/field/property initializer in the same file; Compilation.GetSemanticModel is banned in
-// analyzers, so cross-file initializers stay out of reach). Anything unresolvable (factory
-// parameter, reassigned local, options computed elsewhere) keeps the checks ON: a missed
-// opt-out costs one suppression, a wrong opt-out would silently drop the rule.
+// default without a project-wide suppression. The exemption needs POSITIVE, DEFINITE evidence,
+// because a wrong opt-out silently drops the rule while a missed one only costs a suppression:
+//
+//  - the factory's construction in sight: an inline receiver, or the initializer of a local,
+//    readonly field, or get-only property in the same file (Compilation.GetSemanticModel is
+//    banned in analyzers, so cross-file initializers are out of reach; settable slots could
+//    be repointed from anywhere),
+//  - an options argument that FOLDS TO A CONSTANT carrying the flag -- a conditional or
+//    computed expression that merely mentions DisableSendableChecks might still evaluate
+//    strict at runtime,
+//  - and no reassignment of the receiver symbol anywhere in the file, so the initializer is
+//    actually the value the creation runs on.
 internal static class FactoryOptOut
 {
     public static bool DisablesSendableChecks(IInvocationOperation invocation)
@@ -25,32 +31,30 @@ internal static class FactoryOptOut
                 ? invocation.Arguments.FirstOrDefault(argument => argument.Parameter?.Ordinal == 0)?.Value
                 : null);
 
-        return FactoryCreationBehind(Unwrap(receiver), invocation) is { } creation && OptsOut(creation);
+        return Unwrap(receiver) switch
+        {
+            IObjectCreationOperation creation => OptsOut(creation),
+            ILocalReferenceOperation local => SymbolOptsOut(local.Local, invocation),
+            IFieldReferenceOperation { Field.IsReadOnly: true } field => SymbolOptsOut(field.Field, invocation),
+            IPropertyReferenceOperation { Property.SetMethod: null } property => SymbolOptsOut(property.Property, invocation),
+            _ => false,
+        };
     }
 
-    private static IObjectCreationOperation? FactoryCreationBehind(IOperation? receiver, IInvocationOperation invocation)
+    private static bool SymbolOptsOut(ISymbol symbol, IInvocationOperation invocation)
     {
-        return receiver switch
-        {
-            IObjectCreationOperation creation => creation,
-            ILocalReferenceOperation local => InitializerCreation(local.Local, invocation),
-            IFieldReferenceOperation field => InitializerCreation(field.Field, invocation),
-            IPropertyReferenceOperation property => InitializerCreation(property.Property, invocation),
-            _ => null,
-        };
+        var model = invocation.SemanticModel;
+        return model is not null
+            && InitializerCreation(symbol, model) is { } creation
+            && OptsOut(creation)
+            && !IsReassigned(symbol, model);
     }
 
     // The declaration initializer, resolvable only in the invocation's own tree: that tree's
     // semantic model is already in hand, and locals are same-tree by construction -- only a
     // factory field/property declared in ANOTHER file stays unresolved (and therefore checked).
-    private static IObjectCreationOperation? InitializerCreation(ISymbol symbol, IInvocationOperation invocation)
+    private static IObjectCreationOperation? InitializerCreation(ISymbol symbol, SemanticModel model)
     {
-        var model = invocation.SemanticModel;
-        if (model is null)
-        {
-            return null;
-        }
-
         foreach (var reference in symbol.DeclaringSyntaxReferences)
         {
             if (reference.SyntaxTree != model.SyntaxTree)
@@ -74,6 +78,53 @@ internal static class FactoryOptOut
         return null;
     }
 
+    // Any write to the symbol after its declaration revokes the initializer's authority: the
+    // local may have been repointed at a strict factory before the creation (and a readonly
+    // field's static constructor can overwrite its initializer). The scan is file-wide and
+    // position-blind -- a loop's back-edge makes a source-later write execute before a
+    // source-earlier creation, so ordering by position would trust too much. Runs only for
+    // receivers whose initializer already proved an opt-out, so the binds stay rare.
+    private static bool IsReassigned(ISymbol symbol, SemanticModel model)
+    {
+        foreach (var identifier in model.SyntaxTree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText != symbol.Name || !IsWriteContext(identifier))
+            {
+                continue;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(model.GetSymbolInfo(identifier).Symbol, symbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Whether the identifier is the target of any assignment kind (simple/compound/coalesce,
+    // including through a member access or a deconstruction tuple) or escapes by ref/out.
+    private static bool IsWriteContext(IdentifierNameSyntax identifier)
+    {
+        SyntaxNode current = identifier;
+        if (current.Parent is MemberAccessExpressionSyntax member && ReferenceEquals(member.Name, identifier))
+        {
+            current = member;
+        }
+
+        while (current.Parent is ArgumentSyntax { Parent: TupleExpressionSyntax tuple })
+        {
+            current = tuple;
+        }
+
+        return current.Parent switch
+        {
+            AssignmentExpressionSyntax assignment => ReferenceEquals(assignment.Left, current),
+            ArgumentSyntax argument => argument.RefOrOutKeyword.RawKind != 0,
+            _ => false,
+        };
+    }
+
     private static bool OptsOut(IObjectCreationOperation factoryCreation)
     {
         if (factoryCreation.Type is not INamedTypeSymbol { Name: "MemoFactory" } factoryType
@@ -93,17 +144,12 @@ internal static class FactoryOptOut
 
             // Flag combinations of the enum's members fold to a compile-time constant (an
             // omitted optional argument folds to None); test the bit against the member's own
-            // declared value rather than hardcoding it.
-            if (argument.Value.ConstantValue is { HasValue: true, Value: int flags })
-            {
-                return DisableFlag(optionsType) is { } bit && (flags & bit) != 0;
-            }
-
-            // Non-constant composition (a flags local OR-ed together): a reference to the
-            // member anywhere inside the argument is still positive evidence of the opt-out.
-            return argument.Value.DescendantsAndSelf().Any(operation =>
-                operation is IFieldReferenceOperation { Field.Name: "DisableSendableChecks" } member
-                && SymbolEqualityComparer.Default.Equals(member.Field.ContainingType, optionsType));
+            // declared value rather than hardcoding it. A NON-constant expression is never a
+            // definite opt-out, however prominently it mentions the flag: a conditional like
+            // `useLax ? DisableSendableChecks : None` still runs strict on one path.
+            return argument.Value.ConstantValue is { HasValue: true, Value: int flags }
+                && DisableFlag(optionsType) is { } bit
+                && (flags & bit) != 0;
         }
 
         return false;

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -103,7 +103,10 @@ internal static class FactoryOptOut
     }
 
     // Whether the identifier is the target of any assignment kind (simple/compound/coalesce,
-    // including through a member access or a deconstruction tuple) or escapes by ref/out.
+    // including through a member access or a deconstruction tuple) or escapes by reference --
+    // a ref/out argument, or `ref x` in a ref-local declaration / ref reassignment / ref
+    // return (RefExpressionSyntax), through which any later write repoints the symbol without
+    // naming it.
     private static bool IsWriteContext(IdentifierNameSyntax identifier)
     {
         SyntaxNode current = identifier;
@@ -121,6 +124,7 @@ internal static class FactoryOptOut
         {
             AssignmentExpressionSyntax assignment => ReferenceEquals(assignment.Left, current),
             ArgumentSyntax argument => argument.RefOrOutKeyword.RawKind != 0,
+            RefExpressionSyntax => true,
             _ => false,
         };
     }

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -24,21 +24,61 @@ internal static class FactoryOptOut
 {
     public static bool DisablesSendableChecks(IInvocationOperation invocation)
     {
-        // Instance creations carry the factory in Instance; the structured-concurrency
-        // creations are extension methods, whose receiver arrives as the first argument.
-        var receiver = invocation.Instance
-            ?? (invocation.TargetMethod.IsExtensionMethod
-                ? invocation.Arguments.FirstOrDefault(argument => argument.Parameter?.Ordinal == 0)?.Value
-                : null);
+        var receiver = Unwrap(ReceiverOf(invocation));
 
-        return Unwrap(receiver) switch
+        // Fluent configuration (AddExecutor/AddTimeProvider/...) mutates and returns the SAME
+        // factory, so the opt-out evidence sits one hop (or several) up the chain: follow
+        // library-declared MemoFactory-returning calls to their own receiver.
+        while (receiver is IInvocationOperation chained && ReturnsTheLibraryFactory(chained.TargetMethod))
+        {
+            receiver = Unwrap(ReceiverOf(chained));
+        }
+
+        return receiver switch
         {
             IObjectCreationOperation creation => OptsOut(creation),
             ILocalReferenceOperation local => SymbolOptsOut(local.Local, invocation),
-            IFieldReferenceOperation { Field.IsReadOnly: true } field => SymbolOptsOut(field.Field, invocation),
-            IPropertyReferenceOperation { Property.SetMethod: null } property => SymbolOptsOut(property.Property, invocation),
+            IFieldReferenceOperation { Field.IsReadOnly: true } field
+                => ContainingTypeFullyInSight(field.Field, invocation) && SymbolOptsOut(field.Field, invocation),
+            IPropertyReferenceOperation { Property.SetMethod: null } property
+                => ContainingTypeFullyInSight(property.Property, invocation) && SymbolOptsOut(property.Property, invocation),
             _ => false,
         };
+    }
+
+    // Instance creations carry the factory in Instance; the structured-concurrency creations
+    // and the fluent configuration methods are extension methods, whose receiver arrives as
+    // the first argument.
+    private static IOperation? ReceiverOf(IInvocationOperation invocation)
+    {
+        return invocation.Instance
+            ?? (invocation.TargetMethod.IsExtensionMethod
+                ? invocation.Arguments.FirstOrDefault(argument => argument.Parameter?.Ordinal == 0)?.Value
+                : null);
+    }
+
+    // A LIBRARY method that returns MemoFactory is the fluent-configuration contract (it
+    // mutates and returns its receiver); a source-declared lookalike could return any factory
+    // it likes and is not followed.
+    private static bool ReturnsTheLibraryFactory(IMethodSymbol method)
+    {
+        return method.ReturnType is INamedTypeSymbol { Name: "MemoFactory" } factoryType
+            && factoryType.ContainingNamespace?.ToDisplayString() == "MemoizR"
+            && FactoryMethods.IsLibraryType(factoryType)
+            && method.ContainingType is { } containingType
+            && FactoryMethods.IsLibraryType(containingType);
+    }
+
+    // A readonly field's (or get-only auto-property's) initializer can still be overwritten by
+    // a constructor, and a partial type can keep that constructor in ANOTHER file, outside the
+    // reassignment scan's reach: only members of types declared entirely in the invocation's
+    // file are trusted.
+    private static bool ContainingTypeFullyInSight(ISymbol symbol, IInvocationOperation invocation)
+    {
+        var tree = invocation.SemanticModel?.SyntaxTree;
+        return tree is not null
+            && symbol.ContainingType is { } containingType
+            && containingType.DeclaringSyntaxReferences.All(reference => reference.SyntaxTree == tree);
     }
 
     private static bool SymbolOptsOut(ISymbol symbol, IInvocationOperation invocation)

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -31,7 +31,10 @@ internal static class FactoryOptOut
             ILocalReferenceOperation local => SymbolOptsOut(local.Local, invocation),
             IFieldReferenceOperation { Field.IsReadOnly: true } field
                 => ContainingTypeFullyInSight(field.Field, invocation) && SymbolOptsOut(field.Field, invocation),
-            IPropertyReferenceOperation { Property.SetMethod: null } property
+            // Overridable getters dispatch dynamically: a derived override can hand back a
+            // strict factory the base initializer never saw, so only a getter that cannot
+            // dispatch elsewhere may vouch for its initializer.
+            IPropertyReferenceOperation { Property: { SetMethod: null, IsVirtual: false, IsAbstract: false, IsOverride: false } } property
                 => ContainingTypeFullyInSight(property.Property, invocation) && SymbolOptsOut(property.Property, invocation),
             _ => false,
         };
@@ -219,11 +222,36 @@ internal static class FactoryOptOut
 
     private static IOperation? Unwrap(IOperation? operation)
     {
-        while (operation is IConversionOperation conversion)
+        while (true)
         {
-            operation = conversion.Operand;
+            switch (operation)
+            {
+                case IConversionOperation conversion:
+                    operation = conversion.Operand;
+                    continue;
+                // `lax?.CreateSignal(...)`: the invocation's receiver is the conditional-access
+                // PLACEHOLDER; the factory is the enclosing conditional access's Operation
+                // (`lax`). At runtime the creation either does not run or runs on that factory
+                // -- either way the opt-out evidence lives there.
+                case IConditionalAccessInstanceOperation placeholder:
+                    operation = EnclosingConditionalAccess(placeholder)?.Operation;
+                    continue;
+                default:
+                    return operation;
+            }
+        }
+    }
+
+    private static IConditionalAccessOperation? EnclosingConditionalAccess(IOperation placeholder)
+    {
+        for (var parent = placeholder.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is IConditionalAccessOperation conditional)
+            {
+                return conditional;
+            }
         }
 
-        return operation;
+        return null;
     }
 }

--- a/MemoizR.Analyzers/FactoryOptOut.cs
+++ b/MemoizR.Analyzers/FactoryOptOut.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace MemoizR.Analyzers;
+
+// The build-time side of MemoFactoryOptions.DisableSendableChecks (A4's migration escape
+// hatch): a creation on a factory that VISIBLY opts out must not fail the very checks its
+// runtime disabled, or the documented per-factory opt-out would be unusable under the Error
+// default without a project-wide suppression. Resolution is best-effort and conservative in
+// the safe direction -- the factory's construction must be in sight (an inline receiver, or a
+// local/field/property initializer in the same file; Compilation.GetSemanticModel is banned in
+// analyzers, so cross-file initializers stay out of reach). Anything unresolvable (factory
+// parameter, reassigned local, options computed elsewhere) keeps the checks ON: a missed
+// opt-out costs one suppression, a wrong opt-out would silently drop the rule.
+internal static class FactoryOptOut
+{
+    public static bool DisablesSendableChecks(IInvocationOperation invocation)
+    {
+        // Instance creations carry the factory in Instance; the structured-concurrency
+        // creations are extension methods, whose receiver arrives as the first argument.
+        var receiver = invocation.Instance
+            ?? (invocation.TargetMethod.IsExtensionMethod
+                ? invocation.Arguments.FirstOrDefault(argument => argument.Parameter?.Ordinal == 0)?.Value
+                : null);
+
+        return FactoryCreationBehind(Unwrap(receiver), invocation) is { } creation && OptsOut(creation);
+    }
+
+    private static IObjectCreationOperation? FactoryCreationBehind(IOperation? receiver, IInvocationOperation invocation)
+    {
+        return receiver switch
+        {
+            IObjectCreationOperation creation => creation,
+            ILocalReferenceOperation local => InitializerCreation(local.Local, invocation),
+            IFieldReferenceOperation field => InitializerCreation(field.Field, invocation),
+            IPropertyReferenceOperation property => InitializerCreation(property.Property, invocation),
+            _ => null,
+        };
+    }
+
+    // The declaration initializer, resolvable only in the invocation's own tree: that tree's
+    // semantic model is already in hand, and locals are same-tree by construction -- only a
+    // factory field/property declared in ANOTHER file stays unresolved (and therefore checked).
+    private static IObjectCreationOperation? InitializerCreation(ISymbol symbol, IInvocationOperation invocation)
+    {
+        var model = invocation.SemanticModel;
+        if (model is null)
+        {
+            return null;
+        }
+
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (reference.SyntaxTree != model.SyntaxTree)
+            {
+                continue;
+            }
+
+            var initializer = reference.GetSyntax() switch
+            {
+                VariableDeclaratorSyntax { Initializer.Value: { } value } => value, // locals and fields
+                PropertyDeclarationSyntax { Initializer.Value: { } value } => value,
+                _ => null,
+            };
+
+            if (initializer is not null && Unwrap(model.GetOperation(initializer)) is IObjectCreationOperation creation)
+            {
+                return creation;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool OptsOut(IObjectCreationOperation factoryCreation)
+    {
+        if (factoryCreation.Type is not INamedTypeSymbol { Name: "MemoFactory" } factoryType
+            || factoryType.ContainingNamespace?.ToDisplayString() != "MemoizR"
+            || !FactoryMethods.IsLibraryType(factoryType))
+        {
+            return false;
+        }
+
+        foreach (var argument in factoryCreation.Arguments)
+        {
+            if (argument.Parameter?.Type is not INamedTypeSymbol { TypeKind: TypeKind.Enum, Name: "MemoFactoryOptions" } optionsType
+                || !FactoryMethods.IsLibraryType(optionsType))
+            {
+                continue;
+            }
+
+            // Flag combinations of the enum's members fold to a compile-time constant (an
+            // omitted optional argument folds to None); test the bit against the member's own
+            // declared value rather than hardcoding it.
+            if (argument.Value.ConstantValue is { HasValue: true, Value: int flags })
+            {
+                return DisableFlag(optionsType) is { } bit && (flags & bit) != 0;
+            }
+
+            // Non-constant composition (a flags local OR-ed together): a reference to the
+            // member anywhere inside the argument is still positive evidence of the opt-out.
+            return argument.Value.DescendantsAndSelf().Any(operation =>
+                operation is IFieldReferenceOperation { Field.Name: "DisableSendableChecks" } member
+                && SymbolEqualityComparer.Default.Equals(member.Field.ContainingType, optionsType));
+        }
+
+        return false;
+    }
+
+    private static int? DisableFlag(INamedTypeSymbol optionsType)
+    {
+        return optionsType.GetMembers("DisableSendableChecks").OfType<IFieldSymbol>()
+            .FirstOrDefault()?.ConstantValue as int?;
+    }
+
+    private static IOperation? Unwrap(IOperation? operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation;
+    }
+}

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -294,14 +294,17 @@ internal sealed class SendableSymbolClassifier
         }
 
         // POLYMORPHIC recursion constructs a FRESH closed symbol per level (Box<T> exposing a
-        // Box<List<T>> member), which the re-entry check above can never catch: the same
-        // DEFINITION re-entering the path more than a handful of times is treated as the same
-        // cycle -- deeper re-instantiations substitute the same declared members, and
-        // realistic nesting of one generic within itself stays far below the bound. Kept in
-        // lockstep with the runtime checker's identical cap.
+        // Box<List<T>> member), which the re-entry check above can never catch. Its signature
+        // is a NON-SHRINKING re-occurrence of the same definition: finite hand-written nesting
+        // (Box<Box<Box<List<int>>>>) strictly shrinks at every recursive step and is walked to
+        // the bottom however deep it goes, while a divergent expansion re-enters its own
+        // definition at the same size or larger and is cut on the second occurrence (landing
+        // on the cycle assumption above). Kept in lockstep with the runtime checker.
         if (named.IsGenericType
-            && inProgress.Count(entry => entry is INamedTypeSymbol { IsGenericType: true } other
-                && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, named.OriginalDefinition)) > 4)
+            && inProgress.Any(entry => entry is INamedTypeSymbol { IsGenericType: true } other
+                && !SymbolEqualityComparer.Default.Equals(other, named)
+                && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, named.OriginalDefinition)
+                && TypeSize(other) <= TypeSize(named)))
         {
             inProgress.Remove(named);
             return null;
@@ -430,6 +433,18 @@ internal sealed class SendableSymbolClassifier
     private static bool IsRootType(INamedTypeSymbol type)
     {
         return type.SpecialType == SpecialType.System_Object || type.SpecialType == SpecialType.System_ValueType;
+    }
+
+    // The number of type nodes in the constructed reference: Box<List<int>> is 3. Finite
+    // nesting shrinks this at every recursive step; polymorphic recursion grows it.
+    private static int TypeSize(ITypeSymbol type)
+    {
+        return type switch
+        {
+            IArrayTypeSymbol array => 1 + TypeSize(array.ElementType),
+            INamedTypeSymbol named => 1 + named.TypeArguments.Sum(TypeSize),
+            _ => 1,
+        };
     }
 
     private string? CheckTypeArguments(INamedTypeSymbol named, HashSet<ITypeSymbol> inProgress)

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -293,6 +293,20 @@ internal sealed class SendableSymbolClassifier
             return null;
         }
 
+        // POLYMORPHIC recursion constructs a FRESH closed symbol per level (Box<T> exposing a
+        // Box<List<T>> member), which the re-entry check above can never catch: the same
+        // DEFINITION re-entering the path more than a handful of times is treated as the same
+        // cycle -- deeper re-instantiations substitute the same declared members, and
+        // realistic nesting of one generic within itself stays far below the bound. Kept in
+        // lockstep with the runtime checker's identical cap.
+        if (named.IsGenericType
+            && inProgress.Count(entry => entry is INamedTypeSymbol { IsGenericType: true } other
+                && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, named.OriginalDefinition)) > 4)
+        {
+            inProgress.Remove(named);
+            return null;
+        }
+
         try
         {
             for (var current = named; current != null && !IsRootType(current); current = current.BaseType)

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -297,14 +297,16 @@ internal sealed class SendableSymbolClassifier
         // Box<List<T>> member), which the re-entry check above can never catch. Its signature
         // is a NON-SHRINKING re-occurrence of the same definition: finite hand-written nesting
         // (Box<Box<Box<List<int>>>>) strictly shrinks at every recursive step and is walked to
-        // the bottom however deep it goes, while a divergent expansion re-enters its own
-        // definition at the same size or larger and is cut on the second occurrence (landing
-        // on the cycle assumption above). Kept in lockstep with the runtime checker.
+        // the bottom however deep it goes. A divergent expansion is walked through its FIRST
+        // re-instantiation -- substituted members can flip the verdict exactly one level down
+        // (Box<T> { Box<List<T>> Next; T Value; } hides the List in the second level's Value)
+        // -- and cut at the second, landing on the cycle assumption above. Kept in lockstep
+        // with the runtime checker.
         if (named.IsGenericType
-            && inProgress.Any(entry => entry is INamedTypeSymbol { IsGenericType: true } other
+            && inProgress.Count(entry => entry is INamedTypeSymbol { IsGenericType: true } other
                 && !SymbolEqualityComparer.Default.Equals(other, named)
                 && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, named.OriginalDefinition)
-                && TypeSize(other) <= TypeSize(named)))
+                && TypeSize(other) <= TypeSize(named)) >= 2)
         {
             inProgress.Remove(named);
             return null;

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -124,6 +124,36 @@ internal sealed class SendableSymbolClassifier
         return IsKnownImmutable(named) || IsTaskOfT(named) || IsKnownSendableCollection(named);
     }
 
+    // A green-listed non-generic class whose green-listed GENERIC sibling derives from it
+    // (Task <- Task<TResult>): the upcast needs no user subclass -- every async method
+    // manufactures one -- so an arbitrary payload can ride behind the surface past checks
+    // that trust the declared type wholesale.
+    internal static bool HasAGreenListedGenericSubclass(INamedTypeSymbol named)
+    {
+        if (named.Arity != 0 || named.IsValueType || named.ContainingNamespace is null)
+        {
+            return false;
+        }
+
+        return named.ContainingNamespace.GetTypeMembers(named.Name)
+            .Any(sibling => sibling.Arity > 0
+                && IsFrameworkGreenListed(sibling)
+                && DerivesFrom(sibling, named));
+    }
+
+    private static bool DerivesFrom(INamedTypeSymbol candidate, INamedTypeSymbol baseType)
+    {
+        for (var current = candidate.BaseType; current is not null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool IsKnownImmutable(ITypeSymbol type)
     {
         if (type is not INamedTypeSymbol named || named.Arity != 0 || !IsDeclaredInFrameworkAssembly(named))

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -441,6 +441,18 @@ internal sealed class SendableSymbolClassifier
             : $"field '{field.Name}'";
     }
 
+    // Whether the property owns a backing slot (an auto-property): the compiler ties the
+    // synthesized field to the property via AssociatedSymbol. Computed getters store nothing
+    // -- state they hand out lives in some field/auto-property flagged at ITS declaration --
+    // so the static-state and smuggle walks only count stored members. (Metadata backing
+    // fields are not imported under MetadataImportOptions.Public, so metadata auto-properties
+    // read as computed: an accepted best-effort miss.)
+    internal static bool HasBackingSlot(IPropertySymbol property)
+    {
+        return property.ContainingType.GetMembers().OfType<IFieldSymbol>()
+            .Any(field => SymbolEqualityComparer.Default.Equals(field.AssociatedSymbol, property));
+    }
+
     internal static string Display(ITypeSymbol type)
     {
         return type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -116,6 +116,14 @@ internal sealed class SendableSymbolClassifier
     // lookalike (`namespace System { class Uri { public int State; } }`) binds over the BCL
     // type and must go through the structural walk, as the runtime's typeof identity would
     // reject it.
+    // Whether the type is on any framework green-list (known immutables, Task<T>, the known
+    // collections): used by MZR006 to avoid nagging about non-sealed BCL types like Uri, whose
+    // accidental subclassing is not a plausible failure mode.
+    internal static bool IsFrameworkGreenListed(INamedTypeSymbol named)
+    {
+        return IsKnownImmutable(named) || IsTaskOfT(named) || IsKnownSendableCollection(named);
+    }
+
     private static bool IsKnownImmutable(ITypeSymbol type)
     {
         if (type is not INamedTypeSymbol named || named.Arity != 0 || !IsDeclaredInFrameworkAssembly(named))

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -438,13 +438,16 @@ internal sealed class SendableSymbolClassifier
     }
 
     // The number of type nodes in the constructed reference: Box<List<int>> is 3. Finite
-    // nesting shrinks this at every recursive step; polymorphic recursion grows it.
-    private static int TypeSize(ITypeSymbol type)
+    // nesting shrinks this at every recursive step; polymorphic recursion grows it. CONTAINING
+    // type arguments count too: a nested Outer<T>.Holder substitutes through them (the runtime
+    // Type flattens outer arguments into GetGenericArguments, so this stays in lockstep).
+    internal static int TypeSize(ITypeSymbol type)
     {
         return type switch
         {
             IArrayTypeSymbol array => 1 + TypeSize(array.ElementType),
-            INamedTypeSymbol named => 1 + named.TypeArguments.Sum(TypeSize),
+            INamedTypeSymbol named => 1 + named.TypeArguments.Sum(TypeSize)
+                + (named.ContainingType is { } containing ? TypeSize(containing) - 1 : 0),
             _ => 1,
         };
     }

--- a/MemoizR.Analyzers/SendableSymbolClassifier.cs
+++ b/MemoizR.Analyzers/SendableSymbolClassifier.cs
@@ -233,7 +233,10 @@ internal sealed class SendableSymbolClassifier
             or "System.Private.Uri" or "System.Runtime.Numerics" or "System.Numerics";
     }
 
-    private static bool HasSendableAttribute(INamedTypeSymbol named)
+    // Internal because MZR004's type-parameter walk uses [Sendable] trust as its descent
+    // boundary: an attributed type's thread-safety assertion does not rest on its type
+    // arguments (MemoizR's own nodes are internally synchronized for any T).
+    internal static bool HasSendableAttribute(INamedTypeSymbol named)
     {
         foreach (var attribute in named.OriginalDefinition.GetAttributes())
         {

--- a/MemoizR.Analyzers/SendableTypeArgumentAnalyzer.cs
+++ b/MemoizR.Analyzers/SendableTypeArgumentAnalyzer.cs
@@ -40,6 +40,14 @@ public sealed class SendableTypeArgumentAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // The runtime accepts a per-factory opt-out (DisableSendableChecks); with an Error
+        // default the build must accept the same escape hatch, or migration would need a
+        // project-wide suppression on top of the documented option.
+        if (FactoryOptOut.DisablesSendableChecks(invocation))
+        {
+            return;
+        }
+
         foreach (var typeArgument in method.TypeArguments)
         {
             var reason = classifier.GetNotSendableReason(typeArgument);

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -41,16 +41,29 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
 
             var classifier = new SendableSymbolClassifier();
             var treeUsesMemoizR = new ConcurrentDictionary<SyntaxTree, bool>();
+
+            // A `global using MemoizR;` anywhere puts MemoizR in scope for EVERY file, so the
+            // per-tree check must not exempt projects that centralize their usings. One shallow
+            // scan per compilation, computed lazily on the first static symbol seen.
+            var compilation = compilationStart.Compilation;
+            var hasGlobalMemoizRUsing = new System.Lazy<bool>(() =>
+                compilation.SyntaxTrees.Any(tree => MemoizRUsingsIn(tree).Any(directive => directive.GlobalKeyword != default)));
+
             compilationStart.RegisterSymbolAction(
-                symbolContext => Analyze(symbolContext, classifier, treeUsesMemoizR),
+                symbolContext => Analyze(symbolContext, classifier, treeUsesMemoizR, hasGlobalMemoizRUsing),
                 SymbolKind.Field, SymbolKind.Property, SymbolKind.Event);
         });
     }
 
-    private static void Analyze(SymbolAnalysisContext context, SendableSymbolClassifier classifier, ConcurrentDictionary<SyntaxTree, bool> treeUsesMemoizR)
+    private static void Analyze(SymbolAnalysisContext context, SendableSymbolClassifier classifier, ConcurrentDictionary<SyntaxTree, bool> treeUsesMemoizR, System.Lazy<bool> hasGlobalMemoizRUsing)
     {
         var symbol = context.Symbol;
-        if (!symbol.IsStatic || symbol.IsImplicitlyDeclared || !IsInMemoizRUsingFile(symbol, treeUsesMemoizR))
+        if (!symbol.IsStatic || symbol.IsImplicitlyDeclared)
+        {
+            return;
+        }
+
+        if (!hasGlobalMemoizRUsing.Value && !IsInMemoizRUsingFile(symbol, treeUsesMemoizR))
         {
             return;
         }
@@ -119,11 +132,15 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        return treeUsesMemoizR.GetOrAdd(tree, static t =>
-            t.GetRoot()
-                .DescendantNodes(node => node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
-                .OfType<UsingDirectiveSyntax>()
-                .Any(directive => directive.Name?.ToString() is { } name
-                    && (name == "MemoizR" || name.StartsWith("MemoizR.", System.StringComparison.Ordinal))));
+        return treeUsesMemoizR.GetOrAdd(tree, static t => MemoizRUsingsIn(t).Any());
+    }
+
+    private static System.Collections.Generic.IEnumerable<UsingDirectiveSyntax> MemoizRUsingsIn(SyntaxTree tree)
+    {
+        return tree.GetRoot()
+            .DescendantNodes(node => node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+            .OfType<UsingDirectiveSyntax>()
+            .Where(directive => directive.Name?.ToString() is { } name
+                && (name == "MemoizR" || name.StartsWith("MemoizR.", System.StringComparison.Ordinal)));
     }
 }

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -141,14 +141,16 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
 
     private static string? ClassifyProperty(IPropertySymbol property, SendableSymbolClassifier classifier)
     {
-        if (property.GetMethod is null)
-        {
-            return null; // set-only oddity: nothing shared can be read back
-        }
-
+        // A settable surface is the hazard by itself -- the get+set arm never required a
+        // backing slot, and a SET-ONLY property is no less writable for dropping the getter.
         if (property.SetMethod is { IsInitOnly: false })
         {
             return "a settable slot";
+        }
+
+        if (property.GetMethod is null)
+        {
+            return null; // only an init setter: nothing writable remains, nothing reads back
         }
 
         if (!SendableSymbolClassifier.HasBackingSlot(property))

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -188,21 +188,33 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
     // member walk would accept that T through the exemption this rule exists to remove.
     private static bool HasUnshieldedTypeParameter(ITypeSymbol type)
     {
-        return HasUnshieldedTypeParameter(type, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+        return HasUnshieldedTypeParameter(
+            type,
+            new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default),
+            new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default));
     }
 
-    private static bool HasUnshieldedTypeParameter(ITypeSymbol type, System.Collections.Generic.HashSet<ITypeSymbol> visited)
+    private static bool HasUnshieldedTypeParameter(
+        ITypeSymbol type,
+        System.Collections.Generic.HashSet<ITypeSymbol> visited,
+        System.Collections.Generic.HashSet<INamedTypeSymbol> walkedDefinitions)
     {
         switch (type)
         {
             case ITypeParameterSymbol:
                 return true;
             case IArrayTypeSymbol array:
-                return HasUnshieldedTypeParameter(array.ElementType, visited);
+                return HasUnshieldedTypeParameter(array.ElementType, visited, walkedDefinitions);
             case INamedTypeSymbol named
                 when visited.Add(named) && !SendableSymbolClassifier.HasSendableAttribute(named):
-                return named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, visited))
-                    || MemberTypesOf(named).Any(memberType => HasUnshieldedTypeParameter(memberType, visited));
+                // Member re-instantiation can construct fresh symbols forever (Box<T> exposing
+                // Box<List<T>>), so the member walk runs once per DECLARATION: deeper
+                // re-instantiations substitute the same members with arguments already walked.
+                var memberTypes = walkedDefinitions.Add((INamedTypeSymbol)named.OriginalDefinition)
+                    ? MemberTypesOf(named)
+                    : System.Linq.Enumerable.Empty<ITypeSymbol>();
+                return named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, visited, walkedDefinitions))
+                    || memberTypes.Any(memberType => HasUnshieldedTypeParameter(memberType, visited, walkedDefinitions));
             default:
                 return false;
         }

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MemoizR.Analyzers;
 public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-        ImmutableArray.Create(DiagnosticDescriptors.MutableStaticState);
+        ImmutableArray.Create(DiagnosticDescriptors.MutableStaticState, DiagnosticDescriptors.NonSealedValueType);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -78,6 +78,7 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
 
         if (finding is null)
         {
+            ReportSmuggleSurfacesIn(context, symbol);
             return;
         }
 
@@ -87,6 +88,37 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
             kind,
             symbol.Name,
             finding));
+    }
+
+    // A static that PASSED the slot rule can still smuggle: a readonly static of a non-sealed
+    // (or [Sendable]-asserted abstract) Sendable type stores whatever subclass got upcast in,
+    // with no creation site where MZR006 would hint and no runtime write validation ever
+    // seeing the slot. Same Info-severity calculus as the creation-site hint.
+    private static void ReportSmuggleSurfacesIn(SymbolAnalysisContext context, ISymbol symbol)
+    {
+        var slotType = symbol switch
+        {
+            IFieldSymbol { IsConst: false } field => field.Type,
+            IPropertySymbol property when HasBackingSlot(property) => property.Type,
+            _ => null,
+        };
+
+        if (slotType is null)
+        {
+            return;
+        }
+
+        foreach (var (named, _) in SubclassSmugglingAnalyzer.NamedTypesIn(slotType, depth: 0))
+        {
+            if (SubclassSmugglingAnalyzer.IsSmuggleSurface(named))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.NonSealedValueType,
+                    symbol.Locations.FirstOrDefault() ?? Location.None,
+                    SendableSymbolClassifier.Display(named),
+                    " (a static slot publishes unchecked: ValidateWrittenValues covers signal writes only)"));
+            }
+        }
     }
 
     private static string? ClassifyField(IFieldSymbol field, SendableSymbolClassifier classifier)
@@ -117,8 +149,24 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
             return "a settable slot";
         }
 
+        if (!HasBackingSlot(property))
+        {
+            // A computed getter owns no static slot: a fresh value per call shares nothing,
+            // and a getter handing out OTHER static state is flagged at that state's own
+            // declaration.
+            return null;
+        }
+
         var reason = NotSendableReason(property.Type, classifier);
         return reason is null ? null : $"get-only, but of non-Sendable type {SendableSymbolClassifier.Display(property.Type)} ({reason})";
+    }
+
+    // Only auto-properties own a backing slot; the compiler ties it to the property via
+    // AssociatedSymbol.
+    private static bool HasBackingSlot(IPropertySymbol property)
+    {
+        return property.ContainingType.GetMembers().OfType<IFieldSymbol>()
+            .Any(field => SymbolEqualityComparer.Default.Equals(field.AssociatedSymbol, property));
     }
 
     // MZR001 gives unbound type parameters the benefit of the doubt because the closed

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -188,10 +188,16 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
     // member walk would accept that T through the exemption this rule exists to remove.
     private static bool HasUnshieldedTypeParameter(ITypeSymbol type)
     {
-        return HasUnshieldedTypeParameter(type, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+        return HasUnshieldedTypeParameter(
+            type,
+            new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default),
+            new System.Collections.Generic.List<INamedTypeSymbol>());
     }
 
-    private static bool HasUnshieldedTypeParameter(ITypeSymbol type, System.Collections.Generic.HashSet<ITypeSymbol> visited)
+    private static bool HasUnshieldedTypeParameter(
+        ITypeSymbol type,
+        System.Collections.Generic.HashSet<ITypeSymbol> visited,
+        System.Collections.Generic.List<INamedTypeSymbol> path)
     {
         switch (type)
         {
@@ -204,26 +210,38 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
                 return !parameter.HasUnmanagedTypeConstraint
                     && !parameter.ConstraintTypes.Any(constraint => constraint.SpecialType == SpecialType.System_Enum);
             case IArrayTypeSymbol array:
-                return HasUnshieldedTypeParameter(array.ElementType, visited);
+                return HasUnshieldedTypeParameter(array.ElementType, visited, path);
             case INamedTypeSymbol named
                 when visited.Add(named) && !SendableSymbolClassifier.HasSendableAttribute(named):
+                if (named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, visited, path)))
+                {
+                    return true;
+                }
+
                 // Member re-instantiation can construct fresh symbols forever (Box<T> exposing
-                // Box<List<T>>), so the member walk needs a divergence bound -- but a
-                // once-per-DECLARATION gate is too coarse: the same nested declaration can
-                // return with DIFFERENT substitutions through its containing type
-                // (Outer<int>.Holder, then Outer<T>.Holder). The bound mirrors the
-                // classifier's: walk members while fewer than two same-definition types of
-                // non-greater size were already visited.
+                // Box<List<T>>), so the member walk needs a divergence bound -- counted on the
+                // recursion PATH, not globally: sibling instantiations (Outer<int>.Holder next
+                // to Outer<string>.Holder next to Outer<T>.Holder) are not recursion and must
+                // all be walked, while a divergent chain stacks same-definition ancestors.
                 var definition = (INamedTypeSymbol)named.OriginalDefinition;
-                var priorNonShrinking = visited.Count(entry => entry is INamedTypeSymbol { } other
-                    && !SymbolEqualityComparer.Default.Equals(other, named)
-                    && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, definition)
+                var priorNonShrinking = path.Count(other =>
+                    SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, definition)
                     && SendableSymbolClassifier.TypeSize(other) <= SendableSymbolClassifier.TypeSize(named));
-                var memberTypes = priorNonShrinking < 2
-                    ? MemberTypesOf(named)
-                    : System.Linq.Enumerable.Empty<ITypeSymbol>();
-                return named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, visited))
-                    || memberTypes.Any(memberType => HasUnshieldedTypeParameter(memberType, visited));
+                if (priorNonShrinking >= 2)
+                {
+                    return false;
+                }
+
+                path.Add(named);
+                try
+                {
+                    return MemberTypesOf(named).Any(memberType => HasUnshieldedTypeParameter(memberType, visited, path));
+                }
+                finally
+                {
+                    path.RemoveAt(path.Count - 1);
+                }
+
             default:
                 return false;
         }

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -188,33 +188,40 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
     // member walk would accept that T through the exemption this rule exists to remove.
     private static bool HasUnshieldedTypeParameter(ITypeSymbol type)
     {
-        return HasUnshieldedTypeParameter(
-            type,
-            new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default),
-            new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default));
+        return HasUnshieldedTypeParameter(type, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
     }
 
-    private static bool HasUnshieldedTypeParameter(
-        ITypeSymbol type,
-        System.Collections.Generic.HashSet<ITypeSymbol> visited,
-        System.Collections.Generic.HashSet<INamedTypeSymbol> walkedDefinitions)
+    private static bool HasUnshieldedTypeParameter(ITypeSymbol type, System.Collections.Generic.HashSet<ITypeSymbol> visited)
     {
         switch (type)
         {
-            case ITypeParameterSymbol:
-                return true;
+            case ITypeParameterSymbol parameter:
+                // `where T : unmanaged` guarantees a no-reference value type for EVERY closed
+                // instantiation: reads hand out copies that can alias nothing, so the slot is
+                // safe without any creation-site check. (A plain `struct` constraint is NOT
+                // enough -- a struct can carry references to mutable objects.)
+                return !parameter.HasUnmanagedTypeConstraint;
             case IArrayTypeSymbol array:
-                return HasUnshieldedTypeParameter(array.ElementType, visited, walkedDefinitions);
+                return HasUnshieldedTypeParameter(array.ElementType, visited);
             case INamedTypeSymbol named
                 when visited.Add(named) && !SendableSymbolClassifier.HasSendableAttribute(named):
                 // Member re-instantiation can construct fresh symbols forever (Box<T> exposing
-                // Box<List<T>>), so the member walk runs once per DECLARATION: deeper
-                // re-instantiations substitute the same members with arguments already walked.
-                var memberTypes = walkedDefinitions.Add((INamedTypeSymbol)named.OriginalDefinition)
+                // Box<List<T>>), so the member walk needs a divergence bound -- but a
+                // once-per-DECLARATION gate is too coarse: the same nested declaration can
+                // return with DIFFERENT substitutions through its containing type
+                // (Outer<int>.Holder, then Outer<T>.Holder). The bound mirrors the
+                // classifier's: walk members while fewer than two same-definition types of
+                // non-greater size were already visited.
+                var definition = (INamedTypeSymbol)named.OriginalDefinition;
+                var priorNonShrinking = visited.Count(entry => entry is INamedTypeSymbol { } other
+                    && !SymbolEqualityComparer.Default.Equals(other, named)
+                    && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, definition)
+                    && SendableSymbolClassifier.TypeSize(other) <= SendableSymbolClassifier.TypeSize(named));
+                var memberTypes = priorNonShrinking < 2
                     ? MemberTypesOf(named)
                     : System.Linq.Enumerable.Empty<ITypeSymbol>();
-                return named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, visited, walkedDefinitions))
-                    || memberTypes.Any(memberType => HasUnshieldedTypeParameter(memberType, visited, walkedDefinitions));
+                return named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, visited))
+                    || memberTypes.Any(memberType => HasUnshieldedTypeParameter(memberType, visited));
             default:
                 return false;
         }

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MemoizR.Analyzers;
+
+// MZR004, the SE-0412 analog proper: Swift 6 rejects every non-isolated mutable global, because
+// a global is reachable from every isolation domain. Here the domains are concurrently running
+// flows, and a static next to a reactive graph is reachable from all of them: a MUTABLE SLOT
+// (non-readonly field, settable property, event) races on the slot itself; a readonly slot of a
+// NON-SENDABLE TYPE shares one mutable object graph. Both are exactly the states the library's
+// own model wants lifted into a Signal/EagerRelativeSignal -- which, like all MemoizR nodes, is
+// [Sendable] and therefore fine to hold in a static.
+//
+// Scoping keeps the rule inside MemoizR's mandate: it fires only when the compilation references
+// the real MemoizR assembly AND the static's file uses MemoizR (a using directive for the
+// MemoizR namespaces). A project's unrelated corners stay unflagged.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.MutableStaticState);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            // Only meaningful in compilations that actually use the library (the analyzer ships
+            // in the nupkg, but transitive references can drag it further than intended).
+            if (compilationStart.Compilation.GetTypeByMetadataName("MemoizR.MemoFactory") is not INamedTypeSymbol factory
+                || !FactoryMethods.IsLibraryType(factory))
+            {
+                return;
+            }
+
+            var classifier = new SendableSymbolClassifier();
+            var treeUsesMemoizR = new ConcurrentDictionary<SyntaxTree, bool>();
+            compilationStart.RegisterSymbolAction(
+                symbolContext => Analyze(symbolContext, classifier, treeUsesMemoizR),
+                SymbolKind.Field, SymbolKind.Property, SymbolKind.Event);
+        });
+    }
+
+    private static void Analyze(SymbolAnalysisContext context, SendableSymbolClassifier classifier, ConcurrentDictionary<SyntaxTree, bool> treeUsesMemoizR)
+    {
+        var symbol = context.Symbol;
+        if (!symbol.IsStatic || symbol.IsImplicitlyDeclared || !IsInMemoizRUsingFile(symbol, treeUsesMemoizR))
+        {
+            return;
+        }
+
+        var (kind, finding) = symbol switch
+        {
+            IFieldSymbol field => ("field", ClassifyField(field, classifier)),
+            IPropertySymbol property => ("property", ClassifyProperty(property, classifier)),
+            IEventSymbol => ("event", "a mutable subscription surface (its backing delegate changes on every add/remove)"),
+            _ => ("", null),
+        };
+
+        if (finding is null)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.MutableStaticState,
+            symbol.Locations.FirstOrDefault() ?? Location.None,
+            kind,
+            symbol.Name,
+            finding));
+    }
+
+    private static string? ClassifyField(IFieldSymbol field, SendableSymbolClassifier classifier)
+    {
+        if (field.IsConst)
+        {
+            return null; // compile-time constant: immutable by construction
+        }
+
+        if (!field.IsReadOnly)
+        {
+            return "a mutable slot";
+        }
+
+        var reason = classifier.GetNotSendableReason(field.Type);
+        return reason is null ? null : $"readonly, but of non-Sendable type {SendableSymbolClassifier.Display(field.Type)} ({reason})";
+    }
+
+    private static string? ClassifyProperty(IPropertySymbol property, SendableSymbolClassifier classifier)
+    {
+        if (property.GetMethod is null)
+        {
+            return null; // set-only oddity: nothing shared can be read back
+        }
+
+        if (property.SetMethod is { IsInitOnly: false })
+        {
+            return "a settable slot";
+        }
+
+        var reason = classifier.GetNotSendableReason(property.Type);
+        return reason is null ? null : $"get-only, but of non-Sendable type {SendableSymbolClassifier.Display(property.Type)} ({reason})";
+    }
+
+    // The mandate boundary: the static's FILE must use MemoizR. Using directives sit at the
+    // compilation-unit or namespace level, so the scan is shallow; the verdict is cached per
+    // tree (symbol actions fire per static, and many statics share a file).
+    private static bool IsInMemoizRUsingFile(ISymbol symbol, ConcurrentDictionary<SyntaxTree, bool> treeUsesMemoizR)
+    {
+        var tree = symbol.Locations.FirstOrDefault()?.SourceTree;
+        if (tree is null)
+        {
+            return false;
+        }
+
+        return treeUsesMemoizR.GetOrAdd(tree, static t =>
+            t.GetRoot()
+                .DescendantNodes(node => node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+                .OfType<UsingDirectiveSyntax>()
+                .Any(directive => directive.Name?.ToString() is { } name
+                    && (name == "MemoizR" || name.StartsWith("MemoizR.", System.StringComparison.Ordinal))));
+    }
+}

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -101,7 +101,7 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
             return "a mutable slot";
         }
 
-        var reason = classifier.GetNotSendableReason(field.Type);
+        var reason = NotSendableReason(field.Type, classifier);
         return reason is null ? null : $"readonly, but of non-Sendable type {SendableSymbolClassifier.Display(field.Type)} ({reason})";
     }
 
@@ -117,8 +117,22 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
             return "a settable slot";
         }
 
-        var reason = classifier.GetNotSendableReason(property.Type);
+        var reason = NotSendableReason(property.Type, classifier);
         return reason is null ? null : $"get-only, but of non-Sendable type {SendableSymbolClassifier.Display(property.Type)} ({reason})";
+    }
+
+    // MZR001 gives unbound type parameters the benefit of the doubt because the closed
+    // instantiation is checked at its own creation site. A static has NO later site: every
+    // closed C<T> mints a fresh process-wide slot no rule ever sees again, so here a type
+    // parameter is unverifiable rather than trusted.
+    private static string? NotSendableReason(ITypeSymbol type, SendableSymbolClassifier classifier)
+    {
+        if (type is ITypeParameterSymbol)
+        {
+            return "a type parameter is unverifiable in a static: unlike a creation site, no closed instantiation is ever checked";
+        }
+
+        return classifier.GetNotSendableReason(type);
     }
 
     // The mandate boundary: the static's FILE must use MemoizR. Using directives sit at the

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -187,20 +187,54 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
         return classifier.GetNotSendableReason(type);
     }
 
-    // No depth cap: a declared type reference is a finite tree (each type argument is a
-    // strictly smaller reference), so the recursion terminates on its own -- and a cap would
-    // have to choose between failing open (a parameter buried one level past it silently
-    // trusted) and misreporting deep concrete types as parameters.
+    // No depth cap: the type graph is finite and the visited set breaks cycles, so the
+    // recursion terminates on its own -- and a cap would have to choose between failing open
+    // (a parameter buried one level past it silently trusted) and misreporting deep concrete
+    // types as parameters. Besides type arguments, MEMBER types of source-declared types are
+    // walked: a nested `sealed class Holder { public T Value ... }` carries the OUTER type
+    // parameter on its members, not in its own argument list, and the shared classifier's
+    // member walk would accept that T through the exemption this rule exists to remove.
     private static bool HasUnshieldedTypeParameter(ITypeSymbol type)
     {
-        return type switch
+        return HasUnshieldedTypeParameter(type, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+    }
+
+    private static bool HasUnshieldedTypeParameter(ITypeSymbol type, System.Collections.Generic.HashSet<ITypeSymbol> visited)
+    {
+        switch (type)
         {
-            ITypeParameterSymbol => true,
-            IArrayTypeSymbol array => HasUnshieldedTypeParameter(array.ElementType),
-            INamedTypeSymbol named when !SendableSymbolClassifier.HasSendableAttribute(named) =>
-                named.TypeArguments.Any(HasUnshieldedTypeParameter),
-            _ => false,
-        };
+            case ITypeParameterSymbol:
+                return true;
+            case IArrayTypeSymbol array:
+                return HasUnshieldedTypeParameter(array.ElementType, visited);
+            case INamedTypeSymbol named
+                when visited.Add(named) && !SendableSymbolClassifier.HasSendableAttribute(named):
+                return named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, visited))
+                    || MemberTypesOf(named).Any(memberType => HasUnshieldedTypeParameter(memberType, visited));
+            default:
+                return false;
+        }
+    }
+
+    private static System.Collections.Generic.IEnumerable<ITypeSymbol> MemberTypesOf(INamedTypeSymbol named)
+    {
+        if (!named.Locations.Any(location => location.IsInSource))
+        {
+            yield break; // metadata members are import-limited; framework internals carry no user T
+        }
+
+        foreach (var member in named.GetMembers())
+        {
+            switch (member)
+            {
+                case IFieldSymbol { IsStatic: false, IsImplicitlyDeclared: false } field:
+                    yield return field.Type;
+                    break;
+                case IPropertySymbol { IsStatic: false, GetMethod: not null } property:
+                    yield return property.Type;
+                    break;
+            }
+        }
     }
 
     // The mandate boundary: the static's FILE must use MemoizR. Using directives sit at the

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -123,16 +123,32 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
 
     // MZR001 gives unbound type parameters the benefit of the doubt because the closed
     // instantiation is checked at its own creation site. A static has NO later site: every
-    // closed C<T> mints a fresh process-wide slot no rule ever sees again, so here a type
-    // parameter is unverifiable rather than trusted.
+    // closed C<T> mints a fresh process-wide slot no rule ever sees again, so a type parameter
+    // ANYWHERE in the slot's type (T itself, ImmutableArray<T>, Holder<T>) is unverifiable
+    // rather than trusted. [Sendable]-attributed types are the one shield: their thread-safety
+    // assertion does not rest on the type arguments -- MemoizR's own nodes are internally
+    // synchronized for any T, and a Signal<T> static's closed T IS checked later, at the
+    // CreateSignal call that built the instance.
     private static string? NotSendableReason(ITypeSymbol type, SendableSymbolClassifier classifier)
     {
-        if (type is ITypeParameterSymbol)
+        if (HasUnshieldedTypeParameter(type, depth: 0))
         {
             return "a type parameter is unverifiable in a static: unlike a creation site, no closed instantiation is ever checked";
         }
 
         return classifier.GetNotSendableReason(type);
+    }
+
+    private static bool HasUnshieldedTypeParameter(ITypeSymbol type, int depth)
+    {
+        return depth <= 4 && type switch
+        {
+            ITypeParameterSymbol => true,
+            IArrayTypeSymbol array => HasUnshieldedTypeParameter(array.ElementType, depth + 1),
+            INamedTypeSymbol named when !SendableSymbolClassifier.HasSendableAttribute(named) =>
+                named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, depth + 1)),
+            _ => false,
+        };
     }
 
     // The mandate boundary: the static's FILE must use MemoizR. Using directives sit at the

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -197,10 +197,12 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
         {
             case ITypeParameterSymbol parameter:
                 // `where T : unmanaged` guarantees a no-reference value type for EVERY closed
-                // instantiation: reads hand out copies that can alias nothing, so the slot is
+                // instantiation (reads hand out copies that can alias nothing), and
+                // `where T : Enum` guarantees immutable values or immutable boxes -- both are
                 // safe without any creation-site check. (A plain `struct` constraint is NOT
-                // enough -- a struct can carry references to mutable objects.)
-                return !parameter.HasUnmanagedTypeConstraint;
+                // enough: a struct can carry references to mutable objects.)
+                return !parameter.HasUnmanagedTypeConstraint
+                    && !parameter.ConstraintTypes.Any(constraint => constraint.SpecialType == SpecialType.System_Enum);
             case IArrayTypeSymbol array:
                 return HasUnshieldedTypeParameter(array.ElementType, visited);
             case INamedTypeSymbol named

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -58,8 +58,10 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
     private static void Analyze(SymbolAnalysisContext context, SendableSymbolClassifier classifier, ConcurrentDictionary<SyntaxTree, bool> treeUsesMemoizR, System.Lazy<bool> hasGlobalMemoizRUsing)
     {
         var symbol = context.Symbol;
-        if (!symbol.IsStatic || symbol.IsImplicitlyDeclared)
+        if (!symbol.IsStatic || symbol.IsImplicitlyDeclared || symbol.IsAbstract)
         {
+            // A static ABSTRACT member is only a contract: the interface owns no storage --
+            // the implementing types own (and answer for) the actual slots.
             return;
         }
 

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -131,7 +131,7 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
     // CreateSignal call that built the instance.
     private static string? NotSendableReason(ITypeSymbol type, SendableSymbolClassifier classifier)
     {
-        if (HasUnshieldedTypeParameter(type, depth: 0))
+        if (HasUnshieldedTypeParameter(type))
         {
             return "a type parameter is unverifiable in a static: unlike a creation site, no closed instantiation is ever checked";
         }
@@ -139,14 +139,18 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
         return classifier.GetNotSendableReason(type);
     }
 
-    private static bool HasUnshieldedTypeParameter(ITypeSymbol type, int depth)
+    // No depth cap: a declared type reference is a finite tree (each type argument is a
+    // strictly smaller reference), so the recursion terminates on its own -- and a cap would
+    // have to choose between failing open (a parameter buried one level past it silently
+    // trusted) and misreporting deep concrete types as parameters.
+    private static bool HasUnshieldedTypeParameter(ITypeSymbol type)
     {
-        return depth <= 4 && type switch
+        return type switch
         {
             ITypeParameterSymbol => true,
-            IArrayTypeSymbol array => HasUnshieldedTypeParameter(array.ElementType, depth + 1),
+            IArrayTypeSymbol array => HasUnshieldedTypeParameter(array.ElementType),
             INamedTypeSymbol named when !SendableSymbolClassifier.HasSendableAttribute(named) =>
-                named.TypeArguments.Any(argument => HasUnshieldedTypeParameter(argument, depth + 1)),
+                named.TypeArguments.Any(HasUnshieldedTypeParameter),
             _ => false,
         };
     }

--- a/MemoizR.Analyzers/StaticStateAnalyzer.cs
+++ b/MemoizR.Analyzers/StaticStateAnalyzer.cs
@@ -99,7 +99,7 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
         var slotType = symbol switch
         {
             IFieldSymbol { IsConst: false } field => field.Type,
-            IPropertySymbol property when HasBackingSlot(property) => property.Type,
+            IPropertySymbol property when SendableSymbolClassifier.HasBackingSlot(property) => property.Type,
             _ => null,
         };
 
@@ -149,7 +149,7 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
             return "a settable slot";
         }
 
-        if (!HasBackingSlot(property))
+        if (!SendableSymbolClassifier.HasBackingSlot(property))
         {
             // A computed getter owns no static slot: a fresh value per call shares nothing,
             // and a getter handing out OTHER static state is flagged at that state's own
@@ -159,14 +159,6 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
 
         var reason = NotSendableReason(property.Type, classifier);
         return reason is null ? null : $"get-only, but of non-Sendable type {SendableSymbolClassifier.Display(property.Type)} ({reason})";
-    }
-
-    // Only auto-properties own a backing slot; the compiler ties it to the property via
-    // AssociatedSymbol.
-    private static bool HasBackingSlot(IPropertySymbol property)
-    {
-        return property.ContainingType.GetMembers().OfType<IFieldSymbol>()
-            .Any(field => SymbolEqualityComparer.Default.Equals(field.AssociatedSymbol, property));
     }
 
     // MZR001 gives unbound type parameters the benefit of the doubt because the closed
@@ -223,18 +215,31 @@ public sealed class StaticStateAnalyzer : DiagnosticAnalyzer
             yield break; // metadata members are import-limited; framework internals carry no user T
         }
 
-        foreach (var member in named.GetMembers())
+        // The base chain is walked like the classifier walks it: an INHERITED member stores
+        // state (and possibly an outer type parameter) exactly like a declared one. Only
+        // STORED members contribute -- explicit fields and auto-properties; a computed member
+        // (`public T New => default!`) holds no slot, the member-level analog of the
+        // top-level computed-getter exemption.
+        for (var current = named; current is not null && !IsRootType(current); current = current.BaseType)
         {
-            switch (member)
+            foreach (var member in current.GetMembers())
             {
-                case IFieldSymbol { IsStatic: false, IsImplicitlyDeclared: false } field:
-                    yield return field.Type;
-                    break;
-                case IPropertySymbol { IsStatic: false, GetMethod: not null } property:
-                    yield return property.Type;
-                    break;
+                switch (member)
+                {
+                    case IFieldSymbol { IsStatic: false, IsImplicitlyDeclared: false } field:
+                        yield return field.Type;
+                        break;
+                    case IPropertySymbol { IsStatic: false } property when SendableSymbolClassifier.HasBackingSlot(property):
+                        yield return property.Type;
+                        break;
+                }
             }
         }
+    }
+
+    private static bool IsRootType(INamedTypeSymbol type)
+    {
+        return type.SpecialType is SpecialType.System_Object or SpecialType.System_ValueType;
     }
 
     // The mandate boundary: the static's FILE must use MemoizR. Using directives sit at the

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -33,25 +33,62 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // The runtime-guard suggestion only holds where the guard exists: ValidateWrittenValues
+        // checks SIGNAL writes (values user code hands in); memo outputs publish unchecked.
+        var mitigation = IsSignalCreation(method)
+            ? ", or enable MemoFactoryOptions.ValidateWrittenValues to check written instances at runtime"
+            : " (memo outputs publish unchecked: ValidateWrittenValues covers signal writes only)";
+
         foreach (var typeArgument in method.TypeArguments)
         {
-            // Interfaces, abstract classes and object are MZR001's (Warning) territory already;
-            // green-listed framework types (Uri is not sealed!) are not plausibly subclassed by
-            // accident, and value types cannot be subclassed at all.
-            if (typeArgument is not INamedTypeSymbol named
-                || named.TypeKind != TypeKind.Class
-                || named.IsSealed
-                || named.IsAbstract
-                || named.SpecialType == SpecialType.System_Object
-                || SendableSymbolClassifier.IsFrameworkGreenListed(named))
+            // Smuggling hides inside Sendable CONTAINERS too (ImmutableArray<OpenBase>,
+            // Task<OpenBase>): the container passes the green-lists, but the non-sealed element
+            // type is the smuggle surface -- unfold nested type arguments.
+            foreach (var named in NamedTypesIn(typeArgument, depth: 0))
             {
-                continue;
+                if (IsSmuggleSurface(named))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.NonSealedValueType,
+                        ComputationLambdas.NameLocation(invocation),
+                        SendableSymbolClassifier.Display(named),
+                        mitigation));
+                }
             }
-
-            context.ReportDiagnostic(Diagnostic.Create(
-                DiagnosticDescriptors.NonSealedValueType,
-                ComputationLambdas.NameLocation(invocation),
-                SendableSymbolClassifier.Display(named)));
         }
+    }
+
+    private static System.Collections.Generic.IEnumerable<INamedTypeSymbol> NamedTypesIn(ITypeSymbol type, int depth)
+    {
+        if (depth > 4 || type is not INamedTypeSymbol named)
+        {
+            yield break;
+        }
+
+        yield return named;
+        foreach (var argument in named.TypeArguments)
+        {
+            foreach (var nested in NamedTypesIn(argument, depth + 1))
+            {
+                yield return nested;
+            }
+        }
+    }
+
+    // Interfaces, abstract classes and object are MZR001's (Warning) territory already;
+    // green-listed framework types (Uri is not sealed!) are not plausibly subclassed by
+    // accident, and value types cannot be subclassed at all.
+    private static bool IsSmuggleSurface(INamedTypeSymbol named)
+    {
+        return named.TypeKind == TypeKind.Class
+            && !named.IsSealed
+            && !named.IsAbstract
+            && named.SpecialType != SpecialType.System_Object
+            && !SendableSymbolClassifier.IsFrameworkGreenListed(named);
+    }
+
+    private static bool IsSignalCreation(IMethodSymbol method)
+    {
+        return method.Name is "CreateSignal" or "CreateEagerRelativeSignal" or "CreateActorSignal";
     }
 }

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -77,20 +78,26 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
             : " (ValidateWrittenValues cannot see it: the runtime check covers the written instance's own type, not contents nested inside it)";
     }
 
-    private static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(ITypeSymbol type, int depth)
+    internal static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(ITypeSymbol type, int depth)
     {
-        if (type is not INamedTypeSymbol named)
+        return NamedTypesIn(type, depth, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+    }
+
+    private static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(
+        ITypeSymbol type, int depth, System.Collections.Generic.HashSet<ITypeSymbol> visited)
+    {
+        if (type is not INamedTypeSymbol named || !visited.Add(type))
         {
             yield break;
         }
 
         yield return (named, depth);
 
-        // [Sendable]-attributed types shield their arguments: the thread-safety assertion does
-        // not rest on them -- Sending<T> DELIBERATELY wraps a non-Sendable payload for
-        // transfer, and a user-asserted container accounts for its contents. No depth cap
-        // otherwise: the declared type tree is finite, so the walk terminates on its own, and
-        // a cap would silently drop the hint for deeply nested surfaces.
+        // [Sendable]-attributed types shield their arguments and members: the thread-safety
+        // assertion does not rest on them -- Sending<T> DELIBERATELY wraps a non-Sendable
+        // payload for transfer, and a user-asserted container accounts for its contents. No
+        // depth cap otherwise: the type graph is finite and the visited set breaks cycles
+        // (self-referential records), so the walk terminates on its own.
         if (SendableSymbolClassifier.HasSendableAttribute(named))
         {
             yield break;
@@ -98,7 +105,37 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
 
         foreach (var argument in named.TypeArguments)
         {
-            foreach (var nested in NamedTypesIn(argument, depth + 1))
+            foreach (var nested in NamedTypesIn(argument, depth + 1, visited))
+            {
+                yield return nested;
+            }
+        }
+
+        // A sealed Sendable DTO hides the same hole in a MEMBER type (sealed record
+        // Box(OpenBase Value)): the classifier trusted OpenBase's declared structure, so the
+        // walk must visit the member types it trusted. Source-declared types only -- metadata
+        // members are import-limited, and framework internals are not the user's smuggle
+        // surface (green-listed containers already expose their payload via type arguments).
+        if (!named.Locations.Any(location => location.IsInSource))
+        {
+            yield break;
+        }
+
+        foreach (var member in named.GetMembers())
+        {
+            var memberType = member switch
+            {
+                IFieldSymbol { IsStatic: false, IsImplicitlyDeclared: false } field => field.Type,
+                IPropertySymbol { IsStatic: false, GetMethod: not null } property => property.Type,
+                _ => null,
+            };
+
+            if (memberType is null)
+            {
+                continue;
+            }
+
+            foreach (var nested in NamedTypesIn(memberType, depth + 1, visited))
             {
                 yield return nested;
             }
@@ -112,7 +149,7 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
     // or implementer -- the smuggle hole reopens exactly where the Error rule went quiet.
     // Green-listed framework types (Uri is not sealed!) are not plausibly subclassed by
     // accident, object stays MZR001's, and value types cannot be subclassed at all.
-    private static bool IsSmuggleSurface(INamedTypeSymbol named)
+    internal static bool IsSmuggleSurface(INamedTypeSymbol named)
     {
         if (named.SpecialType == SpecialType.System_Object || SendableSymbolClassifier.IsFrameworkGreenListed(named))
         {

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -10,7 +10,8 @@ namespace MemoizR.Analyzers;
 // documented limitation, which Swift closes by requiring Sendable classes to be final. Info
 // severity by design: non-sealed records are idiomatic and the hole only bites when an actual
 // mutable subclass exists; the runtime counterpart is MemoFactoryOptions.ValidateWrittenValues,
-// which checks each written instance's runtime type.
+// which checks each written instance's runtime type -- the instance's OWN type only, so the
+// hint suggests it solely where it can fire (top-level signal values, not nested contents).
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
 {
@@ -33,18 +34,19 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // The runtime-guard suggestion only holds where the guard exists: ValidateWrittenValues
-        // checks SIGNAL writes (values user code hands in); memo outputs publish unchecked.
-        var mitigation = IsSignalCreation(method)
-            ? ", or enable MemoFactoryOptions.ValidateWrittenValues to check written instances at runtime"
-            : " (memo outputs publish unchecked: ValidateWrittenValues covers signal writes only)";
+        // Smuggling is a hole in the Sendable checks; a factory that visibly opted out of them
+        // (DisableSendableChecks) has nothing to smuggle past, so the hint would be pure noise.
+        if (FactoryOptOut.DisablesSendableChecks(invocation))
+        {
+            return;
+        }
 
         foreach (var typeArgument in method.TypeArguments)
         {
             // Smuggling hides inside Sendable CONTAINERS too (ImmutableArray<OpenBase>,
             // Task<OpenBase>): the container passes the green-lists, but the non-sealed element
             // type is the smuggle surface -- unfold nested type arguments.
-            foreach (var named in NamedTypesIn(typeArgument, depth: 0))
+            foreach (var (named, depth) in NamedTypesIn(typeArgument, depth: 0))
             {
                 if (IsSmuggleSurface(named))
                 {
@@ -52,20 +54,37 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
                         DiagnosticDescriptors.NonSealedValueType,
                         ComputationLambdas.NameLocation(invocation),
                         SendableSymbolClassifier.Display(named),
-                        mitigation));
+                        Mitigation(method, depth)));
                 }
             }
         }
     }
 
-    private static System.Collections.Generic.IEnumerable<INamedTypeSymbol> NamedTypesIn(ITypeSymbol type, int depth)
+    // The runtime-guard suggestion only holds where the guard can actually fire:
+    // ValidateWrittenValues checks the WRITTEN INSTANCE's runtime type on SIGNAL writes. Memo
+    // outputs publish unchecked, and a surface nested inside a container
+    // (ImmutableArray<OpenBase>) is invisible to it -- the check sees the written container's
+    // type, never the contents behind it.
+    private static string Mitigation(IMethodSymbol method, int depth)
+    {
+        if (!IsSignalCreation(method))
+        {
+            return " (memo outputs publish unchecked: ValidateWrittenValues covers signal writes only)";
+        }
+
+        return depth == 0
+            ? ", or enable MemoFactoryOptions.ValidateWrittenValues to check written instances at runtime"
+            : " (ValidateWrittenValues cannot see it: the runtime check covers the written instance's own type, not contents nested inside it)";
+    }
+
+    private static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(ITypeSymbol type, int depth)
     {
         if (depth > 4 || type is not INamedTypeSymbol named)
         {
             yield break;
         }
 
-        yield return named;
+        yield return (named, depth);
         foreach (var argument in named.TypeArguments)
         {
             foreach (var nested in NamedTypesIn(argument, depth + 1))

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -200,10 +200,15 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
     // promise for itself), so the assertion binds the declaring author and NOT every subclass
     // or implementer -- the smuggle hole reopens exactly where the Error rule went quiet.
     // Green-listed framework types (Uri is not sealed!) are not plausibly subclassed by
-    // accident, object stays MZR001's, and value types cannot be subclassed at all.
+    // accident, object stays MZR001's, and value types cannot be subclassed at all. The
+    // exception is a surface whose green-listed GENERIC subclass the framework itself ships
+    // (Task <- Task<TResult>): no accident needed -- the creation check sees only the
+    // declared type, and ValidateWrittenValues is the net that catches the instance.
     internal static bool IsSmuggleSurface(INamedTypeSymbol named)
     {
-        if (named.SpecialType == SpecialType.System_Object || SendableSymbolClassifier.IsFrameworkGreenListed(named))
+        if (named.SpecialType == SpecialType.System_Object
+            || (SendableSymbolClassifier.IsFrameworkGreenListed(named)
+                && !SendableSymbolClassifier.HasAGreenListedGenericSubclass(named)))
         {
             return false;
         }

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -79,12 +79,23 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
 
     private static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(ITypeSymbol type, int depth)
     {
-        if (depth > 4 || type is not INamedTypeSymbol named)
+        if (type is not INamedTypeSymbol named)
         {
             yield break;
         }
 
         yield return (named, depth);
+
+        // [Sendable]-attributed types shield their arguments: the thread-safety assertion does
+        // not rest on them -- Sending<T> DELIBERATELY wraps a non-Sendable payload for
+        // transfer, and a user-asserted container accounts for its contents. No depth cap
+        // otherwise: the declared type tree is finite, so the walk terminates on its own, and
+        // a cap would silently drop the hint for deeply nested surfaces.
+        if (SendableSymbolClassifier.HasSendableAttribute(named))
+        {
+            yield break;
+        }
+
         foreach (var argument in named.TypeArguments)
         {
             foreach (var nested in NamedTypesIn(argument, depth + 1))

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -1,0 +1,57 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace MemoizR.Analyzers;
+
+// MZR006: the Sendable verdict is computed from the DECLARED type, so a non-sealed class can
+// smuggle a mutable subclass past the creation-time checks through an upcast -- ADR 0003's
+// documented limitation, which Swift closes by requiring Sendable classes to be final. Info
+// severity by design: non-sealed records are idiomatic and the hole only bites when an actual
+// mutable subclass exists; the runtime counterpart is MemoFactoryOptions.ValidateWrittenValues,
+// which checks each written instance's runtime type.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.NonSealedValueType);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(Analyze, OperationKind.Invocation);
+    }
+
+    private static void Analyze(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var method = invocation.TargetMethod;
+        if (!FactoryMethods.IsValueBearingCreation(method))
+        {
+            return;
+        }
+
+        foreach (var typeArgument in method.TypeArguments)
+        {
+            // Interfaces, abstract classes and object are MZR001's (Warning) territory already;
+            // green-listed framework types (Uri is not sealed!) are not plausibly subclassed by
+            // accident, and value types cannot be subclassed at all.
+            if (typeArgument is not INamedTypeSymbol named
+                || named.TypeKind != TypeKind.Class
+                || named.IsSealed
+                || named.IsAbstract
+                || named.SpecialType == SpecialType.System_Object
+                || SendableSymbolClassifier.IsFrameworkGreenListed(named))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.NonSealedValueType,
+                ComputationLambdas.NameLocation(invocation),
+                SendableSymbolClassifier.Display(named)));
+        }
+    }
+}

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -105,16 +105,27 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // Interfaces, abstract classes and object are MZR001's (Warning) territory already;
-    // green-listed framework types (Uri is not sealed!) are not plausibly subclassed by
-    // accident, and value types cannot be subclassed at all.
+    // Non-sealed concrete classes smuggle via ordinary upcasts. Abstract classes and
+    // interfaces are normally MZR001's (Error) territory -- EXCEPT when a [Sendable] assertion
+    // lets them pass: the attribute is deliberately not inherited (each type must make the
+    // promise for itself), so the assertion binds the declaring author and NOT every subclass
+    // or implementer -- the smuggle hole reopens exactly where the Error rule went quiet.
+    // Green-listed framework types (Uri is not sealed!) are not plausibly subclassed by
+    // accident, object stays MZR001's, and value types cannot be subclassed at all.
     private static bool IsSmuggleSurface(INamedTypeSymbol named)
     {
-        return named.TypeKind == TypeKind.Class
-            && !named.IsSealed
-            && !named.IsAbstract
-            && named.SpecialType != SpecialType.System_Object
-            && !SendableSymbolClassifier.IsFrameworkGreenListed(named);
+        if (named.SpecialType == SpecialType.System_Object || SendableSymbolClassifier.IsFrameworkGreenListed(named))
+        {
+            return false;
+        }
+
+        return named.TypeKind switch
+        {
+            TypeKind.Class when !named.IsAbstract => !named.IsSealed,
+            TypeKind.Class => SendableSymbolClassifier.HasSendableAttribute(named),
+            TypeKind.Interface => SendableSymbolClassifier.HasSendableAttribute(named),
+            _ => false,
+        };
     }
 
     private static bool IsSignalCreation(IMethodSymbol method)

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -23,10 +23,17 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterOperationAction(Analyze, OperationKind.Invocation);
+        // The classifier caches verdicts per type symbol, so it is scoped to one compilation.
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var classifier = new SendableSymbolClassifier();
+            compilationStart.RegisterOperationAction(
+                operationContext => Analyze(operationContext, classifier),
+                OperationKind.Invocation);
+        });
     }
 
-    private static void Analyze(OperationAnalysisContext context)
+    private static void Analyze(OperationAnalysisContext context, SendableSymbolClassifier classifier)
     {
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
@@ -44,6 +51,13 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
 
         foreach (var typeArgument in method.TypeArguments)
         {
+            // A type argument the Sendable classifier REJECTS is MZR001's territory: the
+            // value never passes the creation check, so there is no smuggle hole to hint at.
+            if (classifier.GetNotSendableReason(typeArgument) is not null)
+            {
+                continue;
+            }
+
             // Smuggling hides inside Sendable CONTAINERS too (ImmutableArray<OpenBase>,
             // Task<OpenBase>): the container passes the green-lists, but the non-sealed element
             // type is the smuggle surface -- unfold nested type arguments.

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -80,11 +80,16 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
 
     internal static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(ITypeSymbol type, int depth)
     {
-        return NamedTypesIn(type, depth, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+        return NamedTypesIn(
+            type,
+            depth,
+            new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default),
+            new System.Collections.Generic.List<INamedTypeSymbol>());
     }
 
     private static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(
-        ITypeSymbol type, int depth, System.Collections.Generic.HashSet<ITypeSymbol> visited)
+        ITypeSymbol type, int depth, System.Collections.Generic.HashSet<ITypeSymbol> visited,
+        System.Collections.Generic.List<INamedTypeSymbol> path)
     {
         if (type is not INamedTypeSymbol named || !visited.Add(type))
         {
@@ -103,27 +108,42 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        // Member re-instantiation can construct fresh symbols forever (Box<T> exposing
-        // Box<List<T>>), so the member walk needs a divergence bound -- but a
-        // once-per-DECLARATION gate is too coarse: the same nested declaration can return with
-        // DIFFERENT substitutions through its containing type (Outer<int>.Holder, then
-        // Outer<T>.Holder). The bound mirrors the classifier's: walk members while fewer than
-        // two same-definition types of non-greater size were already visited.
-        var definition = (INamedTypeSymbol)named.OriginalDefinition;
-        var priorNonShrinking = visited.Count(entry => entry is INamedTypeSymbol { } other
-            && !SymbolEqualityComparer.Default.Equals(other, named)
-            && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, definition)
-            && SendableSymbolClassifier.TypeSize(other) <= SendableSymbolClassifier.TypeSize(named));
-        var memberTypes = priorNonShrinking < 2
-            ? StoredMemberTypesOf(named)
-            : System.Linq.Enumerable.Empty<ITypeSymbol>();
-
-        foreach (var inner in named.TypeArguments.Concat(memberTypes))
+        foreach (var argument in named.TypeArguments)
         {
-            foreach (var nested in NamedTypesIn(inner, depth + 1, visited))
+            foreach (var nested in NamedTypesIn(argument, depth + 1, visited, path))
             {
                 yield return nested;
             }
+        }
+
+        // Member re-instantiation can construct fresh symbols forever (Box<T> exposing
+        // Box<List<T>>), so the member walk needs a divergence bound -- counted on the
+        // recursion PATH, not globally: sibling instantiations of one declaration are not
+        // recursion and must all be walked, while a divergent chain stacks same-definition
+        // ancestors.
+        var definition = (INamedTypeSymbol)named.OriginalDefinition;
+        var priorNonShrinking = path.Count(other =>
+            SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, definition)
+            && SendableSymbolClassifier.TypeSize(other) <= SendableSymbolClassifier.TypeSize(named));
+        if (priorNonShrinking >= 2)
+        {
+            yield break;
+        }
+
+        path.Add(named);
+        try
+        {
+            foreach (var memberType in StoredMemberTypesOf(named))
+            {
+                foreach (var nested in NamedTypesIn(memberType, depth + 1, visited, path))
+                {
+                    yield return nested;
+                }
+            }
+        }
+        finally
+        {
+            path.RemoveAt(path.Count - 1);
         }
     }
 

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -80,16 +80,11 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
 
     internal static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(ITypeSymbol type, int depth)
     {
-        return NamedTypesIn(
-            type,
-            depth,
-            new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default),
-            new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default));
+        return NamedTypesIn(type, depth, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
     }
 
     private static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(
-        ITypeSymbol type, int depth, System.Collections.Generic.HashSet<ITypeSymbol> visited,
-        System.Collections.Generic.HashSet<INamedTypeSymbol> walkedDefinitions)
+        ITypeSymbol type, int depth, System.Collections.Generic.HashSet<ITypeSymbol> visited)
     {
         if (type is not INamedTypeSymbol named || !visited.Add(type))
         {
@@ -109,15 +104,23 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
         }
 
         // Member re-instantiation can construct fresh symbols forever (Box<T> exposing
-        // Box<List<T>>), so the member walk runs once per DECLARATION: deeper
-        // re-instantiations substitute the same members with arguments already walked.
-        var memberTypes = walkedDefinitions.Add((INamedTypeSymbol)named.OriginalDefinition)
+        // Box<List<T>>), so the member walk needs a divergence bound -- but a
+        // once-per-DECLARATION gate is too coarse: the same nested declaration can return with
+        // DIFFERENT substitutions through its containing type (Outer<int>.Holder, then
+        // Outer<T>.Holder). The bound mirrors the classifier's: walk members while fewer than
+        // two same-definition types of non-greater size were already visited.
+        var definition = (INamedTypeSymbol)named.OriginalDefinition;
+        var priorNonShrinking = visited.Count(entry => entry is INamedTypeSymbol { } other
+            && !SymbolEqualityComparer.Default.Equals(other, named)
+            && SymbolEqualityComparer.Default.Equals(other.OriginalDefinition, definition)
+            && SendableSymbolClassifier.TypeSize(other) <= SendableSymbolClassifier.TypeSize(named));
+        var memberTypes = priorNonShrinking < 2
             ? StoredMemberTypesOf(named)
             : System.Linq.Enumerable.Empty<ITypeSymbol>();
 
         foreach (var inner in named.TypeArguments.Concat(memberTypes))
         {
-            foreach (var nested in NamedTypesIn(inner, depth + 1, visited, walkedDefinitions))
+            foreach (var nested in NamedTypesIn(inner, depth + 1, visited))
             {
                 yield return nested;
             }

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -80,11 +80,16 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
 
     internal static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(ITypeSymbol type, int depth)
     {
-        return NamedTypesIn(type, depth, new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+        return NamedTypesIn(
+            type,
+            depth,
+            new System.Collections.Generic.HashSet<ITypeSymbol>(SymbolEqualityComparer.Default),
+            new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default));
     }
 
     private static System.Collections.Generic.IEnumerable<(INamedTypeSymbol Named, int Depth)> NamedTypesIn(
-        ITypeSymbol type, int depth, System.Collections.Generic.HashSet<ITypeSymbol> visited)
+        ITypeSymbol type, int depth, System.Collections.Generic.HashSet<ITypeSymbol> visited,
+        System.Collections.Generic.HashSet<INamedTypeSymbol> walkedDefinitions)
     {
         if (type is not INamedTypeSymbol named || !visited.Add(type))
         {
@@ -103,9 +108,16 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        foreach (var inner in named.TypeArguments.Concat(StoredMemberTypesOf(named)))
+        // Member re-instantiation can construct fresh symbols forever (Box<T> exposing
+        // Box<List<T>>), so the member walk runs once per DECLARATION: deeper
+        // re-instantiations substitute the same members with arguments already walked.
+        var memberTypes = walkedDefinitions.Add((INamedTypeSymbol)named.OriginalDefinition)
+            ? StoredMemberTypesOf(named)
+            : System.Linq.Enumerable.Empty<ITypeSymbol>();
+
+        foreach (var inner in named.TypeArguments.Concat(memberTypes))
         {
-            foreach (var nested in NamedTypesIn(inner, depth + 1, visited))
+            foreach (var nested in NamedTypesIn(inner, depth + 1, visited, walkedDefinitions))
             {
                 yield return nested;
             }

--- a/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
+++ b/MemoizR.Analyzers/SubclassSmugglingAnalyzer.cs
@@ -103,41 +103,44 @@ public sealed class SubclassSmugglingAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        foreach (var argument in named.TypeArguments)
+        foreach (var inner in named.TypeArguments.Concat(StoredMemberTypesOf(named)))
         {
-            foreach (var nested in NamedTypesIn(argument, depth + 1, visited))
+            foreach (var nested in NamedTypesIn(inner, depth + 1, visited))
             {
                 yield return nested;
             }
         }
+    }
 
-        // A sealed Sendable DTO hides the same hole in a MEMBER type (sealed record
-        // Box(OpenBase Value)): the classifier trusted OpenBase's declared structure, so the
-        // walk must visit the member types it trusted. Source-declared types only -- metadata
-        // members are import-limited, and framework internals are not the user's smuggle
-        // surface (green-listed containers already expose their payload via type arguments).
+    // A sealed Sendable DTO hides the same hole in a MEMBER type (sealed record
+    // Box(OpenBase Value)): the classifier trusted OpenBase's declared structure, so the walk
+    // must visit the member types it trusted -- INHERITED ones included (the classifier walks
+    // base types), and only STORED ones (explicit fields and auto-properties; a computed
+    // member holds no slot). Source-declared types only -- metadata members are
+    // import-limited, and framework internals are not the user's smuggle surface (green-listed
+    // containers already expose their payload via type arguments).
+    private static System.Collections.Generic.IEnumerable<ITypeSymbol> StoredMemberTypesOf(INamedTypeSymbol named)
+    {
         if (!named.Locations.Any(location => location.IsInSource))
         {
             yield break;
         }
 
-        foreach (var member in named.GetMembers())
+        for (var current = named; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
         {
-            var memberType = member switch
+            foreach (var member in current.GetMembers())
             {
-                IFieldSymbol { IsStatic: false, IsImplicitlyDeclared: false } field => field.Type,
-                IPropertySymbol { IsStatic: false, GetMethod: not null } property => property.Type,
-                _ => null,
-            };
+                var memberType = member switch
+                {
+                    IFieldSymbol { IsStatic: false, IsImplicitlyDeclared: false } field => field.Type,
+                    IPropertySymbol { IsStatic: false } property when SendableSymbolClassifier.HasBackingSlot(property) => property.Type,
+                    _ => null,
+                };
 
-            if (memberType is null)
-            {
-                continue;
-            }
-
-            foreach (var nested in NamedTypesIn(memberType, depth + 1, visited))
-            {
-                yield return nested;
+                if (memberType is not null)
+                {
+                    yield return memberType;
+                }
             }
         }
     }

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -34,7 +34,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         foreach (var block in context.OperationBlocks)
         {
-            foreach (var (variable, transferPosition, scanRoots, transfer) in Transfers(block))
+            foreach (var (variable, transferPosition, scanRoots, escaped, transfer) in Transfers(block))
             {
                 // A using-declared local is Disposed by the SENDER at scope end -- after the
                 // handoff, with no source reference to scan for: destroying the object the
@@ -45,7 +45,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                ReportUsesAfter(context, scanRoots, variable, transferPosition);
+                ReportUsesAfter(context, scanRoots, escaped, variable, transferPosition);
             }
         }
     }
@@ -53,7 +53,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // Every Sending<T> creation (constructor or Sending.Transfer) whose argument is a
     // local/parameter reference, with the position the transfer happens at and the regions the
     // report walk covers.
-    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, IOperation Transfer)> Transfers(IOperation block)
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer)> Transfers(IOperation block)
     {
         foreach (var operation in block.DescendantsAndSelf())
         {
@@ -66,16 +66,56 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 _ => (false, null),
             };
 
-            if (!isTransfer || ReferencedVariable(TransferTarget(argument)) is not { } variable)
+            if (!isTransfer)
             {
                 continue;
             }
 
-            var scanRoots = ScanRootsFor(operation, EnclosingFunctionBody(operation, block));
-            if (scanRoots.Count > 0)
+            foreach (var source in TransferSources(argument))
             {
-                yield return (variable, operation.Syntax.Span.End, scanRoots, operation);
+                if (ReferencedVariable(source) is not { } variable)
+                {
+                    continue;
+                }
+
+                var (scanRoots, escaped) = ScanRootsFor(operation, EnclosingFunctionBody(operation, block));
+                if (scanRoots.Count > 0)
+                {
+                    yield return (variable, operation.Syntax.Span.End, scanRoots, escaped, operation);
+                }
             }
+        }
+    }
+
+    // The variables an argument expression can HAND OFF. An assignment transfers its target
+    // (Transfer(list = new(...)) / Transfer(list ??= new(...)): the variable aliases the value
+    // afterwards); a null-coalescing or conditional expression transfers whichever operand the
+    // runtime picks (Transfer(list ?? fallback), Transfer(c ? a : b)) -- each is a
+    // MAY-transfer, so each is tracked.
+    private static System.Collections.Generic.IEnumerable<IOperation> TransferSources(IOperation? argument)
+    {
+        switch (argument)
+        {
+            case IAssignmentOperation assignment:
+                yield return assignment.Target;
+                break;
+            case ICoalesceOperation coalesce:
+                foreach (var source in TransferSources(coalesce.Value).Concat(TransferSources(coalesce.WhenNull)))
+                {
+                    yield return source;
+                }
+
+                break;
+            case IConditionalOperation { WhenFalse: { } whenFalse } conditional:
+                foreach (var source in TransferSources(conditional.WhenTrue).Concat(TransferSources(whenFalse)))
+                {
+                    yield return source;
+                }
+
+                break;
+            case not null:
+                yield return argument;
+                break;
         }
     }
 
@@ -85,7 +125,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // lands in, and the FINALLY blocks of enclosing tries -- no such region, no sender-side
     // continuation at all. (break/continue are NOT exits: control resumes after the loop,
     // where later uses remain reachable, so they keep the full scope.)
-    private static List<IOperation> ScanRootsFor(IOperation transfer, IOperation scope)
+    private static (List<IOperation> Roots, bool Escaped) ScanRootsFor(IOperation transfer, IOperation scope)
     {
         var roots = new List<IOperation>();
         var escape = default(IOperation);
@@ -119,7 +159,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             roots.Add(scope);
         }
 
-        return roots;
+        return (roots, escape is not null);
     }
 
     // A THROWN transfer lands in the try's handlers -- when the throw came from the try BODY
@@ -139,15 +179,6 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // Transfer(list = new(...)) -- and the lazy-init form Transfer(list ??= new(...)): after
-    // the statement the variable ALIASES the transferred value on every path, so the
-    // assignment's target is what the sender keeps holding. IAssignmentOperation covers
-    // simple, coalesce and compound forms alike.
-    private static IOperation? TransferTarget(IOperation? argument)
-    {
-        return argument is IAssignmentOperation assignment ? assignment.Target : argument;
-    }
-
     // A transfer inside a nested callback only concerns the callback's own body: the outer
     // flow is not sequenced after it (the callback may run later or never), so its transfer
     // must not poison outer references. A transfer in the OUTER body rightly covers uses
@@ -165,7 +196,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return block;
     }
 
-    private static void ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, ISymbol variable, int transferPosition)
+    private static void ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition)
     {
         var scope = scanRoots[scanRoots.Count - 1]; // the outermost root is the reinit scope boundary
 
@@ -178,7 +209,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .SelectMany(root => root.DescendantsAndSelf())
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && operation.Syntax.SpanStart >= transferPosition
-                && !IsInASiblingArmOfTheTransfer(operation, transferPosition))
+                && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
+                && (escaped || !IsInAnUnreachableCatch(operation, transferPosition)))
             .OrderBy(operation => operation.Syntax.SpanStart);
 
         // Regions where a SKIPPED conditional reinitialization dominates: inside its own arm,
@@ -220,6 +252,26 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         foreach (var (region, position) in dominated)
         {
             if (start >= position && region.Contains(start))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // A catch handler observes a NON-ESCAPING transfer only through an exception thrown after
+    // it: when the transfer is the LAST operation of its try body, a completed handoff skips
+    // the handlers, and a throw from the transfer expression itself means no wrapper escaped.
+    // (Escaping thrown transfers scan their handlers deliberately: the throw carries the
+    // completed wrapper into them.)
+    private static bool IsInAnUnreachableCatch(IOperation use, int transferPosition)
+    {
+        for (IOperation child = use; child.Parent is { } parent; child = parent)
+        {
+            if (parent is ITryOperation { Body: { } body } && child is ICatchClauseOperation
+                && Covers(body, transferPosition)
+                && !body.Descendants().Any(operation => operation.Syntax.SpanStart >= transferPosition))
             {
                 return true;
             }
@@ -400,6 +452,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return scope.DescendantsAndSelf().OfType<IBranchOperation>().Any(branch =>
             branch.Syntax.SpanStart >= transferPosition
             && branch.Syntax.Span.End <= reinitPosition
+            // A branch in a mutually exclusive sibling arm of the transfer never runs on the
+            // path that transferred (`if (move) Transfer(list); else break;`): it cannot skip
+            // anything on that path.
+            && !IsInASiblingArmOfTheTransfer(branch, transferPosition)
             && CanSkipPast(branch, reinitPosition));
     }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -193,7 +193,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // nested switch or inner loop resumes inside the body, and the next MoveNext still runs.
     private static bool ExitsTheLoop(IOperation operation, IForEachLoopOperation loop)
     {
-        if (operation is IReturnOperation or IThrowOperation)
+        // yield return only SUSPENDS the iterator: the next MoveNext resumes inside the loop,
+        // so the foreach keeps iterating (yield break, like return, ends it for good).
+        if (operation is IReturnOperation { Kind: not OperationKind.YieldReturn } or IThrowOperation)
         {
             return true;
         }
@@ -250,9 +252,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     // The sub-expressions a compound argument carries into the handoff: whichever operand the
-    // runtime picks for ??/?:/switch expressions, EVERY element of a tuple or array
-    // (Transfer((list, 0)) / Transfer(new[] { list }): the container hands off its contents
-    // with it), and a conversion's operand. Null marks a leaf.
+    // runtime picks for ??/?:/switch expressions, EVERY element of a tuple, array or anonymous
+    // object (Transfer((list, 0)) / Transfer(new[] { list }) / Transfer(new { Value = list }):
+    // the container deterministically stores its contents, unlike an arbitrary object
+    // initializer's setters), and a conversion's operand. Null marks a leaf.
     private static System.Collections.Generic.IEnumerable<IOperation?>? CarriedParts(IOperation argument)
     {
         return argument switch
@@ -262,6 +265,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             ISwitchExpressionOperation switchExpression => switchExpression.Arms.Select(arm => (IOperation?)arm.Value),
             ITupleOperation tuple => tuple.Elements,
             IArrayCreationOperation { Initializer: { } initializer } => initializer.ElementValues,
+            IAnonymousObjectCreationOperation anonymous => anonymous.Initializers.Select(initializer =>
+                (IOperation?)(initializer is ISimpleAssignmentOperation member ? member.Value : initializer)),
             IConversionOperation conversion => new[] { conversion.Operand },
             _ => null,
         };
@@ -272,7 +277,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // observable from the escaping expression itself, the CATCH handlers a thrown transfer
     // lands in, and the FINALLY blocks of enclosing tries -- no such region, no sender-side
     // continuation at all. (break/continue are NOT exits: control resumes after the loop,
-    // where later uses remain reachable, so they keep the full scope.)
+    // where later uses remain reachable, so they keep the full scope. Neither is yield
+    // return: the iterator resumes right after it on the next MoveNext.)
     private static (List<IOperation> Roots, bool Escaped) ScanRootsFor(IOperation transfer, IOperation scope)
     {
         var roots = new List<IOperation>();
@@ -284,7 +290,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 break;
             }
 
-            if (parent is IReturnOperation or IThrowOperation)
+            if (parent is IReturnOperation { Kind: not OperationKind.YieldReturn } or IThrowOperation)
             {
                 if (escape is null)
                 {
@@ -493,8 +499,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     // Whether CALLING the local function reads the transferred value: the body is scanned in
-    // source order, and a body that REASSIGNS the variable (with a non-reading RHS) before any
-    // read only ever touches the fresh value.
+    // source order. A reassignment (with a non-reading RHS) that DEFINITELY runs before any
+    // read means the call only ever touches the fresh value; a CONDITIONAL one
+    // (`if (reset) list = new();`) may be skipped, so later reads still count -- except the
+    // ones it dominates (same arm, after it), which read the value it wrote.
     private static bool LocalFunctionReads(IMethodSymbol localFunction, ISymbol variable, IOperation scope)
     {
         var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
@@ -509,16 +517,52 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 && !IsInsideNameOf(operation))
             .OrderBy(operation => operation.Syntax.SpanStart);
 
+        var dominated = default(List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>);
         foreach (var reference in references)
         {
-            if (reference.Parent is ISimpleAssignmentOperation assignment
-                && ReferenceEquals(assignment.Target, reference))
+            if (IsDominatedByASkippedReinitialization(dominated, reference))
             {
-                return assignment.Value.DescendantsAndSelf().Any(operation =>
-                    SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+                continue;
             }
 
-            return true; // a plain read of the transferred value
+            if (reference.Parent is not ISimpleAssignmentOperation assignment
+                || !ReferenceEquals(assignment.Target, reference))
+            {
+                return true; // a plain read of the transferred value
+            }
+
+            if (assignment.Value.DescendantsAndSelf().Any(operation =>
+                    SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)))
+            {
+                return true; // the RHS builds the replacement FROM the transferred value
+            }
+
+            if (!IsConditionalWithin(assignment, declaration)
+                && !ABranchCanSkip(assignment, declaration.Syntax.SpanStart, declaration))
+            {
+                return false; // a definite reset: every call rewrites before any read
+            }
+
+            (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
+                .Add((DominatingRegion(assignment).Syntax.Span, reference.Syntax.Span.End));
+        }
+
+        return false;
+    }
+
+    // Whether control can reach past the operation without executing it, judged within the
+    // local function's body: any conditional/loop/switch/try ancestor below the declaration
+    // makes it skippable -- and a nested function's body is deferred entirely.
+    private static bool IsConditionalWithin(IOperation operation, ILocalFunctionOperation declaration)
+    {
+        for (var parent = operation.Parent; parent is not null && !ReferenceEquals(parent, declaration); parent = parent.Parent)
+        {
+            if (parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
+                or ILoopOperation or ITryOperation or IConditionalAccessOperation
+                or IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return true;
+            }
         }
 
         return false;

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -57,13 +57,20 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 _ => (false, null),
             };
 
-            if (!isTransfer || ReferencedVariable(argument) is not { } variable)
+            if (!isTransfer || ReferencedVariable(TransferTarget(argument)) is not { } variable)
             {
                 continue;
             }
 
             yield return (variable, operation.Syntax.Span.End, EnclosingFunctionBody(operation, block));
         }
+    }
+
+    // Transfer(list = new(...)): after the statement the variable ALIASES the transferred
+    // value -- the assignment's target is what the sender keeps holding.
+    private static IOperation? TransferTarget(IOperation? argument)
+    {
+        return argument is ISimpleAssignmentOperation assignment ? assignment.Target : argument;
     }
 
     // A transfer inside a nested callback only concerns the callback's own body: the outer
@@ -208,7 +215,32 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(outArgument, transferPosition, scope);
         }
 
+        // (list, _) = (...): a deconstruction target is definitely assigned like a
+        // simple-assignment target, with the same RHS-read caveat.
+        if (DeconstructionOf(reference) is { } deconstruction)
+        {
+            rhsUse = deconstruction.Value.DescendantsAndSelf()
+                .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+            return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(deconstruction, transferPosition, scope);
+        }
+
         return ReferenceRole.Use;
+    }
+
+    // The reference must be a tuple ELEMENT on the deconstruction's target side; a read nested
+    // inside an element expression (arr[list.Count]) is an ordinary use.
+    private static IDeconstructionAssignmentOperation? DeconstructionOf(IOperation reference)
+    {
+        var current = reference;
+        while (current.Parent is ITupleOperation or IConversionOperation)
+        {
+            current = current.Parent;
+        }
+
+        return current.Parent is IDeconstructionAssignmentOperation deconstruction
+            && ReferenceEquals(deconstruction.Target, current)
+            ? deconstruction
+            : null;
     }
 
     private static IOperation? SiblingArgumentRead(IArgumentOperation outArgument, ISymbol variable)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -705,39 +705,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 CallEffect: (BodyEffect?)CallEffectOf(invocation, variable, transferPosition, scope)))
             .Where(call => call.CallEffect != BodyEffect.None);
 
-        // Converting a READING local function to a delegate after the handoff escapes like a
-        // lambda: the delegate can run later with the retained alias (a resetting body makes
-        // no such promise -- it may never run).
-        var methodGroupEscapes = scanRoots
-            .SelectMany(root => root.DescendantsAndSelf())
-            .OfType<IMethodReferenceOperation>()
-            .Where(reference => reference.Method.MethodKind == MethodKind.LocalFunction
-                && reference.Syntax.SpanStart >= transferPosition
-                && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
-                && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
-                && !IsWithinALocalFunctionBody(reference, scanRoots)
-                && LocalFunctionCallEffect(reference.Method, variable, scope,
-                    new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)) == BodyEffect.Reads)
-            .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
-
-        // A stored delegate that CAPTURED the transferred variable and escapes after the
-        // handoff (returned, passed on, stored elsewhere) can run later against the
-        // receiver-owned object. Calls are classified separately, and a bare store target
-        // rewrites the local without running anything.
-        var delegateEscapes = scanRoots
-            .SelectMany(root => root.DescendantsAndSelf())
-            .OfType<ILocalReferenceOperation>()
-            .Where(reference => reference.Local.Type is { TypeKind: TypeKind.Delegate }
-                && reference.Syntax.SpanStart >= transferPosition
-                && !IsAStoreTargetOrInvokeReceiver(reference)
-                && !IsInsideNameOf(reference)
-                && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
-                && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
-                && !IsWithinALocalFunctionBody(reference, scanRoots)
-                && AnyStoredCallableReads(reference.Local, variable, reference, 0, scope))
-            .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
-
-        var orderedUses = laterReferences.Concat(callableCalls).Concat(methodGroupEscapes).Concat(delegateEscapes)
+        var orderedUses = laterReferences.Concat(callableCalls)
+            .Concat(EscapeUses(scanRoots, escaped, variable, transferPosition, scope))
             .OrderBy(use => use.Operation.Syntax.SpanStart);
 
         // Regions where a SKIPPED conditional reinitialization dominates: inside its own arm,
@@ -787,6 +756,42 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    // Post-transfer ESCAPES of callables that captured the transferred variable: a READING
+    // local function converted to a delegate, or a stored delegate reference leaving the
+    // scope -- both can run later against the receiver-owned object. Calls are classified
+    // separately; a bare store target rewrites the local without running anything, and a
+    // resetting body makes no promise (it may never run).
+    private static IEnumerable<(IOperation Operation, BodyEffect? CallEffect)> EscapeUses(
+        List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition, IOperation scope)
+    {
+        var methodGroupEscapes = scanRoots
+            .SelectMany(root => root.DescendantsAndSelf())
+            .OfType<IMethodReferenceOperation>()
+            .Where(reference => reference.Method.MethodKind == MethodKind.LocalFunction
+                && reference.Syntax.SpanStart >= transferPosition
+                && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
+                && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
+                && !IsWithinALocalFunctionBody(reference, scanRoots)
+                && LocalFunctionCallEffect(reference.Method, variable, scope,
+                    new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)) == BodyEffect.Reads)
+            .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
+
+        var delegateEscapes = scanRoots
+            .SelectMany(root => root.DescendantsAndSelf())
+            .OfType<ILocalReferenceOperation>()
+            .Where(reference => reference.Local.Type is { TypeKind: TypeKind.Delegate }
+                && reference.Syntax.SpanStart >= transferPosition
+                && !IsAStoreTargetOrInvokeReceiver(reference)
+                && !IsInsideNameOf(reference)
+                && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
+                && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
+                && !IsWithinALocalFunctionBody(reference, scanRoots)
+                && AnyStoredCallableReads(reference.Local, variable, reference, 0, scope))
+            .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
+
+        return methodGroupEscapes.Concat(delegateEscapes);
     }
 
     private static BodyEffect CallEffectOf(IInvocationOperation invocation, ISymbol variable, int transferPosition, IOperation scope)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -40,7 +40,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 // STATEMENT as its resource -- is Disposed by the SENDER at scope end, after
                 // the handoff, with no source reference to scan for: destroying the object the
                 // receiver now owns is a guaranteed use-after-transfer.
-                if (variable is ILocalSymbol { IsUsing: true } || IsDisposedByAnEnclosingUsing(transfer, variable))
+                if (variable is ILocalSymbol { IsUsing: true }
+                    || IsDisposedByAnEnclosingUsing(transfer, variable)
+                    || IsIteratedByAnEnclosingForeach(transfer, transferPosition, variable))
                 {
                     Report(context, transfer, variable);
                     continue;
@@ -97,15 +99,49 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 break; // a using outside the callback disposes on the OUTER flow's schedule
             }
 
+            // Only a resource that IS the variable disposes the handoff: `using (stream)`.
+            // A resource merely mentioning it (`using (new Scope(list.Count))`) disposes the
+            // wrapper, not the transferred object.
             if (parent is IUsingOperation usingOperation
-                && usingOperation.Resources.DescendantsAndSelf().Any(operation =>
-                    SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)))
+                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(usingOperation.Resources), variable))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // An enclosing foreach KEEPS READING its collection after the body iteration that
+    // performed the handoff: the next MoveNext is a sender-side use with no source reference
+    // -- unless the transfer's continuation definitely leaves the loop (a break/return/throw
+    // on the transfer's own conditional level).
+    private static bool IsIteratedByAnEnclosingForeach(IOperation transfer, int transferPosition, ISymbol variable)
+    {
+        for (var parent = transfer.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                break;
+            }
+
+            if (parent is IForEachLoopOperation foreachLoop
+                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(foreachLoop.Collection), variable)
+                && !DefinitelyExitsAfter(foreachLoop, transferPosition))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool DefinitelyExitsAfter(IForEachLoopOperation loop, int transferPosition)
+    {
+        return loop.Body.DescendantsAndSelf().Any(operation =>
+            operation.Syntax.SpanStart >= transferPosition
+            && operation is IReturnOperation or IThrowOperation or IBranchOperation { BranchKind: BranchKind.Break }
+            && IsOnTheTransfersConditionalLevel(operation, transferPosition));
     }
 
     // The variables an argument expression can HAND OFF. An assignment transfers its target
@@ -273,6 +309,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             switch (Classify(reference, variable, transferPosition, scope, out var rhsUse))
             {
                 case ReferenceRole.FreshValueFromHere:
+                    // A throwing RHS/out-call can reach an enclosing catch AFTER the handoff
+                    // but BEFORE the reinitialization completed: the handler still sees the
+                    // transferred value on that path.
+                    if (CatchUseDuringReinitialization(reference.Parent!, variable, scope) is { } windowUse)
+                    {
+                        Report(context, windowUse, variable);
+                    }
+
                     return; // a definite reinitialization: everything after is a new value
                 case ReferenceRole.ConditionalReinitialization:
                     (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
@@ -431,6 +475,42 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return reinitialization;
     }
 
+    // The exception WINDOW between the transfer and a completed reinitialization: when the
+    // reinitializing expression can throw (an invocation, creation or await), an enclosing
+    // catch entered from the try BODY observes the still-transferred value.
+    private static IOperation? CatchUseDuringReinitialization(IOperation reinitialization, ISymbol variable, IOperation scope)
+    {
+        var reinitRoot = reinitialization is IArgumentOperation { Parent: { } call } ? call : reinitialization;
+        var canThrow = reinitRoot.DescendantsAndSelf()
+            .Any(operation => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation);
+        if (!canThrow)
+        {
+            return null;
+        }
+
+        for (IOperation child = reinitRoot; child.Parent is { } parent && !ReferenceEquals(child, scope); child = parent)
+        {
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                break;
+            }
+
+            if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body))
+            {
+                var use = tryOperation.Catches
+                    .SelectMany(catchClause => catchClause.DescendantsAndSelf())
+                    .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                        && !IsInsideNameOf(operation));
+                if (use is not null)
+                {
+                    return use;
+                }
+            }
+        }
+
+        return null;
+    }
+
     private enum ReferenceRole { Use, FreshValueFromHere, ConditionalReinitialization }
 
     // A reference that REINITIALIZES the variable ends tracking when it definitely executes
@@ -455,7 +535,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         if (reference.Parent is IArgumentOperation { Parameter.RefKind: RefKind.Out } outArgument)
         {
-            rhsUse = SiblingArgumentRead(outArgument, variable);
+            rhsUse = SiblingArgumentRead(outArgument, variable, transferPosition);
             return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(outArgument, transferPosition, scope);
         }
 
@@ -488,7 +568,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             : null;
     }
 
-    private static IOperation? SiblingArgumentRead(IArgumentOperation outArgument, ISymbol variable)
+    private static IOperation? SiblingArgumentRead(IArgumentOperation outArgument, ISymbol variable, int transferPosition)
     {
         var arguments = outArgument.Parent switch
         {
@@ -497,9 +577,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             _ => ImmutableArray<IArgumentOperation>.Empty,
         };
 
+        // Position-filtered: when the same invocation performs the handoff
+        // (Reset(Sending.Transfer(list), out list)), the reference inside the transfer
+        // argument itself is the handoff, not a post-transfer read.
         return arguments.Where(argument => !ReferenceEquals(argument, outArgument))
             .SelectMany(argument => argument.Value.DescendantsAndSelf())
             .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                && operation.Syntax.SpanStart >= transferPosition
                 && !IsInsideNameOf(operation));
     }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -53,7 +53,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 // reads still inside the RHS (after the transfer) and the throw window count.
                 if (EnclosingReinitializingAssignment(transfer, variable) is { } enclosingReinit)
                 {
-                    if (!ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition, scope)
+                    if (!ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition, transfer, scope)
                         && CatchUseDuringReinitialization(enclosingReinit, variable, scope) is { } windowUse)
                     {
                         Report(context, windowUse, variable);
@@ -62,7 +62,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                ReportUsesAfter(context, scanRoots, escaped, variable, transferPosition, scope);
+                ReportUsesAfter(context, scanRoots, escaped, variable, transferPosition, transfer, scope);
             }
         }
     }
@@ -638,7 +638,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return block;
     }
 
-    private static bool ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition, IOperation scope)
+    private static bool ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition, IOperation transfer, IOperation scope)
     {
 
         // Source-ordered walk of every later reference. References in a MUTUALLY EXCLUSIVE
@@ -673,6 +673,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 // A call WRAPPING the transfer (Use(Sending.Transfer(list))) starts before it,
                 // but its body runs only after all arguments -- the handoff included.
                 && (invocation.Syntax.SpanStart >= transferPosition || Covers(invocation, transferPosition))
+                // A PROPAGATED transfer's own call site is the handoff, not a use of it.
+                && !ReferenceEquals(invocation, transfer)
                 && !IsInASiblingArmOfTheTransfer(invocation, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition))
                 && !IsWithinALocalFunctionBody(invocation, scanRoots))
@@ -680,7 +682,22 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 CallEffect: (BodyEffect?)CallEffectOf(invocation, variable, transferPosition, scope)))
             .Where(call => call.CallEffect != BodyEffect.None);
 
-        var orderedUses = laterReferences.Concat(callableCalls)
+        // Converting a READING local function to a delegate after the handoff escapes like a
+        // lambda: the delegate can run later with the retained alias (a resetting body makes
+        // no such promise -- it may never run).
+        var methodGroupEscapes = scanRoots
+            .SelectMany(root => root.DescendantsAndSelf())
+            .OfType<IMethodReferenceOperation>()
+            .Where(reference => reference.Method.MethodKind == MethodKind.LocalFunction
+                && reference.Syntax.SpanStart >= transferPosition
+                && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
+                && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
+                && !IsWithinALocalFunctionBody(reference, scanRoots)
+                && LocalFunctionCallEffect(reference.Method, variable, scope,
+                    new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)) == BodyEffect.Reads)
+            .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
+
+        var orderedUses = laterReferences.Concat(callableCalls).Concat(methodGroupEscapes)
             .OrderBy(use => use.Operation.Syntax.SpanStart);
 
         // Regions where a SKIPPED conditional reinitialization dominates: inside its own arm,
@@ -1047,12 +1064,36 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         return initializer.Initializers.SelectMany(element => element switch
         {
-            ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Property.IsIndexer: true } indexer } member =>
+            // Indexer sets and Add calls are KNOWN stores only on framework collections: a
+            // user-defined Add/setter may drop what it was handed, like a custom setter.
+            ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Property.IsIndexer: true } indexer } member
+                when IsFrameworkDeclared(indexer.Property.ContainingType) =>
                 indexer.Arguments.Select(argument => (IOperation?)argument.Value).Concat(new[] { (IOperation?)member.Value }),
             ISimpleAssignmentOperation member when StoresIntoACompilerKnownSlot(member) => new[] { (IOperation?)member.Value },
-            IInvocationOperation add => add.Arguments.Select(argument => (IOperation?)argument.Value),
+            IInvocationOperation add when IsFrameworkDeclared(add.TargetMethod.ContainingType) =>
+                add.Arguments.Select(argument => (IOperation?)argument.Value),
             _ => System.Linq.Enumerable.Empty<IOperation?>(),
         });
+    }
+
+    // Metadata types under the System root: their collection contracts store what they are
+    // handed. Source-declared types make no such promise.
+    private static bool IsFrameworkDeclared(INamedTypeSymbol? type)
+    {
+        if (type is null || type.Locations.Any(location => location.IsInSource))
+        {
+            return false;
+        }
+
+        for (var current = type.ContainingNamespace; current is { IsGlobalNamespace: false }; current = current.ContainingNamespace)
+        {
+            if (current.ContainingNamespace is { IsGlobalNamespace: true })
+            {
+                return current.Name == "System";
+            }
+        }
+
+        return false;
     }
 
     private static bool StoresIntoACompilerKnownSlot(ISimpleAssignmentOperation member)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -77,15 +77,31 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         {
             if (reference.Parent is ISimpleAssignmentOperation assignment && ReferenceEquals(assignment.Target, reference))
             {
-                return; // reassigned: the old, transferred value is gone
+                // A reassignment gives the variable a fresh value -- but only if its RHS does
+                // not itself READ the transferred one (`list = Clone(list)` uses it to build
+                // the replacement, which is exactly a use after transfer).
+                var rhsUse = assignment.Value.DescendantsAndSelf()
+                    .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+                if (rhsUse is null)
+                {
+                    return;
+                }
+
+                Report(context, rhsUse, variable);
+                return;
             }
 
-            context.ReportDiagnostic(Diagnostic.Create(
-                DiagnosticDescriptors.UseAfterTransfer,
-                reference.Syntax.GetLocation(),
-                variable.Name));
+            Report(context, reference, variable);
             return; // one report per transfer keeps the noise proportional
         }
+    }
+
+    private static void Report(OperationBlockAnalysisContext context, IOperation reference, ISymbol variable)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.UseAfterTransfer,
+            reference.Syntax.GetLocation(),
+            variable.Name));
     }
 
     private static ISymbol? ReferencedVariable(IOperation? operation)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -522,7 +522,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IConversionOperation conversion => new[] { conversion.Operand },
             // Tuple.Create(list) is the constructor spelling of a framework value carrier.
             IInvocationOperation { TargetMethod: { Name: "Create", ContainingType: { } factory } } factoryCall
-                when factory.Name is "Tuple" or "ValueTuple" && IsFrameworkDeclared(factory) =>
+                when factory.Name is "Tuple" or "ValueTuple" or "KeyValuePair" && IsFrameworkDeclared(factory) =>
                 factoryCall.Arguments.Select(argument => (IOperation?)argument.Value),
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are
@@ -1204,7 +1204,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // Everything an object creation deterministically stores: its initializer's
     // compiler-known slots -- and, for a POSITIONAL RECORD, the primary constructor's
     // arguments, each stored in its same-named auto-property.
-    private static System.Collections.Generic.IEnumerable<IOperation?> ObjectCreationCarriedParts(IObjectCreationOperation creation)
+    private static System.Collections.Generic.IEnumerable<IOperation?> ObjectCreationCarriedParts(
+        IObjectCreationOperation creation, HashSet<string>? alsoOverwritten = null)
     {
         if (creation.Initializer is { } initializer)
         {
@@ -1231,6 +1232,15 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
+        foreach (var carried in RecordConstructorCarriedParts(creation, alsoOverwritten))
+        {
+            yield return carried;
+        }
+    }
+
+    private static System.Collections.Generic.IEnumerable<IOperation?> RecordConstructorCarriedParts(
+        IObjectCreationOperation creation, HashSet<string>? alsoOverwritten)
+    {
         if (creation.Constructor is not { ContainingType: { IsRecord: true } recordType } constructor
             || !constructor.DeclaringSyntaxReferences.Any(reference =>
                 reference.GetSyntax() is Microsoft.CodeAnalysis.CSharp.Syntax.RecordDeclarationSyntax))
@@ -1238,11 +1248,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        var overwritten = new HashSet<string>(
-            (creation.Initializer?.Initializers ?? System.Collections.Immutable.ImmutableArray<IOperation>.Empty)
-                .OfType<ISimpleAssignmentOperation>()
-                .Select(member => (member.Target as IPropertyReferenceOperation)?.Property.Name)
-                .Where(name => name is not null)!);
+        var overwritten = OverwrittenSlots(creation.Initializer);
+        if (alsoOverwritten is not null)
+        {
+            overwritten.UnionWith(alsoOverwritten);
+        }
 
         foreach (var argument in creation.Arguments)
         {
@@ -1325,15 +1335,29 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         // The clone SHALLOW-COPIES the operand's slots: a compound operand unfolds its
-        // carried parts, and a leaf operand (a record variable) shares its reference-typed
-        // contents with the receiver-owned clone -- the variable itself is a source.
-        var operandParts = operand is null
-            ? System.Linq.Enumerable.Empty<IOperation?>()
-            : CarriedParts(operand) ?? new[] { (IOperation?)operand };
+        // carried parts -- minus slots the with-initializer definitely OVERWRITES -- and a
+        // leaf operand (a record variable) shares its reference-typed contents with the
+        // receiver-owned clone, so the variable itself is a source.
+        var overwritten = OverwrittenSlots(withOperation.Initializer);
+        var operandParts = operand switch
+        {
+            null => System.Linq.Enumerable.Empty<IOperation?>(),
+            IObjectCreationOperation creation => ObjectCreationCarriedParts(creation, overwritten),
+            _ => CarriedParts(operand) ?? new[] { (IOperation?)operand },
+        };
 
         return withOperation.Initializer is { } initializer
             ? operandParts.Concat(InitializerCarriedParts(initializer))
             : operandParts;
+    }
+
+    private static HashSet<string> OverwrittenSlots(IObjectOrCollectionInitializerOperation? initializer)
+    {
+        return new HashSet<string>(
+            (initializer?.Initializers ?? System.Collections.Immutable.ImmutableArray<IOperation>.Empty)
+                .OfType<ISimpleAssignmentOperation>()
+                .Select(member => (member.Target as IPropertyReferenceOperation)?.Property.Name)
+                .Where(name => name is not null)!);
     }
 
     private static bool RetainsItsSlot(IOperation? member)
@@ -1859,13 +1883,23 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 && Covers(parent, transferPosition)
                 && !Covers(child, transferPosition)
                 && !Covers(dominatingPart, transferPosition)
-                && !IsInACaseGuard(parent, transferPosition))
+                && !IsInACaseGuard(parent, transferPosition)
+                // goto case/default re-enters a sibling arm: the arms are not mutually
+                // exclusive when the transfer's own case jumps on.
+                && !(parent is ISwitchOperation switchOperation && TheTransfersCaseJumpsOn(switchOperation, transferPosition)))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private static bool TheTransfersCaseJumpsOn(ISwitchOperation switchOperation, int transferPosition)
+    {
+        var transferCase = switchOperation.Cases.FirstOrDefault(switchCase => Covers(switchCase, transferPosition));
+        return transferCase is not null
+            && transferCase.Descendants().Any(operation => operation is IBranchOperation { BranchKind: BranchKind.GoTo });
     }
 
     // A `when` guard is arm-SELECTION machinery, not an arm: a failing guard falls through to

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -59,7 +59,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 if (EnclosingReinitializingAssignment(transfer, variable) is { } enclosingReinit)
                 {
                     var reported = ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition, transfer, scope);
-                    if (!reported && CatchUseDuringReinitialization(enclosingReinit, variable, scope) is { } windowUse)
+                    if (!reported && CatchUseDuringReinitialization(enclosingReinit, variable, transferPosition, scope) is { } windowUse)
                     {
                         Report(context, windowUse, variable);
                         reported = true;
@@ -794,7 +794,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     // A throwing RHS/out-call can reach an enclosing catch AFTER the handoff
                     // but BEFORE the reinitialization completed: the handler still sees the
                     // transferred value on that path.
-                    if (CatchUseDuringReinitialization(reference.Parent!, variable, scope) is { } windowUse)
+                    if (CatchUseDuringReinitialization(reference.Parent!, variable, transferPosition, scope) is { } windowUse)
                     {
                         Report(context, windowUse, variable);
                         return true;
@@ -889,7 +889,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
-        if (CatchUseDuringReinitialization(call, variable, scope) is { } windowUse)
+        if (CatchUseDuringReinitialization(call, variable, transferPosition, scope) is { } windowUse)
         {
             Report(context, windowUse, variable);
             return true;
@@ -1035,11 +1035,6 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     private static bool ClauseCanCatch(ICatchClauseOperation catchClause, IThrowOperation thrown)
     {
-        if (catchClause.Filter is not null)
-        {
-            return true; // a filter may pass
-        }
-
         var exception = thrown.Exception;
         while (exception is IConversionOperation conversion)
         {
@@ -1051,6 +1046,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        // C# tests the clause TYPE before evaluating any filter: a filtered clause of an
+        // unrelated type never receives the throw -- the filter only matters (and may
+        // pass) once the type gate admits it.
         return catchClause.ExceptionType is not { } caughtType
             || caughtType.SpecialType == SpecialType.System_Object
             || SelfAndBases(thrownType).Contains(caughtType, SymbolEqualityComparer.Default);
@@ -1518,6 +1516,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     or IArrayInitializerOperation or IObjectOrCollectionInitializerOperation
                     or IArrayCreationOperation or IAnonymousObjectCreationOperation:
                     continue; // wrappers: the payload rides along
+                // value-selecting expressions: either arm can BE the result (`flag ? use
+                // : null`), so the payload rides -- a reference in the CONDITION or the
+                // governing value is only examined, never published.
+                case IConditionalOperation conditional when !ReferenceEquals(child, conditional.Condition):
+                    continue;
+                case ICoalesceOperation:
+                    continue;
+                case ISwitchExpressionArmOperation arm when ReferenceEquals(child, arm.Value):
+                    continue;
+                case ISwitchExpressionOperation switchExpression when !ReferenceEquals(child, switchExpression.Value):
+                    continue;
                 case IReturnOperation { Kind: not OperationKind.YieldBreak }:
                     return true;
                 case IArgumentOperation:
@@ -1549,7 +1558,26 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        return ReferencedVariable(receiver);
+        return ReferencedSlot(receiver);
+    }
+
+    // The slot a delegate lives in: a local, a parameter, or a field/property on the
+    // method's OWN instance (`this.use` and bare `use` name the same slot; another
+    // instance's slot is not this one). Cross-method mutation of such a slot stays
+    // invisible, matching the best-effort store model.
+    private static ISymbol? ReferencedSlot(IOperation? reference)
+    {
+        if (ReferencedVariable(reference) is { } variable)
+        {
+            return variable;
+        }
+
+        return reference switch
+        {
+            IFieldReferenceOperation { Instance: null or IInstanceReferenceOperation } field => field.Field,
+            IPropertyReferenceOperation { Instance: null or IInstanceReferenceOperation } property => property.Property,
+            _ => null,
+        };
     }
 
     // Every callable stored in the delegate local that can still be its value AT THE CALL:
@@ -1600,7 +1628,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             // Action use = use2 (alone or inside a combine): the copy SNAPSHOTS what the
             // source holds AT THE COPY -- stores landing in the source afterwards are not
             // in use's invocation list.
-            if (ReferencedVariable(item) is { } alias)
+            if (ReferencedSlot(item) is { } alias)
             {
                 foreach (var carried in StoredCallables(alias, scope, site, transferPosition, visited))
                 {
@@ -1645,7 +1673,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         foreach (var operation in scope.DescendantsAndSelf())
         {
             if (operation is ICompoundAssignmentOperation { OperatorKind: BinaryOperatorKind.Subtract } removal
-                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(removal.Target), delegateLocal)
+                && SymbolEqualityComparer.Default.Equals(ReferencedSlot(removal.Target), delegateLocal)
                 && operation.Syntax.Span.End <= consumer.Syntax.SpanStart
                 && !IsConditionalWithin(removal, scope)
                 && Callable(removal.Value) is IMethodReferenceOperation methodReference)
@@ -1670,11 +1698,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                         && declarator.Initializer is { } initializer
                     => (initializer.Value, true),
                 ISimpleAssignmentOperation assignment
-                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(assignment.Target), delegateLocal)
+                    when SymbolEqualityComparer.Default.Equals(ReferencedSlot(assignment.Target), delegateLocal)
                     => (assignment.Value, true),
                 // use += adds a target; -= only removes, storing nothing.
                 ICompoundAssignmentOperation { OperatorKind: BinaryOperatorKind.Add } combined
-                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(combined.Target), delegateLocal)
+                    when SymbolEqualityComparer.Default.Equals(ReferencedSlot(combined.Target), delegateLocal)
                     => (combined.Value, false),
                 _ => null,
             };
@@ -1682,14 +1710,65 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             if (matched is { } store
                 && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
                 && (operation.Syntax.SpanStart < consumer.Syntax.Span.End || SharesALoopWith(operation, consumer))
-                // A store inside a local function nothing ever invokes never executed.
-                && !IsInAnUnreferencedNestedFunction(operation, scope))
+                && NestedStoreCanBeCurrent(operation, scope, consumer))
             {
                 stores.Add((operation, store.Value, store.Replaces));
             }
         }
 
         return stores;
+    }
+
+    // A store inside a nested local function is in the list at the call only if its
+    // function can have RUN by then: an invocation source-before the consumer (or carried
+    // back around by a loop) qualifies -- transitively so when that invocation itself sits
+    // in a nested function -- and a method-group lift may travel and run anywhere. A
+    // function nothing references cannot have run at all.
+    private static bool NestedStoreCanBeCurrent(IOperation store, IOperation scope, IOperation consumer)
+    {
+        for (var parent = store.Parent; parent is not null && !ReferenceEquals(parent, scope); parent = parent.Parent)
+        {
+            if (parent is ILocalFunctionOperation nested
+                && !CanHaveRunBefore(nested.Symbol, scope, consumer, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool CanHaveRunBefore(IMethodSymbol localFunction, IOperation scope, IOperation consumer, HashSet<IMethodSymbol> visited)
+    {
+        if (!visited.Add(localFunction.OriginalDefinition))
+        {
+            return false;
+        }
+
+        return scope.DescendantsAndSelf().Any(operation => operation switch
+        {
+            IInvocationOperation invocation
+                when SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.OriginalDefinition, localFunction.OriginalDefinition)
+                => (operation.Syntax.SpanStart < consumer.Syntax.Span.End || SharesALoopWith(operation, consumer))
+                    && NestedCallSiteCanRun(operation, scope, consumer, visited),
+            IMethodReferenceOperation methodReference
+                => SymbolEqualityComparer.Default.Equals(methodReference.Method.OriginalDefinition, localFunction.OriginalDefinition),
+            _ => false,
+        });
+    }
+
+    private static bool NestedCallSiteCanRun(IOperation callSite, IOperation scope, IOperation consumer, HashSet<IMethodSymbol> visited)
+    {
+        for (var parent = callSite.Parent; parent is not null && !ReferenceEquals(parent, scope); parent = parent.Parent)
+        {
+            if (parent is ILocalFunctionOperation nested
+                && !CanHaveRunBefore(nested.Symbol, scope, consumer, visited))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool SharesALoopWith(IOperation store, IOperation consumer)
@@ -1865,8 +1944,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 or IDynamicIndexerAccessOperation or IDynamicObjectCreationOperation
                 or IEventAssignmentOperation
                 // scope exits dispose: Dispose/DisposeAsync is user code and can throw;
-                // a foreach hides MoveNext/Dispose calls on a possibly-custom enumerator
-                or IUsingOperation or IUsingDeclarationOperation or IForEachLoopOperation,
+                // a foreach hides MoveNext/Dispose calls on a possibly-custom enumerator;
+                // a lock's hidden Monitor.Enter throws on a null gate
+                or IUsingOperation or IUsingDeclarationOperation or IForEachLoopOperation
+                or ILockOperation,
         };
     }
 
@@ -1980,13 +2061,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // The exception WINDOW between the transfer and a completed reinitialization: when the
     // reinitializing expression can throw (an invocation, creation or await), an enclosing
     // catch entered from the try BODY observes the still-transferred value.
-    private static IOperation? CatchUseDuringReinitialization(IOperation reinitialization, ISymbol variable, IOperation scope)
+    private static IOperation? CatchUseDuringReinitialization(IOperation reinitialization, ISymbol variable, int transferPosition, IOperation scope)
     {
         var reinitRoot = reinitialization is IArgumentOperation { Parent: { } call } ? call : reinitialization;
-        var failures = reinitRoot.DescendantsAndSelf()
-            .Where(operation => CanThrow(operation)
-                && (operation is IThrowOperation || !IsInsideAThrow(operation)))
-            .ToList();
+        // Only failures once the wrapper EXISTS open the window: a throw from the transfer
+        // expression itself (or earlier RHS work) means nothing escaped, and operations in
+        // sibling arms or nested functions never run on this path at all.
+        var failures = ThrowCapableOpsAfter(reinitRoot, transferPosition).ToList();
         if (failures.Count == 0)
         {
             return null;

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -119,17 +119,19 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // A transfer inside a CALLED local function is sequenced before the caller's
         // continuation: every call site acts as a transfer of its own. Lambdas stay
         // deferred-scoped (they may run later or never).
-        foreach (var propagated in CallSiteTransfers(enclosingBody, block,
+        foreach (var propagated in CallSiteTransfers(enclosingBody, variable, block,
             new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
         {
-            yield return (variable, propagated.Position, propagated.Roots, propagated.Escaped, propagated.Site, propagated.Scope);
+            yield return propagated;
         }
     }
 
-    // Call sites of the local function whose body contains the transfer -- transitively:
-    // a call inside ANOTHER declaration only runs through that declaration's own callers.
-    private static IEnumerable<(int Position, List<IOperation> Roots, bool Escaped, IOperation Site, IOperation Scope)> CallSiteTransfers(
-        IOperation transferBody, IOperation block, HashSet<IMethodSymbol> visited)
+    // Call sites of the local function whose body contains the transfer -- direct calls and
+    // DELEGATE-CARRIED ones -- transitively: a call inside ANOTHER declaration only runs
+    // through that declaration's own callers. A transferred PARAMETER remaps to the caller's
+    // argument at each site.
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> CallSiteTransfers(
+        IOperation transferBody, ISymbol variable, IOperation block, HashSet<IMethodSymbol> visited)
     {
         if (transferBody is not ILocalFunctionOperation declaration || !visited.Add(declaration.Symbol))
         {
@@ -138,7 +140,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         foreach (var invocation in block.DescendantsAndSelf().OfType<IInvocationOperation>())
         {
-            if (!SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.OriginalDefinition, declaration.Symbol))
+            if (!InvokesTheDeclaration(invocation, declaration, block))
             {
                 continue;
             }
@@ -149,9 +151,21 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue; // self-recursion: the body scan already covers it
             }
 
+            foreach (var entry in CallSiteEntries(invocation, callBody, variable, declaration, block, visited))
+            {
+                yield return entry;
+            }
+        }
+    }
+
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> CallSiteEntries(
+        IInvocationOperation invocation, IOperation callBody, ISymbol variable, ILocalFunctionOperation declaration, IOperation block, HashSet<IMethodSymbol> visited)
+    {
+        foreach (var callVariable in CallSiteVariables(invocation, variable, declaration))
+        {
             if (callBody is ILocalFunctionOperation)
             {
-                foreach (var nested in CallSiteTransfers(callBody, block, visited))
+                foreach (var nested in CallSiteTransfers(callBody, callVariable, block, visited))
                 {
                     yield return nested;
                 }
@@ -162,7 +176,47 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             var (roots, escaped) = ScanRootsFor(invocation, callBody);
             if (roots.Count > 0)
             {
-                yield return (invocation.Syntax.Span.End, roots, escaped, invocation, callBody);
+                yield return (callVariable, invocation.Syntax.Span.End, roots, escaped, invocation, callBody);
+            }
+        }
+    }
+
+    private static bool InvokesTheDeclaration(IInvocationOperation invocation, ILocalFunctionOperation declaration, IOperation block)
+    {
+        // move() runs Move when the delegate local can hold it at the call.
+        if (invocation.TargetMethod.MethodKind == MethodKind.DelegateInvoke)
+        {
+            return DelegateReceiver(invocation) is { } receiver
+                && StoredCallables(receiver, block, invocation, transferPosition: 0, new HashSet<ISymbol>(SymbolEqualityComparer.Default))
+                    .OfType<IMethodReferenceOperation>()
+                    .Any(reference => SymbolEqualityComparer.Default.Equals(reference.Method.OriginalDefinition, declaration.Symbol));
+        }
+
+        return SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.OriginalDefinition, declaration.Symbol);
+    }
+
+    // The caller-side variable the transferred callee variable aliases at THIS call: a
+    // captured local stays itself; a PARAMETER maps to the matching argument's sources.
+    private static IEnumerable<ISymbol> CallSiteVariables(IInvocationOperation invocation, ISymbol variable, ILocalFunctionOperation declaration)
+    {
+        if (variable is not IParameterSymbol parameter
+            || !SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol.OriginalDefinition, declaration.Symbol))
+        {
+            yield return variable;
+            yield break;
+        }
+
+        var argument = invocation.Arguments.FirstOrDefault(candidate => candidate.Parameter?.Ordinal == parameter.Ordinal);
+        if (argument is null)
+        {
+            yield break;
+        }
+
+        foreach (var source in TransferSources(argument.Value))
+        {
+            if (ReferencedVariable(source) is { } mapped)
+            {
+                yield return mapped;
             }
         }
     }
@@ -187,14 +241,41 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             // assigns the fresh element to the variable right after its RHS evaluated.
             if (parent is IDeconstructionAssignmentOperation deconstruction
                 && !ReferenceEquals(child, deconstruction.Target)
-                && deconstruction.Target.DescendantsAndSelf()
-                    .Any(element => SymbolEqualityComparer.Default.Equals(ReferencedVariable(element), variable)))
+                && DeconstructionFreshlyResets(deconstruction, variable))
             {
                 return deconstruction;
             }
         }
 
         return null;
+    }
+
+    // Only the POSITIONALLY MATCHED RHS element decides: `(list, _) = (list, Transfer(list))`
+    // writes the transferred reference back into the variable, resetting nothing. A
+    // non-tuple RHS (a method returning a tuple) is opaque -- it could return the same
+    // object -- so tracking continues.
+    private static bool DeconstructionFreshlyResets(IDeconstructionAssignmentOperation deconstruction, ISymbol variable)
+    {
+        var value = deconstruction.Value;
+        while (value is IConversionOperation conversion)
+        {
+            value = conversion.Operand;
+        }
+
+        if (deconstruction.Target is not ITupleOperation targets || value is not ITupleOperation values)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < targets.Elements.Length && i < values.Elements.Length; i++)
+        {
+            if (SymbolEqualityComparer.Default.Equals(ReferencedVariable(targets.Elements[i]), variable))
+            {
+                return ReadWithin(values.Elements[i], variable) is null;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsDisposedByAnEnclosingUsing(IOperation transfer, ISymbol variable)
@@ -370,19 +451,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IArrayCreationOperation { Initializer: { } initializer } => initializer.ElementValues,
             IAnonymousObjectCreationOperation anonymous => anonymous.Initializers.Select(initializer =>
                 (IOperation?)(initializer is ISimpleAssignmentOperation member ? member.Value : initializer)),
-            IObjectCreationOperation { Initializer: { } objectInitializer } => objectInitializer.Initializers
-                .SelectMany(element => element switch
-                {
-                    // Member writes carry through compiler-known slots only; an INDEXER
-                    // initializer (["x"] = list) stores value AND keys into the collection;
-                    // a collection initializer's Add elements carry like collection
-                    // expressions.
-                    ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Property.IsIndexer: true } indexer } member =>
-                        indexer.Arguments.Select(argument => (IOperation?)argument.Value).Concat(new[] { (IOperation?)member.Value }),
-                    ISimpleAssignmentOperation member when StoresIntoACompilerKnownSlot(member) => new[] { (IOperation?)member.Value },
-                    IInvocationOperation add => add.Arguments.Select(argument => (IOperation?)argument.Value),
-                    _ => System.Linq.Enumerable.Empty<IOperation?>(),
-                }),
+            IObjectCreationOperation { Initializer: { } objectInitializer } => InitializerCarriedParts(objectInitializer),
+            // box with { Value = list }: the receiver's CLONE carries the same reference in
+            // its slot. The operand itself stays a leaf like a spread's: the original object
+            // is not handed off, only its contents are copied into the clone.
+            IWithOperation { Initializer: { } withInitializer } => InitializerCarriedParts(withInitializer),
             IConversionOperation conversion => new[] { conversion.Operand },
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are
@@ -937,6 +1010,21 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    // Member writes carry through compiler-known slots only; an INDEXER initializer
+    // (["x"] = list) stores value AND keys into the collection; a collection initializer's
+    // Add elements carry like collection expressions.
+    private static System.Collections.Generic.IEnumerable<IOperation?> InitializerCarriedParts(IObjectOrCollectionInitializerOperation initializer)
+    {
+        return initializer.Initializers.SelectMany(element => element switch
+        {
+            ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Property.IsIndexer: true } indexer } member =>
+                indexer.Arguments.Select(argument => (IOperation?)argument.Value).Concat(new[] { (IOperation?)member.Value }),
+            ISimpleAssignmentOperation member when StoresIntoACompilerKnownSlot(member) => new[] { (IOperation?)member.Value },
+            IInvocationOperation add => add.Arguments.Select(argument => (IOperation?)argument.Value),
+            _ => System.Linq.Enumerable.Empty<IOperation?>(),
+        });
+    }
+
     private static bool StoresIntoACompilerKnownSlot(ISimpleAssignmentOperation member)
     {
         return member.Target is IFieldReferenceOperation
@@ -1263,7 +1351,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IUnaryOperation unary => unary.OperatorMethod is not null,
             IBinaryOperation binary => binary.OperatorMethod is not null,
             _ => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
-                or IPropertyReferenceOperation or IArrayElementReferenceOperation,
+                or IPropertyReferenceOperation or IArrayElementReferenceOperation or IThrowOperation,
         };
     }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -188,7 +188,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         foreach (var invocation in block.DescendantsAndSelf().OfType<IInvocationOperation>())
         {
-            if (!InvokesTheBody(invocation, transferBody, functionSymbol, block))
+            if (!InvokesTheBody(invocation, transferBody, functionSymbol, anchor, block))
+            {
+                continue;
+            }
+
+            // A call in a mutually exclusive sibling arm of the store/transfer never runs
+            // on the path that stored the transferring callable.
+            if (IsInASiblingArmOfTheTransfer(invocation, anchor.Syntax.Span.End))
             {
                 continue;
             }
@@ -229,14 +236,15 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool InvokesTheBody(IInvocationOperation invocation, IOperation transferBody, IMethodSymbol functionSymbol, IOperation block)
+    private static bool InvokesTheBody(IInvocationOperation invocation, IOperation transferBody, IMethodSymbol functionSymbol, IOperation anchor, IOperation block)
     {
         // move() runs the body when the delegate local can hold it at the call -- a stored
-        // METHOD GROUP matches by symbol, a stored LAMBDA by the operation itself.
+        // METHOD GROUP matches by symbol, a stored LAMBDA by the operation itself. Stores
+        // resolve against the real anchor so sibling-arm stores stay excluded.
         if (invocation.TargetMethod.MethodKind == MethodKind.DelegateInvoke)
         {
             return DelegateReceiver(invocation) is { } receiver
-                && StoredCallables(receiver, block, invocation, transferPosition: 0, new HashSet<ISymbol>(SymbolEqualityComparer.Default))
+                && StoredCallables(receiver, block, invocation, anchor.Syntax.Span.End, new HashSet<ISymbol>(SymbolEqualityComparer.Default))
                     .Any(callable => ReferenceEquals(callable, transferBody)
                         || (callable is IMethodReferenceOperation methodReference
                             && SymbolEqualityComparer.Default.Equals(methodReference.Method.OriginalDefinition, functionSymbol)));
@@ -512,6 +520,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             // off, only copied from).
             IWithOperation withOperation => WithCarriedParts(withOperation),
             IConversionOperation conversion => new[] { conversion.Operand },
+            // Tuple.Create(list) is the constructor spelling of a framework value carrier.
+            IInvocationOperation { TargetMethod: { Name: "Create", ContainingType: { } factory } } factoryCall
+                when factory.Name is "Tuple" or "ValueTuple" && IsFrameworkDeclared(factory) =>
+                factoryCall.Arguments.Select(argument => (IOperation?)argument.Value),
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are
             // walkable regardless.
@@ -873,7 +885,44 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        // The callee can fail BEFORE its reset lands: a caller-side catch that resumes then
+        // continues with the ORIGINAL value still in the variable -- the reset is only
+        // conditional for such callers.
+        if (effect == BodyEffect.Resets
+            && CalleeCanThrowBeforeItsReset(call, variable, scope)
+            && ACaughtFailureCanResumePast(call, call.Syntax.Span.End))
+        {
+            (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
+                .Add((DominatingRegion(call).Syntax.Span, call.Syntax.Span.End));
+            return null;
+        }
+
         return false;
+    }
+
+    private static bool CalleeCanThrowBeforeItsReset(IOperation call, ISymbol variable, IOperation scope)
+    {
+        if (call is not IInvocationOperation { TargetMethod: { MethodKind: MethodKind.LocalFunction } target })
+        {
+            return false;
+        }
+
+        var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
+            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, target.OriginalDefinition));
+        if (declaration is null)
+        {
+            return false;
+        }
+
+        var reset = declaration.DescendantsAndSelf().FirstOrDefault(operation =>
+            SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+            && ResetShapeOf(operation, variable, declaration, out _) is not null);
+        var limit = reset?.Syntax.SpanStart ?? int.MaxValue;
+
+        return declaration.DescendantsAndSelf().Any(operation =>
+            operation.Syntax.Span.End <= limit
+            && !IsWithinANestedFunction(operation, declaration)
+            && CanThrow(operation));
     }
 
     // Arguments evaluate BEFORE the callee runs: a read among them is a use no body effect
@@ -945,15 +994,56 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         for (IOperation child = use; child.Parent is { } parent; child = parent)
         {
-            if (parent is ITryOperation { Body: { } body } && child is ICatchClauseOperation
+            if (parent is ITryOperation { Body: { } body } && child is ICatchClauseOperation clause
                 && Covers(body, transferPosition)
-                && !CanThrowAfterTheTransfer(body, transferPosition))
+                && !ThrowCapableOpsAfter(body, transferPosition).Any(operation => FailureReaches(operation, clause)))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private static IEnumerable<IOperation> ThrowCapableOpsAfter(IOperation region, int transferPosition)
+    {
+        return region.DescendantsAndSelf().Where(operation =>
+            operation.Syntax.Span.End > transferPosition
+            && !IsWithinANestedFunction(operation, region)
+            && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
+            && CanThrow(operation)
+            // an explicit throw governs its subtree: its operand is not an independent failure
+            && (operation is IThrowOperation || !IsInsideAThrow(operation)));
+    }
+
+    // An EXPLICIT throw carries its type: an unfiltered catch of an unrelated type can
+    // never receive it. Every other failure's type is unknowable and reaches any clause.
+    private static bool FailureReaches(IOperation operation, ICatchClauseOperation clause)
+    {
+        return operation is not IThrowOperation thrown || ClauseCanCatch(clause, thrown);
+    }
+
+    private static bool ClauseCanCatch(ICatchClauseOperation catchClause, IThrowOperation thrown)
+    {
+        if (catchClause.Filter is not null)
+        {
+            return true; // a filter may pass
+        }
+
+        var exception = thrown.Exception;
+        while (exception is IConversionOperation conversion)
+        {
+            exception = conversion.Operand;
+        }
+
+        if (exception?.Type is not INamedTypeSymbol thrownType)
+        {
+            return true;
+        }
+
+        return catchClause.ExceptionType is not { } caughtType
+            || caughtType.SpecialType == SpecialType.System_Object
+            || SelfAndBases(thrownType).Contains(caughtType, SymbolEqualityComparer.Default);
     }
 
     private static bool IsWithinALocalFunctionBody(IOperation operation, List<IOperation> scanRoots)
@@ -1148,12 +1238,20 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
+        var overwritten = new HashSet<string>(
+            (creation.Initializer?.Initializers ?? System.Collections.Immutable.ImmutableArray<IOperation>.Empty)
+                .OfType<ISimpleAssignmentOperation>()
+                .Select(member => (member.Target as IPropertyReferenceOperation)?.Property.Name)
+                .Where(name => name is not null)!);
+
         foreach (var argument in creation.Arguments)
         {
             // Only the SYNTHESIZED positional property stores its parameter (its declaring
             // syntax IS the parameter); an explicitly redeclared property replaces the
-            // storage and may never read it.
+            // storage and may never read it -- and an object initializer that definitely
+            // OVERWRITES the slot drops the constructor's value before the object escapes.
             if (argument.Parameter is { } parameter
+                && !overwritten.Contains(parameter.Name)
                 && recordType.GetMembers(parameter.Name).OfType<IPropertySymbol>().Any(property =>
                     SendableSymbolClassifier.HasBackingSlot(property)
                     && property.DeclaringSyntaxReferences.Any(reference =>
@@ -1453,21 +1551,22 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var yieldedACallable = false;
-            foreach (var callable in Callables(value))
+            foreach (var item in Callables(value))
             {
-                yieldedACallable = true;
-                yield return callable;
-            }
-
-            if (!yieldedACallable && ReferencedVariable(value) is { } alias)
-            {
-                // Action use = use2: the copy SNAPSHOTS what the source holds AT THE COPY --
-                // stores landing in the source afterwards are not in use's invocation list.
-                foreach (var carried in StoredCallables(alias, scope, site, transferPosition, visited))
+                // Action use = use2 (alone or inside a combine): the copy SNAPSHOTS what the
+                // source holds AT THE COPY -- stores landing in the source afterwards are
+                // not in use's invocation list.
+                if (ReferencedVariable(item) is { } alias)
                 {
-                    yield return carried;
+                    foreach (var carried in StoredCallables(alias, scope, site, transferPosition, visited))
+                    {
+                        yield return carried;
+                    }
+
+                    continue;
                 }
+
+                yield return item;
             }
         }
     }
@@ -1577,6 +1676,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             case IAnonymousFunctionOperation or IMethodReferenceOperation:
                 yield return stored;
                 break;
+            // read + noop keeps BOTH operands in the invocation list.
+            case IBinaryOperation { OperatorKind: BinaryOperatorKind.Add } combine:
+                foreach (var callable in Callables(combine.LeftOperand).Concat(Callables(combine.RightOperand)))
+                {
+                    yield return callable;
+                }
+
+                break;
             case IConditionalOperation { WhenFalse: { } whenFalse } conditional:
                 foreach (var callable in Callables(conditional.WhenTrue).Concat(Callables(whenFalse)))
                 {
@@ -1590,6 +1697,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     yield return callable;
                 }
 
+                break;
+            // a delegate-typed variable inside a compound store: an ALIAS the caller resolves.
+            case ILocalReferenceOperation or IParameterReferenceOperation:
+                yield return stored;
                 break;
         }
     }
@@ -1680,12 +1791,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // escaped).
     private static bool CanThrowAfterTheTransfer(IOperation region, int transferPosition)
     {
-        return region.DescendantsAndSelf().Any(operation =>
-            operation.Syntax.Span.End > transferPosition
-            && !IsWithinANestedFunction(operation, region)
-            // An op in a mutually exclusive sibling arm never runs on the transferred path.
-            && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
-            && CanThrow(operation));
+        return ThrowCapableOpsAfter(region, transferPosition).Any();
     }
 
     // The heuristic throw model shared by catch reachability and the reinitialization
@@ -1803,8 +1909,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     private static IOperation? CatchUseDuringReinitialization(IOperation reinitialization, ISymbol variable, IOperation scope)
     {
         var reinitRoot = reinitialization is IArgumentOperation { Parent: { } call } ? call : reinitialization;
-        var canThrow = reinitRoot.DescendantsAndSelf().Any(CanThrow);
-        if (!canThrow)
+        var failures = reinitRoot.DescendantsAndSelf()
+            .Where(operation => CanThrow(operation)
+                && (operation is IThrowOperation || !IsInsideAThrow(operation)))
+            .ToList();
+        if (failures.Count == 0)
         {
             return null;
         }
@@ -1817,7 +1926,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
 
             if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body)
-                && WindowUseIn(tryOperation, variable, scope) is { } use)
+                && WindowUseIn(tryOperation, variable, scope, failures) is { } use)
             {
                 return use;
             }
@@ -1829,10 +1938,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // The first window region that actually READS the transferred value. A handler that
     // REWRITES the variable before touching it (catch { list = new(); ... }) is a recovery,
     // not a use -- the reinitialization classification applies inside the window too.
-    private static IOperation? WindowUseIn(ITryOperation tryOperation, ISymbol variable, IOperation scope)
+    private static IOperation? WindowUseIn(ITryOperation tryOperation, ISymbol variable, IOperation scope, List<IOperation> failures)
     {
         foreach (var region in WindowRegionsOf(tryOperation))
         {
+            // A catch no failure of the window can reach never observes the value; the
+            // finally runs regardless.
+            if (region is ICatchClauseOperation clause && !failures.Any(failure => FailureReaches(failure, clause)))
+            {
+                continue;
+            }
+
             if (EffectOf(region, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default), out var read) == BodyEffect.Reads)
             {
                 return read;

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -34,8 +34,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         foreach (var block in context.OperationBlocks)
         {
-            foreach (var (variable, transferPosition, scanRoots) in Transfers(block))
+            foreach (var (variable, transferPosition, scanRoots, transfer) in Transfers(block))
             {
+                // A using-declared local is Disposed by the SENDER at scope end -- after the
+                // handoff, with no source reference to scan for: destroying the object the
+                // receiver now owns is a guaranteed use-after-transfer.
+                if (variable is ILocalSymbol { IsUsing: true })
+                {
+                    Report(context, transfer, variable);
+                    continue;
+                }
+
                 ReportUsesAfter(context, scanRoots, variable, transferPosition);
             }
         }
@@ -44,7 +53,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // Every Sending<T> creation (constructor or Sending.Transfer) whose argument is a
     // local/parameter reference, with the position the transfer happens at and the regions the
     // report walk covers.
-    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots)> Transfers(IOperation block)
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, IOperation Transfer)> Transfers(IOperation block)
     {
         foreach (var operation in block.DescendantsAndSelf())
         {
@@ -65,22 +74,22 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             var scanRoots = ScanRootsFor(operation, EnclosingFunctionBody(operation, block));
             if (scanRoots.Count > 0)
             {
-                yield return (variable, operation.Syntax.Span.End, scanRoots);
+                yield return (variable, operation.Syntax.Span.End, scanRoots, operation);
             }
         }
     }
 
     // Where the sender-side scan looks. Normally the whole scope; a transfer the flow
     // immediately leaves behind (`return Sending.Transfer(list);` / `throw`) is only still
-    // observable from the FINALLY blocks of enclosing tries, which run after the return
-    // expression evaluated -- no finally, no sender-side continuation at all. (break/continue
-    // are NOT exits: control resumes after the loop, where later uses remain reachable, so
-    // they keep the full scope.)
+    // observable from the escaping expression itself, the CATCH handlers a thrown transfer
+    // lands in, and the FINALLY blocks of enclosing tries -- no such region, no sender-side
+    // continuation at all. (break/continue are NOT exits: control resumes after the loop,
+    // where later uses remain reachable, so they keep the full scope.)
     private static List<IOperation> ScanRootsFor(IOperation transfer, IOperation scope)
     {
         var roots = new List<IOperation>();
-        var escapes = false;
-        for (var parent = transfer.Parent; parent is not null; parent = parent.Parent)
+        var escape = default(IOperation);
+        for (IOperation child = transfer; child.Parent is { } parent; child = parent)
         {
             if (ReferenceEquals(parent, scope) || parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
             {
@@ -89,7 +98,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             if (parent is IReturnOperation or IThrowOperation)
             {
-                if (!escapes)
+                if (escape is null)
                 {
                     // The escaping expression itself still evaluates past the transfer:
                     // `return Pair(Sending.Transfer(list), list);` reads the second argument
@@ -97,20 +106,37 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     roots.Add(parent);
                 }
 
-                escapes = true;
+                escape = parent;
             }
-            else if (escapes && parent is ITryOperation { Finally: { } finallyBlock })
+            else if (escape is not null && parent is ITryOperation tryOperation)
             {
-                roots.Add(finallyBlock); // inner finallys first: they execute first
+                AddHandlerRoots(roots, tryOperation, child, escapedByThrow: escape is IThrowOperation);
             }
         }
 
-        if (!escapes)
+        if (escape is null)
         {
             roots.Add(scope);
         }
 
         return roots;
+    }
+
+    // A THROWN transfer lands in the try's handlers -- when the throw came from the try BODY
+    // (a throw inside one catch never reaches its sibling catches; which handler matches is
+    // not decidable statically, so every candidate is scanned). Finallys run for return and
+    // throw alike: catches before finally, inner tries first.
+    private static void AddHandlerRoots(List<IOperation> roots, ITryOperation tryOperation, IOperation child, bool escapedByThrow)
+    {
+        if (escapedByThrow && ReferenceEquals(child, tryOperation.Body))
+        {
+            roots.AddRange(tryOperation.Catches);
+        }
+
+        if (tryOperation.Finally is { } finallyBlock)
+        {
+            roots.Add(finallyBlock);
+        }
     }
 
     // Transfer(list = new(...)) -- and the lazy-init form Transfer(list ??= new(...)): after

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -58,10 +58,20 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 // reads still inside the RHS (after the transfer) and the throw window count.
                 if (EnclosingReinitializingAssignment(transfer, variable) is { } enclosingReinit)
                 {
-                    if (!ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition, transfer, scope)
-                        && CatchUseDuringReinitialization(enclosingReinit, variable, scope) is { } windowUse)
+                    var reported = ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition, transfer, scope);
+                    if (!reported && CatchUseDuringReinitialization(enclosingReinit, variable, scope) is { } windowUse)
                     {
                         Report(context, windowUse, variable);
+                        reported = true;
+                    }
+
+                    // The RHS can throw into a RESUMING catch before the assignment
+                    // completes: after the try the variable may still hold the transferred
+                    // value, so later uses stay reportable.
+                    if (!reported && CanThrowAfterTheTransfer(enclosingReinit, transferPosition)
+                        && ACaughtFailureCanResumePast(enclosingReinit, enclosingReinit.Syntax.Span.End))
+                    {
+                        ReportUsesAfter(context, scanRoots, escaped, variable, transferPosition, transfer, scope);
                     }
 
                     continue;
@@ -1899,7 +1909,28 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         var transferCase = switchOperation.Cases.FirstOrDefault(switchCase => Covers(switchCase, transferPosition));
         return transferCase is not null
-            && transferCase.Descendants().Any(operation => operation is IBranchOperation { BranchKind: BranchKind.GoTo });
+            && transferCase.Descendants().Any(operation =>
+                operation is IBranchOperation { BranchKind: BranchKind.GoTo }
+                // only `goto case`/`goto default` re-enters an arm -- a plain goto label
+                // leaves the switch -- and only when it belongs to THIS switch and can run
+                // after the handoff.
+                && operation.Syntax is Microsoft.CodeAnalysis.CSharp.Syntax.GotoStatementSyntax gotoSyntax
+                && gotoSyntax.CaseOrDefaultKeyword.RawKind != 0
+                && operation.Syntax.SpanStart >= transferPosition
+                && ReferenceEquals(NearestSwitch(operation), switchOperation));
+    }
+
+    private static ISwitchOperation? NearestSwitch(IOperation operation)
+    {
+        for (var parent = operation.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is ISwitchOperation nearest)
+            {
+                return nearest;
+            }
+        }
+
+        return null;
     }
 
     // A `when` guard is arm-SELECTION machinery, not an arm: a failing guard falls through to

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -530,9 +530,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             // off, only copied from).
             IWithOperation withOperation => WithCarriedParts(withOperation),
             IConversionOperation conversion => new[] { conversion.Operand },
-            // Tuple.Create(list) is the constructor spelling of a framework value carrier.
+            // Tuple.Create(list) is the constructor spelling of a framework value carrier,
+            // and the immutable/frozen collection factories' Create store their ARGUMENTS
+            // as elements the same way (ImmutableArray.Create(list) retains the list).
+            // CreateRange and the ToImmutable*/ToFrozen* conversions stay leaves: they copy
+            // elements OUT of their source, which is itself never retained.
             IInvocationOperation { TargetMethod: { Name: "Create", ContainingType: { } factory } } factoryCall
-                when factory.Name is "Tuple" or "ValueTuple" or "KeyValuePair" && IsFrameworkDeclared(factory) =>
+                when IsACarrierFactory(factory) =>
                 factoryCall.Arguments.Select(argument => (IOperation?)argument.Value),
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are
@@ -544,6 +548,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                         : new[] { (IOperation?)child }),
             _ => null,
         };
+    }
+
+    // Framework factories whose Create stores its arguments: the tuple family carries each
+    // argument in a field, and the immutable/frozen collection factories build a container
+    // around the argument REFERENCES -- freezing the shape shares the contents.
+    private static bool IsACarrierFactory(INamedTypeSymbol factory)
+    {
+        return (factory.Name is "Tuple" or "ValueTuple" or "KeyValuePair"
+                || factory.Name.StartsWith("Immutable", System.StringComparison.Ordinal)
+                || factory.Name.StartsWith("Frozen", System.StringComparison.Ordinal))
+            && IsFrameworkDeclared(factory);
     }
 
     // Where the sender-side scan looks. Normally the whole scope; a transfer the flow

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -105,16 +105,25 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // True when no branching construct separates the reassignment from the transfer: every
-    // conditional/loop/switch/try ancestor of the assignment must also span the transfer, so
-    // both sit on the same conditional level and source order implies execution order.
+    // True when the reassignment DEFINITELY executes on the path that transferred: walking up
+    // from the assignment, every branching ancestor (if/switch/loop/try/?.) must be entered
+    // through the ARM that also contains the transfer. An ancestor merely spanning the
+    // transfer is not enough -- `try { Transfer(list); } catch { list = new(); }` spans it,
+    // but the catch arm may never run. Checking the path-CHILD's span covers both cases at
+    // once (a child containing the transfer implies its parent does too); the one arm exempted
+    // is a finally block, which always executes.
     private static bool IsOnTheTransfersConditionalLevel(IOperation assignment, int transferPosition)
     {
-        for (var parent = assignment.Parent; parent is not null; parent = parent.Parent)
+        for (IOperation child = assignment; child.Parent is { } parent; child = parent)
         {
             var branches = parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
                 or ILoopOperation or ITryOperation or IConditionalAccessOperation;
-            if (branches && !parent.Syntax.Span.Contains(transferPosition))
+            if (!branches || (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Finally)))
+            {
+                continue;
+            }
+
+            if (!child.Syntax.Span.Contains(transferPosition))
             {
                 return false;
             }

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -98,17 +98,76 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                var enclosingBody = EnclosingFunctionBody(operation, block);
-                var (scanRoots, escaped) = ScanRootsFor(operation, enclosingBody);
-                if (scanRoots.Count > 0)
+                foreach (var entry in EntriesFor(operation, variable, block))
                 {
-                    yield return (variable, operation.Syntax.Span.End, scanRoots, escaped, operation, enclosingBody);
+                    yield return entry;
                 }
             }
         }
     }
 
-    private static ISimpleAssignmentOperation? EnclosingReinitializingAssignment(IOperation transfer, ISymbol variable)
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> EntriesFor(
+        IOperation transfer, ISymbol variable, IOperation block)
+    {
+        var enclosingBody = EnclosingFunctionBody(transfer, block);
+        var (scanRoots, escaped) = ScanRootsFor(transfer, enclosingBody);
+        if (scanRoots.Count > 0)
+        {
+            yield return (variable, transfer.Syntax.Span.End, scanRoots, escaped, transfer, enclosingBody);
+        }
+
+        // A transfer inside a CALLED local function is sequenced before the caller's
+        // continuation: every call site acts as a transfer of its own. Lambdas stay
+        // deferred-scoped (they may run later or never).
+        foreach (var propagated in CallSiteTransfers(enclosingBody, block,
+            new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
+        {
+            yield return (variable, propagated.Position, propagated.Roots, propagated.Escaped, propagated.Site, propagated.Scope);
+        }
+    }
+
+    // Call sites of the local function whose body contains the transfer -- transitively:
+    // a call inside ANOTHER declaration only runs through that declaration's own callers.
+    private static IEnumerable<(int Position, List<IOperation> Roots, bool Escaped, IOperation Site, IOperation Scope)> CallSiteTransfers(
+        IOperation transferBody, IOperation block, HashSet<IMethodSymbol> visited)
+    {
+        if (transferBody is not ILocalFunctionOperation declaration || !visited.Add(declaration.Symbol))
+        {
+            yield break;
+        }
+
+        foreach (var invocation in block.DescendantsAndSelf().OfType<IInvocationOperation>())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.OriginalDefinition, declaration.Symbol))
+            {
+                continue;
+            }
+
+            var callBody = EnclosingFunctionBody(invocation, block);
+            if (ReferenceEquals(callBody, transferBody))
+            {
+                continue; // self-recursion: the body scan already covers it
+            }
+
+            if (callBody is ILocalFunctionOperation)
+            {
+                foreach (var nested in CallSiteTransfers(callBody, block, visited))
+                {
+                    yield return nested;
+                }
+
+                continue;
+            }
+
+            var (roots, escaped) = ScanRootsFor(invocation, callBody);
+            if (roots.Count > 0)
+            {
+                yield return (invocation.Syntax.Span.End, roots, escaped, invocation, callBody);
+            }
+        }
+    }
+
+    private static IOperation? EnclosingReinitializingAssignment(IOperation transfer, ISymbol variable)
     {
         for (IOperation child = transfer; child.Parent is { } parent; child = parent)
         {
@@ -122,6 +181,16 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 && SymbolEqualityComparer.Default.Equals(ReferencedVariable(assignment.Target), variable))
             {
                 return assignment;
+            }
+
+            // (list, _) = (new List<int>(), Sending.Transfer(list)): the deconstruction
+            // assigns the fresh element to the variable right after its RHS evaluated.
+            if (parent is IDeconstructionAssignmentOperation deconstruction
+                && !ReferenceEquals(child, deconstruction.Target)
+                && deconstruction.Target.DescendantsAndSelf()
+                    .Any(element => SymbolEqualityComparer.Default.Equals(ReferencedVariable(element), variable)))
+            {
+                return deconstruction;
             }
         }
 
@@ -962,7 +1031,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return BodyEffect.None;
         }
 
-        var reads = StoredCallables(delegateLocal, scope, invocation, transferPosition).Any(callable => callable switch
+        var candidates = StoredCallables(delegateLocal, scope, invocation, transferPosition,
+            new HashSet<ISymbol>(SymbolEqualityComparer.Default));
+        var reads = candidates.Any(callable => callable switch
         {
             IAnonymousFunctionOperation lambda =>
                 EffectOf(lambda, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default), out _) == BodyEffect.Reads,
@@ -996,40 +1067,81 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     // Every callable stored in the delegate local that can still be its value AT THE CALL:
-    // stores in a sibling arm of the transfer never run on the transferred path, and a store
-    // that only happens after the call cannot be what it invoked -- unless a loop carries it
-    // back around.
-    private static System.Collections.Generic.IEnumerable<IOperation> StoredCallables(ISymbol delegateLocal, IOperation scope, IInvocationOperation call, int transferPosition)
+    // stores in a sibling arm of the transfer never run on the transferred path, a store
+    // that only happens after the call cannot be what it invoked (unless a loop carries it
+    // back around), a definite `=` overwrite KILLS every earlier target, `-=` never adds
+    // one, and a plain delegate-to-delegate copy carries the SOURCE local's candidates.
+    private static System.Collections.Generic.IEnumerable<IOperation> StoredCallables(
+        ISymbol delegateLocal, IOperation scope, IInvocationOperation call, int transferPosition, HashSet<ISymbol> visited)
     {
-        foreach (var operation in scope.DescendantsAndSelf())
+        if (!visited.Add(delegateLocal))
         {
-            var stored = operation switch
-            {
-                IVariableDeclaratorOperation declarator
-                    when SymbolEqualityComparer.Default.Equals(declarator.Symbol, delegateLocal)
-                    => declarator.Initializer?.Value,
-                ISimpleAssignmentOperation assignment
-                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(assignment.Target), delegateLocal)
-                    => assignment.Value,
-                // use += () => ...: the combine keeps every previous target AND adds this one.
-                ICompoundAssignmentOperation combined
-                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(combined.Target), delegateLocal)
-                    => combined.Value,
-                _ => null,
-            };
+            yield break;
+        }
 
-            if (stored is null
-                || IsInASiblingArmOfTheTransfer(operation, transferPosition)
-                || (operation.Syntax.SpanStart >= call.Syntax.Span.End && !SharesALoopWith(operation, call)))
+        var stores = DelegateStores(delegateLocal, scope, call, transferPosition);
+
+        // A definite overwrite replaces the whole invocation list: candidates begin at the
+        // LAST replace that runs on every path to the call.
+        var killPoint = stores
+            .Where(store => store.Replaces && !IsConditionalWithin(store.Site, scope))
+            .Select(store => store.Site.Syntax.SpanStart)
+            .DefaultIfEmpty(int.MinValue)
+            .Max();
+
+        foreach (var (site, value, _) in stores)
+        {
+            if (site.Syntax.SpanStart < killPoint)
             {
                 continue;
             }
 
-            if (Callable(stored) is { } callable)
+            if (Callable(value) is { } callable)
             {
                 yield return callable;
             }
+            else if (ReferencedVariable(value) is { } alias)
+            {
+                // Action use = use2: the copy carries whatever the SOURCE could hold.
+                foreach (var carried in StoredCallables(alias, scope, call, transferPosition, visited))
+                {
+                    yield return carried;
+                }
+            }
         }
+    }
+
+    private static List<(IOperation Site, IOperation Value, bool Replaces)> DelegateStores(
+        ISymbol delegateLocal, IOperation scope, IInvocationOperation call, int transferPosition)
+    {
+        var stores = new List<(IOperation Site, IOperation Value, bool Replaces)>();
+        foreach (var operation in scope.DescendantsAndSelf())
+        {
+            (IOperation Value, bool Replaces)? matched = operation switch
+            {
+                IVariableDeclaratorOperation declarator
+                    when SymbolEqualityComparer.Default.Equals(declarator.Symbol, delegateLocal)
+                        && declarator.Initializer is { } initializer
+                    => (initializer.Value, true),
+                ISimpleAssignmentOperation assignment
+                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(assignment.Target), delegateLocal)
+                    => (assignment.Value, true),
+                // use += adds a target; -= only removes, storing nothing.
+                ICompoundAssignmentOperation { OperatorKind: BinaryOperatorKind.Add } combined
+                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(combined.Target), delegateLocal)
+                    => (combined.Value, false),
+                _ => null,
+            };
+
+            if (matched is { } store
+                && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
+                && (operation.Syntax.SpanStart < call.Syntax.Span.End || SharesALoopWith(operation, call)))
+            {
+                stores.Add((operation, store.Value, store.Replaces));
+            }
+        }
+
+        return stores;
     }
 
     private static bool SharesALoopWith(IOperation store, IOperation call)
@@ -1134,8 +1246,25 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return region.DescendantsAndSelf().Any(operation =>
             operation.Syntax.Span.End > transferPosition
             && !IsWithinANestedFunction(operation, region)
-            && operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
-                or IPropertyReferenceOperation or IArrayElementReferenceOperation or IFieldReferenceOperation);
+            && CanThrow(operation));
+    }
+
+    // The heuristic throw model shared by catch reachability and the reinitialization
+    // windows: calls, allocations, awaits and member/element accesses that dereference --
+    // a FIELD read only through a possibly-null receiver (`this` cannot be null) -- plus
+    // user-defined conversions/operators and explicit reference downcasts.
+    private static bool CanThrow(IOperation operation)
+    {
+        return operation switch
+        {
+            IFieldReferenceOperation field => field.Instance is not null and not IInstanceReferenceOperation,
+            IConversionOperation conversion => conversion.OperatorMethod is not null
+                || (conversion.Conversion is { IsReference: true, IsImplicit: false } && !conversion.IsTryCast),
+            IUnaryOperation unary => unary.OperatorMethod is not null,
+            IBinaryOperation binary => binary.OperatorMethod is not null,
+            _ => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
+                or IPropertyReferenceOperation or IArrayElementReferenceOperation,
+        };
     }
 
     // The use is in an arm of an if/switch/?. whose SIBLING arm holds the transfer: the arms
@@ -1220,9 +1349,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     private static IOperation? CatchUseDuringReinitialization(IOperation reinitialization, ISymbol variable, IOperation scope)
     {
         var reinitRoot = reinitialization is IArgumentOperation { Parent: { } call } ? call : reinitialization;
-        var canThrow = reinitRoot.DescendantsAndSelf()
-            .Any(operation => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
-                or IPropertyReferenceOperation or IArrayElementReferenceOperation or IFieldReferenceOperation);
+        var canThrow = reinitRoot.DescendantsAndSelf().Any(CanThrow);
         if (!canThrow)
         {
             return null;

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -119,7 +119,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // A transfer inside a CALLED local function is sequenced before the caller's
         // continuation: every call site acts as a transfer of its own. Lambdas stay
         // deferred-scoped (they may run later or never).
-        foreach (var propagated in CallSiteTransfers(enclosingBody, variable, block,
+        foreach (var propagated in CallSiteTransfers(enclosingBody, variable, transfer, block,
             new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
         {
             yield return propagated;
@@ -131,9 +131,18 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // through that declaration's own callers. A transferred PARAMETER remaps to the caller's
     // argument at each site.
     private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> CallSiteTransfers(
-        IOperation transferBody, ISymbol variable, IOperation block, HashSet<IMethodSymbol> visited)
+        IOperation transferBody, ISymbol variable, IOperation anchor, IOperation block, HashSet<IMethodSymbol> visited)
     {
         if (transferBody is not ILocalFunctionOperation declaration || !visited.Add(declaration.Symbol))
+        {
+            yield break;
+        }
+
+        // A by-value parameter definitely reassigned before the handoff no longer aliases
+        // ANY caller argument: the callee transferred its own fresh value.
+        if (variable is IParameterSymbol parameterVariable
+            && SymbolEqualityComparer.Default.Equals(parameterVariable.ContainingSymbol.OriginalDefinition, declaration.Symbol)
+            && DefinitelyReassignedBefore(declaration, variable, anchor))
         {
             yield break;
         }
@@ -165,7 +174,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         {
             if (callBody is ILocalFunctionOperation)
             {
-                foreach (var nested in CallSiteTransfers(callBody, callVariable, block, visited))
+                foreach (var nested in CallSiteTransfers(callBody, callVariable, invocation, block, visited))
                 {
                     yield return nested;
                 }
@@ -547,6 +556,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return tryOperation.Catches.Any(catchClause => catchClause.Filter is null
+            && CanResume(catchClause)
             && (catchClause.ExceptionType is not { } caughtType || CatchesEverything(caughtType)));
     }
 
@@ -576,6 +586,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return tryOperation.Catches.Any(catchClause => catchClause.Filter is null
+            && CanResume(catchClause)
             && (catchClause.ExceptionType is not { } caughtType
                 || SelfAndBases(thrownType).Contains(caughtType, SymbolEqualityComparer.Default)));
     }
@@ -1042,7 +1053,12 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        if (creation.Constructor is not { ContainingType: { IsRecord: true } recordType })
+        // Only the PRIMARY constructor's parameters deterministically store (its declaring
+        // syntax IS the record declaration); a hand-written constructor with a matching
+        // parameter name promises nothing.
+        if (creation.Constructor is not { ContainingType: { IsRecord: true } recordType } constructor
+            || !constructor.DeclaringSyntaxReferences.Any(reference =>
+                reference.GetSyntax() is Microsoft.CodeAnalysis.CSharp.Syntax.RecordDeclarationSyntax))
         {
             yield break;
         }
@@ -1070,26 +1086,30 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 when IsFrameworkDeclared(indexer.Property.ContainingType) =>
                 indexer.Arguments.Select(argument => (IOperation?)argument.Value).Concat(new[] { (IOperation?)member.Value }),
             ISimpleAssignmentOperation member when StoresIntoACompilerKnownSlot(member) => new[] { (IOperation?)member.Value },
+            // Child = { Value = list }: writes INTO the object the transferred payload
+            // already reaches -- the nested initializer carries by the same rules.
+            IMemberInitializerOperation { Initializer: { } nested } => InitializerCarriedParts(nested),
             IInvocationOperation add when IsFrameworkDeclared(add.TargetMethod.ContainingType) =>
                 add.Arguments.Select(argument => (IOperation?)argument.Value),
             _ => System.Linq.Enumerable.Empty<IOperation?>(),
         });
     }
 
-    // Metadata types under the System root: their collection contracts store what they are
-    // handed. Source-declared types make no such promise.
+    // Types living in the SAME ASSEMBLY as System.Object (the core library): their
+    // collection contracts store what they are handed. A System.* NAMESPACE proves nothing --
+    // any referenced assembly can declare one.
     private static bool IsFrameworkDeclared(INamedTypeSymbol? type)
     {
-        if (type is null || type.Locations.Any(location => location.IsInSource))
+        if (type is null)
         {
             return false;
         }
 
-        for (var current = type.ContainingNamespace; current is { IsGlobalNamespace: false }; current = current.ContainingNamespace)
+        for (ITypeSymbol? current = type; current is not null; current = current.BaseType)
         {
-            if (current.ContainingNamespace is { IsGlobalNamespace: true })
+            if (current.SpecialType == SpecialType.System_Object)
             {
-                return current.Name == "System";
+                return SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, current.ContainingAssembly);
             }
         }
 
@@ -1419,13 +1439,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         return operation switch
         {
-            IFieldReferenceOperation field => field.Instance is not null and not IInstanceReferenceOperation,
+            // Instance fields dereference their receiver (`this` cannot be null); a STATIC
+            // field's first touch can run a throwing type initializer.
+            IFieldReferenceOperation field => field.Instance is not IInstanceReferenceOperation,
             IConversionOperation conversion => conversion.OperatorMethod is not null
                 || (conversion.Conversion is { IsReference: true, IsImplicit: false } && !conversion.IsTryCast),
             IUnaryOperation unary => unary.OperatorMethod is not null,
             IBinaryOperation binary => binary.OperatorMethod is not null,
             _ => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
-                or IPropertyReferenceOperation or IArrayElementReferenceOperation or IThrowOperation,
+                or IPropertyReferenceOperation or IArrayElementReferenceOperation or IThrowOperation
+                or IDynamicInvocationOperation or IDynamicMemberReferenceOperation
+                or IDynamicIndexerAccessOperation or IDynamicObjectCreationOperation,
         };
     }
 
@@ -1734,13 +1758,27 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
 
             if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body)
-                && tryOperation.Catches.Length > 0)
+                && tryOperation.Catches.Any(CanResume))
             {
                 return tryOperation;
             }
         }
 
         return null;
+    }
+
+    // A handler that ends in an unconditional throw/return never completes normally:
+    // control does not resume after its try on that path (catch { throw; } re-escapes).
+    private static bool CanResume(ICatchClauseOperation catchClause)
+    {
+        var last = catchClause.Handler.Operations.LastOrDefault();
+        if (last is IExpressionStatementOperation expressionStatement)
+        {
+            last = expressionStatement.Operation;
+        }
+
+        return last is not IThrowOperation
+            && last is not IReturnOperation { Kind: not OperationKind.YieldReturn };
     }
 
     // True when the reassignment DEFINITELY executes on the path that transferred: walking up

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -287,8 +287,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // The sub-expressions a compound argument carries into the handoff: whichever operand the
     // runtime picks for ??/?:/switch expressions, EVERY element of a tuple, array or anonymous
     // object (Transfer((list, 0)) / Transfer(new[] { list }) / Transfer(new { Value = list }):
-    // the container deterministically stores its contents, unlike an arbitrary object
-    // initializer's setters), and a conversion's operand. Null marks a leaf.
+    // the container deterministically stores its contents), an object initializer's writes to
+    // COMPILER-KNOWN slots (fields and auto-properties; a custom setter may not store what it
+    // was handed, so it stays a leaf), and a conversion's operand. Null marks a leaf.
     private static System.Collections.Generic.IEnumerable<IOperation?>? CarriedParts(IOperation argument)
     {
         return argument switch
@@ -300,6 +301,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IArrayCreationOperation { Initializer: { } initializer } => initializer.ElementValues,
             IAnonymousObjectCreationOperation anonymous => anonymous.Initializers.Select(initializer =>
                 (IOperation?)(initializer is ISimpleAssignmentOperation member ? member.Value : initializer)),
+            IObjectCreationOperation { Initializer: { } objectInitializer } => objectInitializer.Initializers
+                .OfType<ISimpleAssignmentOperation>()
+                .Where(member => member.Target is IFieldReferenceOperation
+                    || (member.Target is IPropertyReferenceOperation property && SendableSymbolClassifier.HasBackingSlot(property.Property)))
+                .Select(member => (IOperation?)member.Value),
             IConversionOperation conversion => new[] { conversion.Operand },
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -101,9 +101,18 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             // Only a resource that IS the variable disposes the handoff: `using (stream)`.
             // A resource merely mentioning it (`using (new Scope(list.Count))`) disposes the
-            // wrapper, not the transferred object.
-            if (parent is IUsingOperation usingOperation
-                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(usingOperation.Resources), variable))
+            // wrapper, not the transferred object. A `lock (gate)` around the transfer is the
+            // same shape: the compiler-generated Monitor.Exit touches the handed-off object
+            // at scope end.
+            var scopeExitTarget = parent switch
+            {
+                IUsingOperation usingOperation => usingOperation.Resources,
+                ILockOperation lockOperation => lockOperation.LockedValue,
+                _ => null,
+            };
+
+            if (scopeExitTarget is not null
+                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(scopeExitTarget), variable))
             {
                 return true;
             }
@@ -140,9 +149,34 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         return loop.Body.DescendantsAndSelf().Any(operation =>
             operation.Syntax.SpanStart >= transferPosition
-            && operation is IReturnOperation or IThrowOperation or IBranchOperation { BranchKind: BranchKind.Break }
             && !IsWithinANestedFunction(operation, loop.Body)
+            && ExitsTheLoop(operation, loop)
             && IsOnTheTransfersConditionalLevel(operation, transferPosition));
+    }
+
+    // A break only ends the ITERATION when it leaves THIS foreach: a break belonging to a
+    // nested switch or inner loop resumes inside the body, and the next MoveNext still runs.
+    private static bool ExitsTheLoop(IOperation operation, IForEachLoopOperation loop)
+    {
+        if (operation is IReturnOperation or IThrowOperation)
+        {
+            return true;
+        }
+
+        if (operation is not IBranchOperation { BranchKind: BranchKind.Break } branch)
+        {
+            return false;
+        }
+
+        for (var parent = branch.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is ILoopOperation or ISwitchOperation)
+            {
+                return ReferenceEquals(parent, loop);
+            }
+        }
+
+        return false;
     }
 
     // The variables an argument expression can HAND OFF. An assignment transfers its target
@@ -303,7 +337,23 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 && !IsInsideNameOf(operation)
                 && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(operation, transferPosition)))
-            .OrderBy(operation => operation.Syntax.SpanStart);
+            .Select(operation => (Operation: operation, IsLocalFunctionCall: false));
+
+        // A call to a local function whose body reads the variable is a use AT THE CALL: the
+        // body's reference sits source-BEFORE the transfer when the function is declared
+        // earlier, so the position filter alone would hide it.
+        var localFunctionCalls = scanRoots
+            .SelectMany(root => root.DescendantsAndSelf())
+            .OfType<IInvocationOperation>()
+            .Where(invocation => invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
+                && invocation.Syntax.SpanStart >= transferPosition
+                && !IsInASiblingArmOfTheTransfer(invocation, transferPosition)
+                && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition))
+                && LocalFunctionReads(invocation.TargetMethod, variable, scope))
+            .Select(invocation => (Operation: (IOperation)invocation, IsLocalFunctionCall: true));
+
+        var orderedUses = laterReferences.Concat(localFunctionCalls)
+            .OrderBy(use => use.Operation.Syntax.SpanStart);
 
         // Regions where a SKIPPED conditional reinitialization dominates: inside its own arm,
         // after it, the variable is fresh on every path that reaches the reference
@@ -311,11 +361,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // list), so such references are clean while the scan continues past the arm.
         List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated = null;
 
-        foreach (var reference in laterReferences)
+        foreach (var (reference, isLocalFunctionCall) in orderedUses)
         {
             if (IsDominatedByASkippedReinitialization(dominated, reference))
             {
                 continue;
+            }
+
+            if (isLocalFunctionCall)
+            {
+                Report(context, reference, variable);
+                return;
             }
 
             switch (Classify(reference, variable, transferPosition, scope, out var rhsUse))
@@ -380,6 +436,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool LocalFunctionReads(IMethodSymbol localFunction, ISymbol variable, IOperation scope)
+    {
+        var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
+            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, localFunction));
+
+        return declaration is not null
+            && declaration.DescendantsAndSelf().Any(operation =>
+                SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                && !IsInsideNameOf(operation));
     }
 
     // nameof(list) is a compile-time constant: the reference never reads the object at

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -122,6 +122,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
+        // A TYPE PARAMETER passes the classifier by design (creation sites check the closed
+        // type), but no closed check exists for a generic transfer helper: track it unless
+        // its constraints prove it harmless.
+        if (source.Type is ITypeParameterSymbol typeParameter)
+        {
+            return typeParameter.HasUnmanagedTypeConstraint ? null : variable;
+        }
+
         return source.Type is { } sourceType && classifier.GetNotSendableReason(sourceType) is null
             ? null
             : variable;
@@ -802,15 +810,15 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         var delegateEscapes = scanRoots
             .SelectMany(root => root.DescendantsAndSelf())
-            .OfType<ILocalReferenceOperation>()
-            .Where(reference => reference.Local.Type is { TypeKind: TypeKind.Delegate }
+            .Where(reference => reference is ILocalReferenceOperation or IParameterReferenceOperation
+                && DelegateSymbolOf(reference) is { } delegateSymbol
                 && reference.Syntax.SpanStart >= transferPosition
                 && EscapesTheScope(reference)
                 && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
                 && !IsWithinALocalFunctionBody(reference, scanRoots)
-                && AnyStoredCallableReads(reference.Local, variable, reference, 0, scope))
-            .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
+                && AnyStoredCallableReads(delegateSymbol, variable, reference, transferPosition, scope))
+            .Select(reference => (Operation: reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
 
         return methodGroupEscapes.Concat(delegateEscapes);
     }
@@ -1115,6 +1123,20 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // Only the PRIMARY constructor's parameters deterministically store (its declaring
         // syntax IS the record declaration); a hand-written constructor with a matching
         // parameter name promises nothing.
+        // Known framework VALUE CARRIERS store every constructor argument by contract:
+        // KeyValuePair/Tuple/ValueTuple are tuple syntax in another spelling.
+        if (creation.Constructor is { ContainingType: { } carrierType }
+            && carrierType.Name is "KeyValuePair" or "ValueTuple" or "Tuple"
+            && IsFrameworkDeclared(carrierType))
+        {
+            foreach (var argument in creation.Arguments)
+            {
+                yield return argument.Value;
+            }
+
+            yield break;
+        }
+
         if (creation.Constructor is not { ContainingType: { IsRecord: true } recordType } constructor
             || !constructor.DeclaringSyntaxReferences.Any(reference =>
                 reference.GetSyntax() is Microsoft.CodeAnalysis.CSharp.Syntax.RecordDeclarationSyntax))
@@ -1330,10 +1352,24 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // The local the invocation calls through -- behind a ?. receiver too: use?.Invoke() puts
     // a placeholder in Instance, and the real receiver hangs off the enclosing conditional
     // access.
+    // The delegate-typed local or parameter a reference names.
+    private static ISymbol? DelegateSymbolOf(IOperation reference)
+    {
+        var symbol = ReferencedVariable(reference);
+        var type = symbol switch
+        {
+            ILocalSymbol local => local.Type,
+            IParameterSymbol parameter => parameter.Type,
+            _ => null,
+        };
+
+        return type is { TypeKind: TypeKind.Delegate } ? symbol : null;
+    }
+
     // A delegate reference ESCAPES when it is returned, passed as an argument, or stored
     // into a non-local slot -- merely inspecting it (use != null) runs nothing, a local
     // copy is an alias resolved at ITS uses, and calls/stores are classified separately.
-    private static bool EscapesTheScope(ILocalReferenceOperation reference)
+    private static bool EscapesTheScope(IOperation reference)
     {
         for (IOperation child = reference; child.Parent is { } parent; child = parent)
         {
@@ -1400,26 +1436,18 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .DefaultIfEmpty(int.MinValue)
             .Max();
 
-        var removals = DelegateRemovals(delegateLocal, scope, consumer);
+        var survivors = SurvivingStoreIndices(stores, delegateLocal, scope, consumer);
 
-        foreach (var (site, value, _) in stores)
+        for (var index = 0; index < stores.Count; index++)
         {
-            if (site.Syntax.SpanStart < killPoint)
+            var (site, value, _) = stores[index];
+            if (site.Syntax.SpanStart < killPoint || !survivors.Contains(index))
             {
                 continue;
             }
 
             if (Callable(value) is { } callable)
             {
-                // A definite `-= M` after the store strips that target: only METHOD GROUPS
-                // are identifiable (removing a fresh lambda instance removes nothing).
-                if (callable is IMethodReferenceOperation storedGroup
-                    && removals.Any(removal => removal.Position > site.Syntax.SpanStart
-                        && SymbolEqualityComparer.Default.Equals(removal.Method, storedGroup.Method.OriginalDefinition)))
-                {
-                    continue;
-                }
-
                 yield return callable;
             }
             else if (ReferencedVariable(value) is { } alias)
@@ -1432,6 +1460,31 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
+    }
+
+    // A definite `-= M` strips ONE matching target -- the last prior add/assignment of M
+    // (only method groups are identifiable; removing a fresh lambda instance removes
+    // nothing). Duplicate subscriptions survive their single removal.
+    private static HashSet<int> SurvivingStoreIndices(
+        List<(IOperation Site, IOperation Value, bool Replaces)> stores, ISymbol delegateLocal, IOperation scope, IOperation consumer)
+    {
+        var survivors = new HashSet<int>(Enumerable.Range(0, stores.Count));
+        foreach (var removal in DelegateRemovals(delegateLocal, scope, consumer).OrderBy(removal => removal.Position))
+        {
+            for (var index = stores.Count - 1; index >= 0; index--)
+            {
+                if (survivors.Contains(index)
+                    && stores[index].Site.Syntax.SpanStart < removal.Position
+                    && Callable(stores[index].Value) is IMethodReferenceOperation storedGroup
+                    && SymbolEqualityComparer.Default.Equals(removal.Method, storedGroup.Method.OriginalDefinition))
+                {
+                    survivors.Remove(index);
+                    break;
+                }
+            }
+        }
+
+        return survivors;
     }
 
     private static List<(int Position, IMethodSymbol Method)> DelegateRemovals(ISymbol delegateLocal, IOperation scope, IOperation consumer)
@@ -1602,9 +1655,16 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         return operation switch
         {
-            // Instance fields dereference their receiver (`this` cannot be null); a STATIC
+            // Instance fields dereference REFERENCE-type receivers (`this` and struct locals
+            // cannot be null; the receiver expression is modeled on its own); a STATIC
             // field's first touch can run a throwing type initializer.
-            IFieldReferenceOperation field => field.Instance is not IInstanceReferenceOperation,
+            IFieldReferenceOperation field => field.Instance switch
+            {
+                null => true,
+                IInstanceReferenceOperation => false,
+                { Type.IsValueType: true } => false,
+                _ => true,
+            },
             IConversionOperation conversion => conversion.OperatorMethod is not null
                 || (conversion.Conversion is { IsReference: true, IsImplicit: false } && !conversion.IsTryCast),
             IUnaryOperation unary => unary.OperatorMethod is not null,
@@ -1613,7 +1673,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 or IPropertyReferenceOperation or IArrayElementReferenceOperation or IThrowOperation
                 or IDynamicInvocationOperation or IDynamicMemberReferenceOperation
                 or IDynamicIndexerAccessOperation or IDynamicObjectCreationOperation
-                or IEventAssignmentOperation,
+                or IEventAssignmentOperation
+                // scope exits dispose: Dispose/DisposeAsync is user code and can throw
+                or IUsingOperation or IUsingDeclarationOperation,
         };
     }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -89,6 +89,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             if (parent is IReturnOperation or IThrowOperation)
             {
+                if (!escapes)
+                {
+                    // The escaping expression itself still evaluates past the transfer:
+                    // `return Pair(Sending.Transfer(list), list);` reads the second argument
+                    // after the handoff, before the method returns.
+                    roots.Add(parent);
+                }
+
                 escapes = true;
             }
             else if (escapes && parent is ITryOperation { Finally: { } finallyBlock })
@@ -105,11 +113,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return roots;
     }
 
-    // Transfer(list = new(...)): after the statement the variable ALIASES the transferred
-    // value -- the assignment's target is what the sender keeps holding.
+    // Transfer(list = new(...)) -- and the lazy-init form Transfer(list ??= new(...)): after
+    // the statement the variable ALIASES the transferred value on every path, so the
+    // assignment's target is what the sender keeps holding. IAssignmentOperation covers
+    // simple, coalesce and compound forms alike.
     private static IOperation? TransferTarget(IOperation? argument)
     {
-        return argument is ISimpleAssignmentOperation assignment ? assignment.Target : argument;
+        return argument is IAssignmentOperation assignment ? assignment.Target : argument;
     }
 
     // A transfer inside a nested callback only concerns the callback's own body: the outer
@@ -212,9 +222,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             };
 
             if (dominatingPart is not null
-                && parent.Syntax.Span.Contains(transferPosition)
-                && !child.Syntax.Span.Contains(transferPosition)
-                && !dominatingPart.Syntax.Span.Contains(transferPosition)
+                && Covers(parent, transferPosition)
+                && !Covers(child, transferPosition)
+                && !Covers(dominatingPart, transferPosition)
                 && !IsInACaseGuard(parent, transferPosition))
             {
                 return true;
@@ -238,7 +248,16 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             _ => System.Linq.Enumerable.Empty<IOperation?>(),
         };
 
-        return guards.Any(guard => guard is not null && guard.Syntax.Span.Contains(transferPosition));
+        return guards.Any(guard => guard is not null && Covers(guard, transferPosition));
+    }
+
+    // transferPosition is the transfer's EXCLUSIVE span end, so an operation whose span ends
+    // exactly there (the switch value IS the transfer: `switch (Sending.Transfer(list))`)
+    // still covers it -- plain TextSpan.Contains excludes its own end.
+    private static bool Covers(IOperation operation, int transferPosition)
+    {
+        var span = operation.Syntax.Span;
+        return span.Contains(transferPosition) || span.End == transferPosition;
     }
 
     // The region a skipped conditional reinitialization dominates: its nearest enclosing arm
@@ -361,7 +380,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (!child.Syntax.Span.Contains(transferPosition))
+            if (!Covers(child, transferPosition))
             {
                 return false;
             }

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -376,20 +376,22 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 && !IsWithinALocalFunctionBody(operation, scanRoots)
                 && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(operation, transferPosition)))
-            .Select(operation => (Operation: operation, IsLocalFunctionCall: false));
+            .Select(operation => (Operation: operation, CallEffect: default(BodyEffect?)));
 
-        // A call to a local function whose body reads the variable is a use AT THE CALL: the
+        // A call to a local function whose body reads the variable is a use AT THE CALL (the
         // body's reference sits source-BEFORE the transfer when the function is declared
-        // earlier, so the position filter alone would hide it.
+        // earlier, so the position filter alone would hide it) -- and a call whose body
+        // definitely REWRITES it is a reinitialization at the call site.
         var localFunctionCalls = scanRoots
             .SelectMany(root => root.DescendantsAndSelf())
             .OfType<IInvocationOperation>()
             .Where(invocation => invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
                 && invocation.Syntax.SpanStart >= transferPosition
                 && !IsInASiblingArmOfTheTransfer(invocation, transferPosition)
-                && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition))
-                && LocalFunctionReads(invocation.TargetMethod, variable, scope))
-            .Select(invocation => (Operation: (IOperation)invocation, IsLocalFunctionCall: true));
+                && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition)))
+            .Select(invocation => (Operation: (IOperation)invocation,
+                CallEffect: (BodyEffect?)LocalFunctionCallEffect(invocation.TargetMethod, variable, scope)))
+            .Where(call => call.CallEffect != BodyEffect.None);
 
         var orderedUses = laterReferences.Concat(localFunctionCalls)
             .OrderBy(use => use.Operation.Syntax.SpanStart);
@@ -400,17 +402,21 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // list), so such references are clean while the scan continues past the arm.
         List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated = null;
 
-        foreach (var (reference, isLocalFunctionCall) in orderedUses)
+        foreach (var (reference, callEffect) in orderedUses)
         {
             if (IsDominatedByASkippedReinitialization(dominated, reference))
             {
                 continue;
             }
 
-            if (isLocalFunctionCall)
+            if (callEffect is { } effect)
             {
-                Report(context, reference, variable);
-                return true;
+                if (LocalFunctionCallOutcome(context, reference, variable, effect, transferPosition, scope, ref dominated) is { } outcome)
+                {
+                    return outcome;
+                }
+
+                continue;
             }
 
             switch (Classify(reference, variable, transferPosition, scope, out var rhsUse))
@@ -434,6 +440,36 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     Report(context, rhsUse ?? reference, variable);
                     return true; // one report per transfer keeps the noise proportional
             }
+        }
+
+        return false;
+    }
+
+    // A reading call is the use itself. A resetting call ends tracking exactly like an inline
+    // reinitialization -- when the CALL definitely runs; a conditional one dominates only its
+    // own arm -- minus the throw window: the callee can throw into an enclosing catch before
+    // its reset landed, and the handler then still observes the transferred value. Null: the
+    // scan continues.
+    private static bool? LocalFunctionCallOutcome(OperationBlockAnalysisContext context, IOperation call, ISymbol variable, BodyEffect effect,
+        int transferPosition, IOperation scope, ref List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated)
+    {
+        if (effect == BodyEffect.Reads)
+        {
+            Report(context, call, variable);
+            return true;
+        }
+
+        if (ReinitializationRole(call, transferPosition, scope) != ReferenceRole.FreshValueFromHere)
+        {
+            (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
+                .Add((DominatingRegion(call).Syntax.Span, call.Syntax.Span.End));
+            return null;
+        }
+
+        if (CatchUseDuringReinitialization(call, variable, scope) is { } windowUse)
+        {
+            Report(context, windowUse, variable);
+            return true;
         }
 
         return false;
@@ -498,21 +534,18 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    // Whether CALLING the local function reads the transferred value: the body is scanned in
-    // source order. A reassignment (with a non-reading RHS) that DEFINITELY runs before any
-    // read means the call only ever touches the fresh value; a CONDITIONAL one
-    // (`if (reset) list = new();`) may be skipped, so later reads still count -- except the
-    // ones it dominates (same arm, after it), which read the value it wrote.
-    private static bool LocalFunctionReads(IMethodSymbol localFunction, ISymbol variable, IOperation scope)
-    {
-        var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
-            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, localFunction));
-        if (declaration is null)
-        {
-            return false;
-        }
+    private enum BodyEffect { None, Reads, Resets }
 
-        var references = declaration.DescendantsAndSelf()
+    // What ENTERING the region does to the variable, scanned in source order from the top.
+    // Reads: some path reads the transferred value (`read` is that reference -- possibly the
+    // RHS of a reassignment built FROM it). Resets: a non-reading reassignment that runs
+    // before any read on every path (not nested in a conditional/loop/try, no branch able to
+    // skip it) rewrites the variable. None: the region never touches the transferred value --
+    // reads a skipped conditional reset dominates (same arm, after it) see the fresh value.
+    private static BodyEffect EffectOf(IOperation region, ISymbol variable, out IOperation? read)
+    {
+        read = null;
+        var references = region.DescendantsAndSelf()
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && !IsInsideNameOf(operation))
             .OrderBy(operation => operation.Syntax.SpanStart);
@@ -528,34 +561,47 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             if (reference.Parent is not ISimpleAssignmentOperation assignment
                 || !ReferenceEquals(assignment.Target, reference))
             {
-                return true; // a plain read of the transferred value
+                read = reference; // a plain read of the transferred value
+                return BodyEffect.Reads;
             }
 
-            if (assignment.Value.DescendantsAndSelf().Any(operation =>
-                    SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)))
+            read = assignment.Value.DescendantsAndSelf().FirstOrDefault(operation =>
+                SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                && !IsInsideNameOf(operation));
+            if (read is not null)
             {
-                return true; // the RHS builds the replacement FROM the transferred value
+                return BodyEffect.Reads; // the RHS builds the replacement FROM the transferred value
             }
 
-            if (!IsConditionalWithin(assignment, declaration)
-                && !ABranchCanSkip(assignment, declaration.Syntax.SpanStart, declaration))
+            if (!IsConditionalWithin(assignment, region)
+                && !ABranchCanSkip(assignment, region.Syntax.SpanStart, region))
             {
-                return false; // a definite reset: every call rewrites before any read
+                return BodyEffect.Resets; // rewrites before any read on every path
             }
 
             (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
                 .Add((DominatingRegion(assignment).Syntax.Span, reference.Syntax.Span.End));
         }
 
-        return false;
+        return BodyEffect.None;
+    }
+
+    // Whether CALLING the local function reads the transferred value -- or definitely
+    // rewrites it, making the call act as a reinitialization at the call site.
+    private static BodyEffect LocalFunctionCallEffect(IMethodSymbol localFunction, ISymbol variable, IOperation scope)
+    {
+        var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
+            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, localFunction));
+
+        return declaration is null ? BodyEffect.None : EffectOf(declaration, variable, out _);
     }
 
     // Whether control can reach past the operation without executing it, judged within the
-    // local function's body: any conditional/loop/switch/try ancestor below the declaration
-    // makes it skippable -- and a nested function's body is deferred entirely.
-    private static bool IsConditionalWithin(IOperation operation, ILocalFunctionOperation declaration)
+    // region entered at its top: any conditional/loop/switch/try ancestor below the region
+    // root makes it skippable -- and a nested function's body is deferred entirely.
+    private static bool IsConditionalWithin(IOperation operation, IOperation region)
     {
-        for (var parent = operation.Parent; parent is not null && !ReferenceEquals(parent, declaration); parent = parent.Parent)
+        for (var parent = operation.Parent; parent is not null && !ReferenceEquals(parent, region); parent = parent.Parent)
         {
             if (parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
                 or ILoopOperation or ITryOperation or IConditionalAccessOperation
@@ -709,16 +755,26 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 break;
             }
 
-            if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body))
+            if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body)
+                && WindowUseIn(tryOperation, variable) is { } use)
             {
-                var use = WindowRegionsOf(tryOperation)
-                    .SelectMany(region => region.DescendantsAndSelf())
-                    .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
-                        && !IsInsideNameOf(operation));
-                if (use is not null)
-                {
-                    return use;
-                }
+                return use;
+            }
+        }
+
+        return null;
+    }
+
+    // The first window region that actually READS the transferred value. A handler that
+    // REWRITES the variable before touching it (catch { list = new(); ... }) is a recovery,
+    // not a use -- the reinitialization classification applies inside the window too.
+    private static IOperation? WindowUseIn(ITryOperation tryOperation, ISymbol variable)
+    {
+        foreach (var region in WindowRegionsOf(tryOperation))
+        {
+            if (EffectOf(region, variable, out var read) == BodyEffect.Reads)
+            {
+                return read;
             }
         }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -141,6 +141,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return loop.Body.DescendantsAndSelf().Any(operation =>
             operation.Syntax.SpanStart >= transferPosition
             && operation is IReturnOperation or IThrowOperation or IBranchOperation { BranchKind: BranchKind.Break }
+            && !IsWithinANestedFunction(operation, loop.Body)
             && IsOnTheTransfersConditionalLevel(operation, transferPosition));
     }
 
@@ -154,7 +155,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         switch (argument)
         {
             case IAssignmentOperation assignment:
+                // Transfer(list = other): BOTH list and other alias the handed-off object.
                 yield return assignment.Target;
+                foreach (var source in TransferSources(assignment.Value))
+                {
+                    yield return source;
+                }
+
                 break;
             case ICoalesceOperation coalesce:
                 foreach (var source in TransferSources(coalesce.Value).Concat(TransferSources(coalesce.WhenNull)))
@@ -229,7 +236,12 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
             else if (escape is not null && parent is ITryOperation tryOperation)
             {
-                AddHandlerRoots(roots, tryOperation, child, escapedByThrow: escape is IThrowOperation);
+                // A return whose expression can throw AFTER building the wrapper
+                // (return MayThrow(Sending.Transfer(list));) reaches the handlers like a
+                // thrown transfer does.
+                var reachesHandlers = escape is IThrowOperation
+                    || CanThrowAfterTheTransfer(escape, transfer.Syntax.Span.End);
+                AddHandlerRoots(roots, tryOperation, child, escapedByThrow: reachesHandlers);
             }
         }
 
@@ -360,7 +372,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             if (parent is ITryOperation { Body: { } body } && child is ICatchClauseOperation
                 && Covers(body, transferPosition)
                 && !body.Descendants().Any(operation => operation.Syntax.SpanStart >= transferPosition
-                    && !IsWithinALocalFunction(operation, body)))
+                    && !IsWithinANestedFunction(operation, body))
+                && !CanThrowAfterTheTransfer(body, transferPosition))
             {
                 return true;
             }
@@ -384,19 +397,33 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    // A local-function DECLARATION does not execute (or throw) on the enclosing path: neither
-    // it nor its body counts as code that could reach a handler after the transfer.
-    private static bool IsWithinALocalFunction(IOperation operation, IOperation boundary)
+    // A local-function declaration or lambda body does not execute (or throw, or exit a loop)
+    // on the enclosing path: nothing inside one counts as code the enclosing flow runs.
+    private static bool IsWithinANestedFunction(IOperation operation, IOperation boundary)
     {
         for (var current = operation; current is not null && !ReferenceEquals(current, boundary); current = current.Parent)
         {
-            if (current is ILocalFunctionOperation)
+            if (current is ILocalFunctionOperation or IAnonymousFunctionOperation)
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // Whether the region can still throw ONCE THE WRAPPER EXISTS: calls, creations, awaits,
+    // getters and element reads that END strictly after the transfer -- an op enclosing the
+    // transfer (MayThrow(Sending.Transfer(list))) completes after building the wrapper, while
+    // the Transfer call itself ends exactly AT the position (a throw from it means no wrapper
+    // escaped).
+    private static bool CanThrowAfterTheTransfer(IOperation region, int transferPosition)
+    {
+        return region.DescendantsAndSelf().Any(operation =>
+            operation.Syntax.Span.End > transferPosition
+            && !IsWithinANestedFunction(operation, region)
+            && operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
+                or IPropertyReferenceOperation or IArrayElementReferenceOperation);
     }
 
     // The use is in an arm of an if/switch/?. whose SIBLING arm holds the transfer: the arms
@@ -482,7 +509,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         var reinitRoot = reinitialization is IArgumentOperation { Parent: { } call } ? call : reinitialization;
         var canThrow = reinitRoot.DescendantsAndSelf()
-            .Any(operation => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation);
+            .Any(operation => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
+                or IPropertyReferenceOperation or IArrayElementReferenceOperation);
         if (!canThrow)
         {
             return null;
@@ -497,8 +525,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body))
             {
-                var use = tryOperation.Catches
-                    .SelectMany(catchClause => catchClause.DescendantsAndSelf())
+                var use = WindowRegionsOf(tryOperation)
+                    .SelectMany(region => region.DescendantsAndSelf())
                     .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                         && !IsInsideNameOf(operation));
                 if (use is not null)
@@ -509,6 +537,21 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    // The window reaches the handlers AND the finally: both run when the reinitializing
+    // expression throws before the target was assigned.
+    private static IEnumerable<IOperation> WindowRegionsOf(ITryOperation tryOperation)
+    {
+        foreach (var catchClause in tryOperation.Catches)
+        {
+            yield return catchClause;
+        }
+
+        if (tryOperation.Finally is { } finallyBlock)
+        {
+            yield return finallyBlock;
+        }
     }
 
     private enum ReferenceRole { Use, FreshValueFromHere, ConditionalReinitialization }

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -103,7 +103,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                foreach (var entry in EntriesFor(operation, variable, block))
+                foreach (var entry in EntriesFor(operation, variable, block, classifier))
                 {
                     yield return entry;
                 }
@@ -127,7 +127,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // its constraints prove it harmless.
         if (source.Type is ITypeParameterSymbol typeParameter)
         {
-            return typeParameter.HasUnmanagedTypeConstraint ? null : variable;
+            var provenHarmless = typeParameter.HasUnmanagedTypeConstraint
+                || typeParameter.ConstraintTypes.Any(constraint => constraint.SpecialType == SpecialType.System_Enum);
+            return provenHarmless ? null : variable;
         }
 
         return source.Type is { } sourceType && classifier.GetNotSendableReason(sourceType) is null
@@ -136,7 +138,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> EntriesFor(
-        IOperation transfer, ISymbol variable, IOperation block)
+        IOperation transfer, ISymbol variable, IOperation block, SendableSymbolClassifier classifier)
     {
         var enclosingBody = EnclosingFunctionBody(transfer, block);
         var (scanRoots, escaped) = ScanRootsFor(transfer, enclosingBody);
@@ -148,7 +150,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // A transfer inside a CALLED local function or lambda is sequenced before the
         // caller's continuation: every call site acts as a transfer of its own. A stored
         // but never-invoked callable stays deferred-scoped.
-        foreach (var propagated in CallSiteTransfers(enclosingBody, variable, transfer, block,
+        foreach (var propagated in CallSiteTransfers(enclosingBody, variable, transfer, block, classifier,
             new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
         {
             yield return propagated;
@@ -160,7 +162,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // through that declaration's own callers. A transferred PARAMETER remaps to the caller's
     // argument at each site.
     private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> CallSiteTransfers(
-        IOperation transferBody, ISymbol variable, IOperation anchor, IOperation block, HashSet<IMethodSymbol> visited)
+        IOperation transferBody, ISymbol variable, IOperation anchor, IOperation block, SendableSymbolClassifier classifier, HashSet<IMethodSymbol> visited)
     {
         var functionSymbol = transferBody switch
         {
@@ -197,7 +199,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue; // self-recursion: the body scan already covers it
             }
 
-            foreach (var entry in CallSiteEntries(invocation, callBody, variable, functionSymbol, block, visited))
+            foreach (var entry in CallSiteEntries(invocation, callBody, variable, functionSymbol, block, classifier, visited))
             {
                 yield return entry;
             }
@@ -205,13 +207,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> CallSiteEntries(
-        IInvocationOperation invocation, IOperation callBody, ISymbol variable, IMethodSymbol functionSymbol, IOperation block, HashSet<IMethodSymbol> visited)
+        IInvocationOperation invocation, IOperation callBody, ISymbol variable, IMethodSymbol functionSymbol, IOperation block, SendableSymbolClassifier classifier, HashSet<IMethodSymbol> visited)
     {
-        foreach (var callVariable in CallSiteVariables(invocation, variable, functionSymbol))
+        foreach (var callVariable in CallSiteVariables(invocation, variable, functionSymbol, classifier))
         {
             if (callBody is ILocalFunctionOperation)
             {
-                foreach (var nested in CallSiteTransfers(callBody, callVariable, invocation, block, visited))
+                foreach (var nested in CallSiteTransfers(callBody, callVariable, invocation, block, classifier, visited))
                 {
                     yield return nested;
                 }
@@ -245,7 +247,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     // The caller-side variable the transferred callee variable aliases at THIS call: a
     // captured local stays itself; a PARAMETER maps to the matching argument's sources.
-    private static IEnumerable<ISymbol> CallSiteVariables(IInvocationOperation invocation, ISymbol variable, IMethodSymbol functionSymbol)
+    private static IEnumerable<ISymbol> CallSiteVariables(IInvocationOperation invocation, ISymbol variable, IMethodSymbol functionSymbol, SendableSymbolClassifier classifier)
     {
         if (variable is not IParameterSymbol parameter
             || !SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol.OriginalDefinition, functionSymbol))
@@ -262,7 +264,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         foreach (var source in TransferSources(argument.Value))
         {
-            if (ReferencedVariable(source) is { } mapped)
+            // The same Sendable filter as the direct path: a boxed int argument hands the
+            // receiver nothing mutable.
+            if (TrackedVariableOf(source, classifier) is { } mapped)
             {
                 yield return mapped;
             }
@@ -1222,9 +1226,12 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             operand = conversion.Operand;
         }
 
-        var operandParts = operand is not null && CarriedParts(operand) is { } parts
-            ? parts
-            : System.Linq.Enumerable.Empty<IOperation?>();
+        // The clone SHALLOW-COPIES the operand's slots: a compound operand unfolds its
+        // carried parts, and a leaf operand (a record variable) shares its reference-typed
+        // contents with the receiver-owned clone -- the variable itself is a source.
+        var operandParts = operand is null
+            ? System.Linq.Enumerable.Empty<IOperation?>()
+            : CarriedParts(operand) ?? new[] { (IOperation?)operand };
 
         return withOperation.Initializer is { } initializer
             ? operandParts.Concat(InitializerCarriedParts(initializer))
@@ -1446,11 +1453,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (Callable(value) is { } callable)
+            var yieldedACallable = false;
+            foreach (var callable in Callables(value))
             {
+                yieldedACallable = true;
                 yield return callable;
             }
-            else if (ReferencedVariable(value) is { } alias)
+
+            if (!yieldedACallable && ReferencedVariable(value) is { } alias)
             {
                 // Action use = use2: the copy SNAPSHOTS what the source holds AT THE COPY --
                 // stores landing in the source afterwards are not in use's invocation list.
@@ -1551,6 +1561,37 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    // Every callable a stored value can BE at runtime: `flag ? Touch : fallback` puts
+    // either arm in the delegate, `a ?? b` likewise.
+    private static System.Collections.Generic.IEnumerable<IOperation> Callables(IOperation? stored)
+    {
+        while (stored is IDelegateCreationOperation or IConversionOperation)
+        {
+            stored = stored is IDelegateCreationOperation creation ? creation.Target : ((IConversionOperation)stored).Operand;
+        }
+
+        switch (stored)
+        {
+            case IAnonymousFunctionOperation or IMethodReferenceOperation:
+                yield return stored;
+                break;
+            case IConditionalOperation { WhenFalse: { } whenFalse } conditional:
+                foreach (var callable in Callables(conditional.WhenTrue).Concat(Callables(whenFalse)))
+                {
+                    yield return callable;
+                }
+
+                break;
+            case ICoalesceOperation coalesce:
+                foreach (var callable in Callables(coalesce.Value).Concat(Callables(coalesce.WhenNull)))
+                {
+                    yield return callable;
+                }
+
+                break;
+        }
     }
 
     private static IOperation? Callable(IOperation? stored)
@@ -1674,8 +1715,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 or IDynamicInvocationOperation or IDynamicMemberReferenceOperation
                 or IDynamicIndexerAccessOperation or IDynamicObjectCreationOperation
                 or IEventAssignmentOperation
-                // scope exits dispose: Dispose/DisposeAsync is user code and can throw
-                or IUsingOperation or IUsingDeclarationOperation,
+                // scope exits dispose: Dispose/DisposeAsync is user code and can throw;
+                // a foreach hides MoveNext/Dispose calls on a possibly-custom enumerator
+                or IUsingOperation or IUsingDeclarationOperation or IForEachLoopOperation,
         };
     }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -62,8 +62,36 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            yield return (variable, operation.Syntax.Span.End, EnclosingFunctionBody(operation, block));
+            var scope = EnclosingFunctionBody(operation, block);
+            if (EscapesTheScope(operation, scope))
+            {
+                continue;
+            }
+
+            yield return (variable, operation.Syntax.Span.End, scope);
         }
+    }
+
+    // A transfer the flow immediately leaves behind (`return Sending.Transfer(list);` /
+    // `throw`) has no sender-side continuation in its scope: every later reference is
+    // unreachable on the path that transferred. (break/continue are NOT exits: control
+    // resumes after the loop, where later uses remain reachable.)
+    private static bool EscapesTheScope(IOperation transfer, IOperation scope)
+    {
+        for (var parent = transfer.Parent; parent is not null && !ReferenceEquals(parent, scope); parent = parent.Parent)
+        {
+            if (parent is IReturnOperation or IThrowOperation)
+            {
+                return true;
+            }
+
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                break;
+            }
+        }
+
+        return false;
     }
 
     // Transfer(list = new(...)): after the statement the variable ALIASES the transferred
@@ -152,16 +180,27 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     // The use is in an arm of an if/switch/?. whose SIBLING arm holds the transfer: the arms
     // are mutually exclusive, so no execution path runs the use after the transfer. A use in a
-    // branch the transfer merely precedes stays reportable (some path runs it after).
+    // branch the transfer merely precedes stays reportable (some path runs it after) -- and so
+    // does a use in ANY arm when the transfer sits in the construct's always-executed part
+    // (`if (Sending.Transfer(list) != null) { list.Add(1); }`: the condition dominates both
+    // arms, so the arm runs after the handoff).
     private static bool IsInASiblingArmOfTheTransfer(IOperation use, int transferPosition)
     {
         for (IOperation child = use; child.Parent is { } parent; child = parent)
         {
-            var mutuallyExclusiveArms = parent is IConditionalOperation or ISwitchOperation
-                or ISwitchExpressionOperation or IConditionalAccessOperation;
-            if (mutuallyExclusiveArms
+            var dominatingPart = parent switch
+            {
+                IConditionalOperation conditional => conditional.Condition,
+                ISwitchOperation @switch => @switch.Value,
+                ISwitchExpressionOperation switchExpression => switchExpression.Value,
+                IConditionalAccessOperation conditionalAccess => conditionalAccess.Operation,
+                _ => null,
+            };
+
+            if (dominatingPart is not null
                 && parent.Syntax.Span.Contains(transferPosition)
-                && !child.Syntax.Span.Contains(transferPosition))
+                && !child.Syntax.Span.Contains(transferPosition)
+                && !dominatingPart.Syntax.Span.Contains(transferPosition))
             {
                 return true;
             }

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -11,7 +11,9 @@ namespace MemoizR.Analyzers;
 // mutating it on another flow the moment the wrapper escapes, so the sender must stop using it.
 // The check is method-local and source-ordered: every reference to the transferred local/
 // parameter AFTER the transfer is flagged, until a reassignment gives the variable a fresh
-// value. Deliberately a heuristic (source order approximates execution order; loop back-edges
+// value. A transfer inside a nested callback is scoped to that callback's own body -- the
+// outer flow is not sequenced after code that may run later or never.
+// Deliberately a heuristic (source order approximates execution order; loop back-edges
 // and aliases can evade it) -- Swift proves this with region-based isolation in the type
 // system, which an analyzer cannot reproduce; the single-consumption check in Sending<T> is the
 // runtime backstop on the RECEIVER side.
@@ -32,16 +34,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         foreach (var block in context.OperationBlocks)
         {
-            foreach (var (variable, transferPosition) in Transfers(block))
+            foreach (var (variable, transferPosition, scope) in Transfers(block))
             {
-                ReportUsesAfter(context, block, variable, transferPosition);
+                ReportUsesAfter(context, scope, variable, transferPosition);
             }
         }
     }
 
     // Every Sending<T> creation (constructor or Sending.Transfer) whose argument is a
-    // local/parameter reference, with the position the transfer happens at.
-    private static IEnumerable<(ISymbol Variable, int Position)> Transfers(IOperation block)
+    // local/parameter reference, with the position the transfer happens at and the scope its
+    // report walk covers.
+    private static IEnumerable<(ISymbol Variable, int Position, IOperation Scope)> Transfers(IOperation block)
     {
         foreach (var operation in block.DescendantsAndSelf())
         {
@@ -59,50 +62,83 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            yield return (variable, operation.Syntax.Span.End);
+            yield return (variable, operation.Syntax.Span.End, EnclosingFunctionBody(operation, block));
         }
     }
 
-    private static void ReportUsesAfter(OperationBlockAnalysisContext context, IOperation block, ISymbol variable, int transferPosition)
+    // A transfer inside a nested callback only concerns the callback's own body: the outer
+    // flow is not sequenced after it (the callback may run later or never), so its transfer
+    // must not poison outer references. A transfer in the OUTER body rightly covers uses
+    // inside callbacks defined after it -- if they run at all, they run after the transfer.
+    private static IOperation EnclosingFunctionBody(IOperation operation, IOperation block)
+    {
+        for (var parent = operation.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return parent;
+            }
+        }
+
+        return block;
+    }
+
+    private static void ReportUsesAfter(OperationBlockAnalysisContext context, IOperation scope, ISymbol variable, int transferPosition)
     {
         // Source-ordered walk of every later reference: a reference that is the TARGET of a
         // simple assignment re-initializes the variable, so it and everything after it is a new
         // value -- stop there.
-        var laterReferences = block.DescendantsAndSelf()
+        var laterReferences = scope.DescendantsAndSelf()
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && operation.Syntax.SpanStart >= transferPosition)
             .OrderBy(operation => operation.Syntax.SpanStart);
 
         foreach (var reference in laterReferences)
         {
-            if (reference.Parent is ISimpleAssignmentOperation assignment && ReferenceEquals(assignment.Target, reference))
+            switch (Classify(reference, variable, transferPosition, out var rhsUse))
             {
-                // A reassignment gives the variable a fresh value -- but only if its RHS does
-                // not itself READ the transferred one (`list = Clone(list)` uses it to build
-                // the replacement, which is exactly a use after transfer).
-                var rhsUse = assignment.Value.DescendantsAndSelf()
-                    .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
-                if (rhsUse is not null)
-                {
-                    Report(context, rhsUse, variable);
-                    return;
-                }
-
-                // ...and only if it DEFINITELY executes: a reassignment inside a branch the
-                // transfer is not part of (`if (reset) list = new();`) leaves the other path
-                // still using the transferred value, so the scan continues past it (without
-                // flagging the write target itself).
-                if (IsOnTheTransfersConditionalLevel(assignment, transferPosition))
-                {
-                    return;
-                }
-
-                continue;
+                case ReferenceRole.FreshValueFromHere:
+                    return; // a definite reinitialization: everything after is a new value
+                case ReferenceRole.ConditionalReinitialization:
+                    continue; // may not have run on the path that transferred: keep scanning
+                default:
+                    Report(context, rhsUse ?? reference, variable);
+                    return; // one report per transfer keeps the noise proportional
             }
-
-            Report(context, reference, variable);
-            return; // one report per transfer keeps the noise proportional
         }
+    }
+
+    private enum ReferenceRole { Use, FreshValueFromHere, ConditionalReinitialization }
+
+    // A reference that REINITIALIZES the variable ends tracking when it definitely executes
+    // and is skipped when conditional (sibling arms may not run on the path that transferred).
+    // Reinitializations are a simple-assignment target -- unless its RHS itself READS the
+    // transferred value (`list = Clone(list)` builds the replacement from it: that read is the
+    // use to report) -- and an `out` argument, which the callee must assign and cannot read.
+    private static ReferenceRole Classify(IOperation reference, ISymbol variable, int transferPosition, out IOperation? rhsUse)
+    {
+        rhsUse = null;
+
+        if (reference.Parent is ISimpleAssignmentOperation assignment && ReferenceEquals(assignment.Target, reference))
+        {
+            rhsUse = assignment.Value.DescendantsAndSelf()
+                .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+            return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(assignment, transferPosition);
+        }
+
+        if (reference.Parent is IArgumentOperation { Parameter.RefKind: RefKind.Out } outArgument)
+        {
+            return ReinitializationRole(outArgument, transferPosition);
+        }
+
+        return ReferenceRole.Use;
+    }
+
+    private static ReferenceRole ReinitializationRole(IOperation reinitialization, int transferPosition)
+    {
+        return IsOnTheTransfersConditionalLevel(reinitialization, transferPosition)
+            ? ReferenceRole.FreshValueFromHere
+            : ReferenceRole.ConditionalReinitialization;
     }
 
     // True when the reassignment DEFINITELY executes on the path that transferred: walking up
@@ -112,9 +148,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // but the catch arm may never run. Checking the path-CHILD's span covers both cases at
     // once (a child containing the transfer implies its parent does too); the one arm exempted
     // is a finally block, which always executes.
-    private static bool IsOnTheTransfersConditionalLevel(IOperation assignment, int transferPosition)
+    private static bool IsOnTheTransfersConditionalLevel(IOperation reinitialization, int transferPosition)
     {
-        for (IOperation child = assignment; child.Parent is { } parent; child = parent)
+        for (IOperation child = reinitialization; child.Parent is { } parent; child = parent)
         {
             var branches = parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
                 or ILoopOperation or ITryOperation or IConditionalAccessOperation;

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -304,8 +304,12 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IObjectCreationOperation { Initializer: { } objectInitializer } => objectInitializer.Initializers
                 .SelectMany(element => element switch
                 {
-                    // Member writes carry through compiler-known slots only; a collection
-                    // initializer's Add elements carry like collection-expression elements.
+                    // Member writes carry through compiler-known slots only; an INDEXER
+                    // initializer (["x"] = list) stores value AND keys into the collection;
+                    // a collection initializer's Add elements carry like collection
+                    // expressions.
+                    ISimpleAssignmentOperation { Target: IPropertyReferenceOperation { Property.IsIndexer: true } indexer } member =>
+                        indexer.Arguments.Select(argument => (IOperation?)argument.Value).Concat(new[] { (IOperation?)member.Value }),
                     ISimpleAssignmentOperation member when StoresIntoACompilerKnownSlot(member) => new[] { (IOperation?)member.Value },
                     IInvocationOperation add => add.Arguments.Select(argument => (IOperation?)argument.Value),
                     _ => System.Linq.Enumerable.Empty<IOperation?>(),
@@ -779,12 +783,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return BodyEffect.None;
     }
 
-    // The operations EffectOf walks: references to the variable, plus LOCAL-FUNCTION calls,
-    // whose bodies read or reset transitively (`void Outer() { Use(); }` -- the sibling's
-    // reference sits source-before the transfer, so only the call chain surfaces it).
+    // The operations EffectOf walks: references to the variable, plus LOCAL-FUNCTION and
+    // DELEGATE calls, whose bodies read or reset transitively (`void Outer() { Use(); }` /
+    // `void F() { use(); }` -- the callee's reference sits source-before the transfer, so
+    // only the call chain surfaces it).
     private static bool IsABodyEvent(IOperation operation, ISymbol variable, IOperation region)
     {
-        if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.LocalFunction })
+        if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.LocalFunction or MethodKind.DelegateInvoke })
         {
             return !IsInAnUnreferencedNestedFunction(operation, region);
         }
@@ -807,7 +812,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 return (BodyEffect.Reads, argumentRead, null);
             }
 
-            var callEffect = LocalFunctionCallEffect(invocation.TargetMethod, variable, scope, inProgress);
+            // Delegate stores resolve without the transfer-arm filter here (position 0):
+            // which arm holds the transfer is a scope-level question the body cannot ask.
+            var callEffect = invocation.TargetMethod.MethodKind == MethodKind.DelegateInvoke
+                ? DelegateCallEffect(invocation, variable, transferPosition: 0, scope)
+                : LocalFunctionCallEffect(invocation.TargetMethod, variable, scope, inProgress);
             if (argumentsEffect == BodyEffect.Resets)
             {
                 return (BodyEffect.Resets, null, invocation);
@@ -910,8 +919,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         return region.DescendantsAndSelf().Any(operation => operation switch
         {
-            IInvocationOperation invocation => SymbolEqualityComparer.Default.Equals(invocation.TargetMethod, localFunction),
-            IMethodReferenceOperation methodReference => SymbolEqualityComparer.Default.Equals(methodReference.Method, localFunction),
+            IInvocationOperation invocation => SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.OriginalDefinition, localFunction),
+            IMethodReferenceOperation methodReference => SymbolEqualityComparer.Default.Equals(methodReference.Method.OriginalDefinition, localFunction),
             _ => false,
         });
     }
@@ -922,9 +931,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // detected at the reference where it occurs.
     private static BodyEffect LocalFunctionCallEffect(IMethodSymbol localFunction, ISymbol variable, IOperation scope, HashSet<IMethodSymbol> inProgress)
     {
+        // Use<int>() carries a CONSTRUCTED symbol; the declaration carries the definition.
+        var definition = localFunction.OriginalDefinition;
         var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
-            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, localFunction));
-        if (declaration is null || !inProgress.Add(localFunction))
+            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, definition));
+        if (declaration is null || !inProgress.Add(definition))
         {
             return BodyEffect.None;
         }
@@ -935,7 +946,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
         finally
         {
-            inProgress.Remove(localFunction);
+            inProgress.Remove(definition);
         }
     }
 
@@ -1000,6 +1011,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 ISimpleAssignmentOperation assignment
                     when SymbolEqualityComparer.Default.Equals(ReferencedVariable(assignment.Target), delegateLocal)
                     => assignment.Value,
+                // use += () => ...: the combine keeps every previous target AND adds this one.
+                ICompoundAssignmentOperation combined
+                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(combined.Target), delegateLocal)
+                    => combined.Value,
                 _ => null,
             };
 
@@ -1374,16 +1389,25 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             // path that transferred (`if (move) Transfer(list); else break;`): it cannot skip
             // anything on that path.
             && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
-            && CanSkipPast(operation, reinitPosition));
+            && CanSkipPast(operation, reinitPosition, scope));
     }
 
-    private static bool CanSkipPast(IOperation operation, int reinitPosition)
+    private static bool CanSkipPast(IOperation operation, int reinitPosition, IOperation scope)
     {
         // A caught throw resumes AFTER its try: it skips a reset that try still contains.
         if (operation is IThrowOperation)
         {
             return NearestCatchingTry(operation) is { } catchingTry
                 && catchingTry.Syntax.Span.Contains(reinitPosition);
+        }
+
+        // Returning exits the enclosing function past the reset. Inside a CALLED body's scan
+        // that means the call completes without rewriting -- the caller's later uses still
+        // see the transferred value. In the OUTER scan those later uses are unreachable on
+        // the returning path, so nothing is skipped for them.
+        if (operation is IReturnOperation { Kind: not OperationKind.YieldReturn })
+        {
+            return scope is ILocalFunctionOperation or IAnonymousFunctionOperation;
         }
 
         if (operation is not IBranchOperation branch)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -34,7 +34,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         foreach (var block in context.OperationBlocks)
         {
-            foreach (var (variable, transferPosition, scanRoots, escaped, transfer) in Transfers(block))
+            foreach (var (variable, transferPosition, scanRoots, escaped, transfer, scope) in Transfers(block))
             {
                 // A using-declared local -- or an existing local/parameter handed to a using
                 // STATEMENT as its resource -- is Disposed by the SENDER at scope end, after
@@ -53,8 +53,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 // reads still inside the RHS (after the transfer) and the throw window count.
                 if (EnclosingReinitializingAssignment(transfer, variable) is { } enclosingReinit)
                 {
-                    var scope = scanRoots[scanRoots.Count - 1];
-                    if (!ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition)
+                    if (!ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition, scope)
                         && CatchUseDuringReinitialization(enclosingReinit, variable, scope) is { } windowUse)
                     {
                         Report(context, windowUse, variable);
@@ -63,15 +62,18 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                ReportUsesAfter(context, scanRoots, escaped, variable, transferPosition);
+                ReportUsesAfter(context, scanRoots, escaped, variable, transferPosition, scope);
             }
         }
     }
 
     // Every Sending<T> creation (constructor or Sending.Transfer) whose argument is a
-    // local/parameter reference, with the position the transfer happens at and the regions the
-    // report walk covers.
-    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer)> Transfers(IOperation block)
+    // local/parameter reference, with the position the transfer happens at, the regions the
+    // report walk covers, and the enclosing function body -- declarations and delegate
+    // stores resolve against the BODY even when the scanned regions are narrower (an
+    // escaping `return Pair(Sending.Transfer(list), Use());` still calls a Use declared
+    // outside the return expression).
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> Transfers(IOperation block)
     {
         foreach (var operation in block.DescendantsAndSelf())
         {
@@ -96,10 +98,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                var (scanRoots, escaped) = ScanRootsFor(operation, EnclosingFunctionBody(operation, block));
+                var enclosingBody = EnclosingFunctionBody(operation, block);
+                var (scanRoots, escaped) = ScanRootsFor(operation, enclosingBody);
                 if (scanRoots.Count > 0)
                 {
-                    yield return (variable, operation.Syntax.Span.End, scanRoots, escaped, operation);
+                    yield return (variable, operation.Syntax.Span.End, scanRoots, escaped, operation, enclosingBody);
                 }
             }
         }
@@ -458,9 +461,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return block;
     }
 
-    private static bool ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition)
+    private static bool ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition, IOperation scope)
     {
-        var scope = scanRoots[scanRoots.Count - 1]; // the outermost root is the reinit scope boundary
 
         // Source-ordered walk of every later reference. References in a MUTUALLY EXCLUSIVE
         // sibling arm of the construct holding the transfer are excluded upfront: in

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -291,6 +291,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IAnonymousObjectCreationOperation anonymous => anonymous.Initializers.Select(initializer =>
                 (IOperation?)(initializer is ISimpleAssignmentOperation member ? member.Value : initializer)),
             IConversionOperation conversion => new[] { conversion.Operand },
+            // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
+            // public in the Roslyn this analyzer compiles against, but the children are
+            // walkable regardless. Spread elements are skipped: `[..source]` enumerates the
+            // operand INTO the new collection, so the operand object itself is never carried.
+            { } collection when collection.Syntax is Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax =>
+                collection.ChildOperations
+                    .Where(child => child.Syntax is not Microsoft.CodeAnalysis.CSharp.Syntax.SpreadElementSyntax)
+                    .Select(child => (IOperation?)child),
             _ => null,
         };
     }
@@ -401,25 +409,25 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 && (escaped || !IsInAnUnreachableCatch(operation, transferPosition)))
             .Select(operation => (Operation: operation, CallEffect: default(BodyEffect?)));
 
-        // A call to a local function whose body reads the variable is a use AT THE CALL (the
-        // body's reference sits source-BEFORE the transfer when the function is declared
-        // earlier, so the position filter alone would hide it) -- and a call whose body
-        // definitely REWRITES it is a reinitialization at the call site.
-        var localFunctionCalls = scanRoots
+        // A call to a local function (or through a delegate local) whose body reads the
+        // variable is a use AT THE CALL: the body's reference sits source-BEFORE the transfer
+        // when declared earlier, so the position filter alone would hide it. A body that
+        // definitely REWRITES makes the call a reinitialization instead. Calls written inside
+        // declarations run only through a call TO the declaration -- the call-site effect
+        // resolves the chain transitively, so they are pruned here.
+        var callableCalls = scanRoots
             .SelectMany(root => root.DescendantsAndSelf())
             .OfType<IInvocationOperation>()
-            .Where(invocation => invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
+            .Where(invocation => invocation.TargetMethod.MethodKind is MethodKind.LocalFunction or MethodKind.DelegateInvoke
                 && invocation.Syntax.SpanStart >= transferPosition
                 && !IsInASiblingArmOfTheTransfer(invocation, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition))
-                // A call written inside a local function that nothing ever invokes runs no
-                // more than the declaration around it does.
-                && !IsWithinAnUncalledLocalFunction(invocation, scanRoots, scope))
+                && !IsWithinALocalFunctionBody(invocation, scanRoots))
             .Select(invocation => (Operation: (IOperation)invocation,
-                CallEffect: (BodyEffect?)LocalFunctionCallEffect(invocation.TargetMethod, variable, scope)))
+                CallEffect: (BodyEffect?)CallEffectOf(invocation, variable, scope)))
             .Where(call => call.CallEffect != BodyEffect.None);
 
-        var orderedUses = laterReferences.Concat(localFunctionCalls)
+        var orderedUses = laterReferences.Concat(callableCalls)
             .OrderBy(use => use.Operation.Syntax.SpanStart);
 
         // Regions where a SKIPPED conditional reinitialization dominates: inside its own arm,
@@ -469,6 +477,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static BodyEffect CallEffectOf(IInvocationOperation invocation, ISymbol variable, IOperation scope)
+    {
+        return invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
+            ? LocalFunctionCallEffect(invocation.TargetMethod, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default))
+            : DelegateCallEffect(invocation, variable, scope);
     }
 
     // A reading call is the use itself. A resetting call ends tracking exactly like an inline
@@ -571,52 +586,95 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     // What ENTERING the region does to the variable, scanned in source order from the top.
     // Reads: some path reads the transferred value (`read` is that reference -- possibly the
-    // RHS/sibling argument of a reset built FROM it). Resets: a non-reading reset (simple
-    // assignment, out argument, deconstruction target) that runs before any read on every
-    // path (not nested in a conditional/loop/try, no branch able to skip it) rewrites the
-    // variable. None: the region never touches the transferred value -- reads a skipped
-    // conditional reset dominates (same arm, after it) see the fresh value, and references
-    // inside nested local functions the region never invokes cannot run at all.
-    private static BodyEffect EffectOf(IOperation region, ISymbol variable, out IOperation? read)
+    // RHS/sibling argument of a reset built FROM it, or a call that reads transitively).
+    // Resets: a non-reading reset (simple assignment, out argument, deconstruction target, or
+    // a call whose body definitely rewrites) that runs before any read on every path (not
+    // nested in a conditional/loop/try, no branch able to skip it) rewrites the variable.
+    // None: the region never touches the transferred value -- reads a skipped conditional
+    // reset dominates (same arm, after it) see the fresh value, and references inside nested
+    // local functions the region never invokes cannot run at all. Calls to sibling local
+    // functions resolve against `scope`; `inProgress` breaks recursion cycles.
+    private static BodyEffect EffectOf(IOperation region, ISymbol variable, IOperation scope, HashSet<IMethodSymbol> inProgress, out IOperation? read)
     {
         read = null;
-        var references = region.DescendantsAndSelf()
-            .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
-                && !IsInsideNameOf(operation)
-                && !IsInAnUnreferencedNestedFunction(operation, region))
+        var events = region.DescendantsAndSelf()
+            .Where(operation => IsABodyEvent(operation, variable, region))
             .OrderBy(operation => operation.Syntax.SpanStart);
 
         var dominated = default(List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>);
-        foreach (var reference in references)
+        foreach (var current in events)
         {
-            if (IsDominatedByASkippedReinitialization(dominated, reference))
+            if (IsDominatedByASkippedReinitialization(dominated, current))
             {
                 continue;
             }
 
-            var reset = ResetShapeOf(reference, variable, region, out read);
-            if (reset is null)
+            var (effect, evidence, reset) = ClassifyBodyEvent(current, variable, region, scope, inProgress);
+            if (effect == BodyEffect.Reads)
             {
-                read = reference; // a plain read of the transferred value
+                read = evidence;
                 return BodyEffect.Reads;
             }
 
-            if (read is not null)
+            if (effect != BodyEffect.Resets)
             {
-                return BodyEffect.Reads; // the replacement is built FROM the transferred value
+                continue;
             }
 
-            if (!IsConditionalWithin(reset, region)
-                && !ABranchCanSkip(reset, region.Syntax.SpanStart, region))
+            if (!IsConditionalWithin(reset!, region)
+                && !ABranchCanSkip(reset!, region.Syntax.SpanStart, region))
             {
                 return BodyEffect.Resets; // rewrites before any read on every path
             }
 
             (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
-                .Add((DominatingRegion(reset).Syntax.Span, reference.Syntax.Span.End));
+                .Add((DominatingRegion(reset!).Syntax.Span, current.Syntax.Span.End));
         }
 
         return BodyEffect.None;
+    }
+
+    // The operations EffectOf walks: references to the variable, plus LOCAL-FUNCTION calls,
+    // whose bodies read or reset transitively (`void Outer() { Use(); }` -- the sibling's
+    // reference sits source-before the transfer, so only the call chain surfaces it).
+    private static bool IsABodyEvent(IOperation operation, ISymbol variable, IOperation region)
+    {
+        if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.LocalFunction })
+        {
+            return !IsInAnUnreferencedNestedFunction(operation, region);
+        }
+
+        return SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+            && !IsInsideNameOf(operation)
+            && !IsInAnUnreferencedNestedFunction(operation, region);
+    }
+
+    private static (BodyEffect Effect, IOperation? Evidence, IOperation? Reset) ClassifyBodyEvent(
+        IOperation current, ISymbol variable, IOperation region, IOperation scope, HashSet<IMethodSymbol> inProgress)
+    {
+        if (current is IInvocationOperation invocation)
+        {
+            var callEffect = LocalFunctionCallEffect(invocation.TargetMethod, variable, scope, inProgress);
+            if (callEffect == BodyEffect.Resets
+                && SiblingArgumentRead(invocation.Arguments, variable, region.Syntax.SpanStart) is { } argumentRead)
+            {
+                return (BodyEffect.Reads, argumentRead, null); // arguments run before the body's reset
+            }
+
+            return callEffect == BodyEffect.Reads
+                ? (BodyEffect.Reads, invocation, null)
+                : (callEffect, null, invocation);
+        }
+
+        var reset = ResetShapeOf(current, variable, region, out var resetRead);
+        if (reset is null)
+        {
+            return (BodyEffect.Reads, current, null); // a plain read of the transferred value
+        }
+
+        return resetRead is not null
+            ? (BodyEffect.Reads, resetRead, null) // the replacement is built FROM the transferred value
+            : (BodyEffect.Resets, null, reset);
     }
 
     // The reset operation the reference belongs to (null when it is an ordinary read),
@@ -683,33 +741,94 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         });
     }
 
-    // The outer-scan variant: the boundary is the scan-root set instead of a single region.
-    private static bool IsWithinAnUncalledLocalFunction(IOperation operation, List<IOperation> scanRoots, IOperation scope)
-    {
-        for (var current = operation.Parent; current is not null; current = current.Parent)
-        {
-            if (current is ILocalFunctionOperation nested && !IsReferencedWithin(scope, nested.Symbol))
-            {
-                return true;
-            }
-
-            if (scanRoots.Contains(current))
-            {
-                return false;
-            }
-        }
-
-        return false;
-    }
-
     // Whether CALLING the local function reads the transferred value -- or definitely
-    // rewrites it, making the call act as a reinitialization at the call site.
-    private static BodyEffect LocalFunctionCallEffect(IMethodSymbol localFunction, ISymbol variable, IOperation scope)
+    // rewrites it, making the call act as a reinitialization at the call site. A recursive
+    // chain re-entering a body already on the walk contributes nothing new: mutation is
+    // detected at the reference where it occurs.
+    private static BodyEffect LocalFunctionCallEffect(IMethodSymbol localFunction, ISymbol variable, IOperation scope, HashSet<IMethodSymbol> inProgress)
     {
         var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
             .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, localFunction));
+        if (declaration is null || !inProgress.Add(localFunction))
+        {
+            return BodyEffect.None;
+        }
 
-        return declaration is null ? BodyEffect.None : EffectOf(declaration, variable, out _);
+        try
+        {
+            return EffectOf(declaration, variable, scope, inProgress, out _);
+        }
+        finally
+        {
+            inProgress.Remove(localFunction);
+        }
+    }
+
+    // What invoking the delegate held by a LOCAL does: any lambda (or local function lifted
+    // into the delegate) ever stored in it that reads the transferred value makes the call a
+    // use -- `Action use = () => list.Add(1);` declared before the handoff runs after it.
+    // Never a reset: which stored callable actually runs is dynamic.
+    private static BodyEffect DelegateCallEffect(IInvocationOperation invocation, ISymbol variable, IOperation scope)
+    {
+        if (invocation.Instance is not ILocalReferenceOperation delegateLocal)
+        {
+            return BodyEffect.None;
+        }
+
+        var reads = StoredCallables(delegateLocal.Local, scope).Any(callable => callable switch
+        {
+            IAnonymousFunctionOperation lambda =>
+                EffectOf(lambda, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default), out _) == BodyEffect.Reads,
+            IMethodReferenceOperation { Method: { MethodKind: MethodKind.LocalFunction } method } =>
+                LocalFunctionCallEffect(method, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)) == BodyEffect.Reads,
+            _ => false,
+        });
+
+        return reads ? BodyEffect.Reads : BodyEffect.None;
+    }
+
+    // Every callable ever stored in the delegate local within the scope: its initializer and
+    // all reassignments, unwrapped from the delegate-creation/conversion shells.
+    private static System.Collections.Generic.IEnumerable<IOperation> StoredCallables(ISymbol delegateLocal, IOperation scope)
+    {
+        foreach (var operation in scope.DescendantsAndSelf())
+        {
+            var stored = operation switch
+            {
+                IVariableDeclaratorOperation declarator
+                    when SymbolEqualityComparer.Default.Equals(declarator.Symbol, delegateLocal)
+                    => declarator.Initializer?.Value,
+                ISimpleAssignmentOperation assignment
+                    when SymbolEqualityComparer.Default.Equals(ReferencedVariable(assignment.Target), delegateLocal)
+                    => assignment.Value,
+                _ => null,
+            };
+
+            if (Callable(stored) is { } callable)
+            {
+                yield return callable;
+            }
+        }
+    }
+
+    private static IOperation? Callable(IOperation? stored)
+    {
+        while (true)
+        {
+            switch (stored)
+            {
+                case IDelegateCreationOperation creation:
+                    stored = creation.Target;
+                    break;
+                case IConversionOperation conversion:
+                    stored = conversion.Operand;
+                    break;
+                case IAnonymousFunctionOperation or IMethodReferenceOperation:
+                    return stored;
+                default:
+                    return null;
+            }
+        }
     }
 
     // Whether control can reach past the operation without executing it, judged within the
@@ -872,7 +991,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
 
             if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body)
-                && WindowUseIn(tryOperation, variable) is { } use)
+                && WindowUseIn(tryOperation, variable, scope) is { } use)
             {
                 return use;
             }
@@ -884,11 +1003,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // The first window region that actually READS the transferred value. A handler that
     // REWRITES the variable before touching it (catch { list = new(); ... }) is a recovery,
     // not a use -- the reinitialization classification applies inside the window too.
-    private static IOperation? WindowUseIn(ITryOperation tryOperation, ISymbol variable)
+    private static IOperation? WindowUseIn(ITryOperation tryOperation, ISymbol variable, IOperation scope)
     {
         foreach (var region in WindowRegionsOf(tryOperation))
         {
-            if (EffectOf(region, variable, out var read) == BodyEffect.Reads)
+            if (EffectOf(region, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default), out var read) == BodyEffect.Reads)
             {
                 return read;
             }

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -48,6 +48,21 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
+                // list = MakeFresh(Sending.Transfer(list)): the assignment ENCLOSING the
+                // transfer completes right after the RHS, reinitializing the variable -- only
+                // reads still inside the RHS (after the transfer) and the throw window count.
+                if (EnclosingReinitializingAssignment(transfer, variable) is { } enclosingReinit)
+                {
+                    var scope = scanRoots[scanRoots.Count - 1];
+                    if (!ReportUsesAfter(context, new List<IOperation> { enclosingReinit }, escaped, variable, transferPosition)
+                        && CatchUseDuringReinitialization(enclosingReinit, variable, scope) is { } windowUse)
+                    {
+                        Report(context, windowUse, variable);
+                    }
+
+                    continue;
+                }
+
                 ReportUsesAfter(context, scanRoots, escaped, variable, transferPosition);
             }
         }
@@ -88,6 +103,26 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
+    }
+
+    private static ISimpleAssignmentOperation? EnclosingReinitializingAssignment(IOperation transfer, ISymbol variable)
+    {
+        for (IOperation child = transfer; child.Parent is { } parent; child = parent)
+        {
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                break;
+            }
+
+            if (parent is ISimpleAssignmentOperation assignment
+                && !ReferenceEquals(child, assignment.Target)
+                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(assignment.Target), variable))
+            {
+                return assignment;
+            }
+        }
+
+        return null;
     }
 
     private static bool IsDisposedByAnEnclosingUsing(IOperation transfer, ISymbol variable)
@@ -197,46 +232,39 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 }
 
                 break;
-            case ICoalesceOperation coalesce:
-                foreach (var source in TransferSources(coalesce.Value).Concat(TransferSources(coalesce.WhenNull)))
-                {
-                    yield return source;
-                }
-
-                break;
-            case IConditionalOperation { WhenFalse: { } whenFalse } conditional:
-                foreach (var source in TransferSources(conditional.WhenTrue).Concat(TransferSources(whenFalse)))
-                {
-                    yield return source;
-                }
-
-                break;
-            case ISwitchExpressionOperation switchExpression:
-                foreach (var source in switchExpression.Arms.SelectMany(arm => TransferSources(arm.Value)))
-                {
-                    yield return source;
-                }
-
-                break;
-            case ITupleOperation tuple:
-                // Transfer((list, 0)): the tuple carries the same reference to the receiver.
-                foreach (var source in tuple.Elements.SelectMany(TransferSources))
-                {
-                    yield return source;
-                }
-
-                break;
-            case IConversionOperation conversion:
-                foreach (var source in TransferSources(conversion.Operand))
-                {
-                    yield return source;
-                }
-
-                break;
             case not null:
-                yield return argument;
+                var parts = CarriedParts(argument);
+                if (parts is null)
+                {
+                    yield return argument; // a leaf: the expression itself is the source
+                    break;
+                }
+
+                foreach (var source in parts.SelectMany(TransferSources))
+                {
+                    yield return source;
+                }
+
                 break;
         }
+    }
+
+    // The sub-expressions a compound argument carries into the handoff: whichever operand the
+    // runtime picks for ??/?:/switch expressions, EVERY element of a tuple or array
+    // (Transfer((list, 0)) / Transfer(new[] { list }): the container hands off its contents
+    // with it), and a conversion's operand. Null marks a leaf.
+    private static System.Collections.Generic.IEnumerable<IOperation?>? CarriedParts(IOperation argument)
+    {
+        return argument switch
+        {
+            ICoalesceOperation coalesce => new[] { coalesce.Value, coalesce.WhenNull },
+            IConditionalOperation { WhenFalse: { } whenFalse } conditional => new[] { conditional.WhenTrue, whenFalse },
+            ISwitchExpressionOperation switchExpression => switchExpression.Arms.Select(arm => (IOperation?)arm.Value),
+            ITupleOperation tuple => tuple.Elements,
+            IArrayCreationOperation { Initializer: { } initializer } => initializer.ElementValues,
+            IConversionOperation conversion => new[] { conversion.Operand },
+            _ => null,
+        };
     }
 
     // Where the sender-side scan looks. Normally the whole scope; a transfer the flow
@@ -321,7 +349,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return block;
     }
 
-    private static void ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition)
+    private static bool ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, bool escaped, ISymbol variable, int transferPosition)
     {
         var scope = scanRoots[scanRoots.Count - 1]; // the outermost root is the reinit scope boundary
 
@@ -335,6 +363,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && operation.Syntax.SpanStart >= transferPosition
                 && !IsInsideNameOf(operation)
+                // A local-function DECLARATION does not execute: its body's references count
+                // only through actual invocations (handled below). Lambda bodies stay direct
+                // references -- a delegate built after the transfer escapes into code that
+                // can only run after it.
+                && !IsWithinALocalFunctionBody(operation, scanRoots)
                 && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(operation, transferPosition)))
             .Select(operation => (Operation: operation, IsLocalFunctionCall: false));
@@ -371,7 +404,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             if (isLocalFunctionCall)
             {
                 Report(context, reference, variable);
-                return;
+                return true;
             }
 
             switch (Classify(reference, variable, transferPosition, scope, out var rhsUse))
@@ -383,18 +416,21 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     if (CatchUseDuringReinitialization(reference.Parent!, variable, scope) is { } windowUse)
                     {
                         Report(context, windowUse, variable);
+                        return true;
                     }
 
-                    return; // a definite reinitialization: everything after is a new value
+                    return false; // a definite reinitialization: everything after is a new value
                 case ReferenceRole.ConditionalReinitialization:
                     (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
                         .Add((DominatingRegion(reference.Parent!).Syntax.Span, reference.Syntax.Span.End));
                     continue; // may not have run on the path that transferred: keep scanning
                 default:
                     Report(context, rhsUse ?? reference, variable);
-                    return; // one report per transfer keeps the noise proportional
+                    return true; // one report per transfer keeps the noise proportional
             }
         }
+
+        return false;
     }
 
     private static bool IsDominatedByASkippedReinitialization(List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated, IOperation reference)
@@ -438,15 +474,54 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
+    private static bool IsWithinALocalFunctionBody(IOperation operation, List<IOperation> scanRoots)
+    {
+        for (var current = operation.Parent; current is not null; current = current.Parent)
+        {
+            if (current is ILocalFunctionOperation)
+            {
+                return true;
+            }
+
+            if (scanRoots.Contains(current))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    // Whether CALLING the local function reads the transferred value: the body is scanned in
+    // source order, and a body that REASSIGNS the variable (with a non-reading RHS) before any
+    // read only ever touches the fresh value.
     private static bool LocalFunctionReads(IMethodSymbol localFunction, ISymbol variable, IOperation scope)
     {
         var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
             .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, localFunction));
+        if (declaration is null)
+        {
+            return false;
+        }
 
-        return declaration is not null
-            && declaration.DescendantsAndSelf().Any(operation =>
-                SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
-                && !IsInsideNameOf(operation));
+        var references = declaration.DescendantsAndSelf()
+            .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                && !IsInsideNameOf(operation))
+            .OrderBy(operation => operation.Syntax.SpanStart);
+
+        foreach (var reference in references)
+        {
+            if (reference.Parent is ISimpleAssignmentOperation assignment
+                && ReferenceEquals(assignment.Target, reference))
+            {
+                return assignment.Value.DescendantsAndSelf().Any(operation =>
+                    SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+            }
+
+            return true; // a plain read of the transferred value
+        }
+
+        return false;
     }
 
     // nameof(list) is a compile-time constant: the reference never reads the object at

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -218,9 +218,16 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         // yield return only SUSPENDS the iterator: the next MoveNext resumes inside the loop,
         // so the foreach keeps iterating (yield break, like return, ends it for good).
-        if (operation is IReturnOperation { Kind: not OperationKind.YieldReturn } or IThrowOperation)
+        if (operation is IReturnOperation { Kind: not OperationKind.YieldReturn })
         {
             return true;
+        }
+
+        // A throw absorbed by a catch INSIDE the loop resumes there: only one no handler on
+        // the way out can swallow definitely ends the iteration.
+        if (operation is IThrowOperation)
+        {
+            return !MayBeCaughtWithin(operation, loop);
         }
 
         if (operation is not IBranchOperation { BranchKind: BranchKind.Break } branch)
@@ -293,12 +300,12 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IConversionOperation conversion => new[] { conversion.Operand },
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are
-            // walkable regardless. Spread elements are skipped: `[..source]` enumerates the
-            // operand INTO the new collection, so the operand object itself is never carried.
+            // walkable regardless.
             { } collection when collection.Syntax is Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax =>
-                collection.ChildOperations
-                    .Where(child => child.Syntax is not Microsoft.CodeAnalysis.CSharp.Syntax.SpreadElementSyntax)
-                    .Select(child => (IOperation?)child),
+                collection.ChildOperations.SelectMany(child =>
+                    child.Syntax is Microsoft.CodeAnalysis.CSharp.Syntax.SpreadElementSyntax
+                        ? SpreadCarriedParts(child)
+                        : new[] { (IOperation?)child }),
             _ => null,
         };
     }
@@ -335,12 +342,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
             else if (escape is not null && parent is ITryOperation tryOperation)
             {
-                // A return whose expression can throw AFTER building the wrapper
-                // (return MayThrow(Sending.Transfer(list));) reaches the handlers like a
-                // thrown transfer does.
-                var reachesHandlers = escape is IThrowOperation
-                    || CanThrowAfterTheTransfer(escape, transfer.Syntax.Span.End);
-                AddHandlerRoots(roots, tryOperation, child, escapedByThrow: reachesHandlers);
+                escape = CrossTryTowardScope(roots, tryOperation, child, escape, transfer.Syntax.Span.End);
             }
         }
 
@@ -350,6 +352,76 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return (roots, escape is not null);
+    }
+
+    // Crossing a try on the way out: the handlers/finally that observe the escape become
+    // scan roots, and the escape itself survives -- unless it is a throw this try's own
+    // catches ABSORB, which never leaves the method: control resumes right after the try,
+    // and the sender-side scan must too (null ends the escape).
+    private static IOperation? CrossTryTowardScope(List<IOperation> roots, ITryOperation tryOperation, IOperation child, IOperation escape, int transferPosition)
+    {
+        // A return whose expression can throw AFTER building the wrapper
+        // (return MayThrow(Sending.Transfer(list));) reaches the handlers like a thrown
+        // transfer does.
+        var reachesHandlers = escape is IThrowOperation
+            || CanThrowAfterTheTransfer(escape, transferPosition);
+        AddHandlerRoots(roots, tryOperation, child, escapedByThrow: reachesHandlers);
+
+        if (escape is IThrowOperation thrown && ReferenceEquals(child, tryOperation.Body)
+            && CatchesTheThrow(tryOperation, thrown))
+        {
+            return null;
+        }
+
+        return escape;
+    }
+
+    // Whether the throw DEFINITELY lands in one of the try's handlers: an unfiltered catch
+    // whose type the thrown exception inherits (or a bare catch-all). Filters and unrelated
+    // types stay escapes -- neutralizing an escape that actually leaves would scan code the
+    // transferred path never runs.
+    private static bool CatchesTheThrow(ITryOperation tryOperation, IThrowOperation thrown)
+    {
+        // The thrown operand hides behind the implicit conversion to System.Exception: the
+        // CONVERTED type would never match a derived catch.
+        var exception = thrown.Exception;
+        while (exception is IConversionOperation conversion)
+        {
+            exception = conversion.Operand;
+        }
+
+        if (exception?.Type is not INamedTypeSymbol thrownType)
+        {
+            return false;
+        }
+
+        return tryOperation.Catches.Any(catchClause => catchClause.Filter is null
+            && (catchClause.ExceptionType is not { } caughtType
+                || SelfAndBases(thrownType).Contains(caughtType, SymbolEqualityComparer.Default)));
+    }
+
+    private static System.Collections.Generic.IEnumerable<ITypeSymbol> SelfAndBases(ITypeSymbol type)
+    {
+        for (ITypeSymbol? current = type; current is not null; current = current.BaseType)
+        {
+            yield return current;
+        }
+    }
+
+    // Whether ANY handler between the operation and the boundary could swallow the throw --
+    // filters and types unknown, so possibility suffices.
+    private static bool MayBeCaughtWithin(IOperation thrown, IOperation boundary)
+    {
+        for (IOperation child = thrown; child.Parent is { } parent && !ReferenceEquals(child, boundary); child = parent)
+        {
+            if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body)
+                && tryOperation.Catches.Length > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // A THROWN transfer lands in the try's handlers -- when the throw came from the try BODY
@@ -424,7 +496,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition))
                 && !IsWithinALocalFunctionBody(invocation, scanRoots))
             .Select(invocation => (Operation: (IOperation)invocation,
-                CallEffect: (BodyEffect?)CallEffectOf(invocation, variable, scope)))
+                CallEffect: (BodyEffect?)CallEffectOf(invocation, variable, transferPosition, scope)))
             .Where(call => call.CallEffect != BodyEffect.None);
 
         var orderedUses = laterReferences.Concat(callableCalls)
@@ -479,32 +551,36 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static BodyEffect CallEffectOf(IInvocationOperation invocation, ISymbol variable, IOperation scope)
+    private static BodyEffect CallEffectOf(IInvocationOperation invocation, ISymbol variable, int transferPosition, IOperation scope)
     {
         return invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
             ? LocalFunctionCallEffect(invocation.TargetMethod, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default))
-            : DelegateCallEffect(invocation, variable, scope);
+            : DelegateCallEffect(invocation, variable, transferPosition, scope);
     }
 
-    // A reading call is the use itself. A resetting call ends tracking exactly like an inline
-    // reinitialization -- when the CALL definitely runs; a conditional one dominates only its
-    // own arm -- minus the throw window: the callee can throw into an enclosing catch before
-    // its reset landed, and the handler then still observes the transferred value. Null: the
-    // scan continues.
+    // A reading call is the use itself -- unless its own ARGUMENTS definitely reset the
+    // variable first, feeding the body the fresh value. A resetting call (by body or by
+    // argument) ends tracking exactly like an inline reinitialization -- when the CALL
+    // definitely runs; a conditional one dominates only its own arm -- minus the throw
+    // window: the callee can throw into an enclosing catch before its reset landed, and the
+    // handler then still observes the transferred value. Null: the scan continues.
     private static bool? LocalFunctionCallOutcome(OperationBlockAnalysisContext context, IOperation call, ISymbol variable, BodyEffect effect,
         int transferPosition, IOperation scope, ref List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated)
     {
-        if (effect == BodyEffect.Reads)
+        var argumentsEffect = BodyEffect.None;
+        if (call is IInvocationOperation invocation)
         {
-            Report(context, call, variable);
-            return true;
+            argumentsEffect = ArgumentsEffect(invocation, variable, transferPosition, out var argumentRead);
+            if (argumentRead is not null)
+            {
+                Report(context, argumentRead, variable);
+                return true;
+            }
         }
 
-        // Arguments run BEFORE the body's reset: Reset(list.Count) reads the transferred
-        // value first, and the reset cannot retroactively excuse it.
-        if (call is IInvocationOperation invocation && SiblingArgumentRead(invocation.Arguments, variable, transferPosition) is { } argumentRead)
+        if (effect == BodyEffect.Reads && argumentsEffect != BodyEffect.Resets)
         {
-            Report(context, argumentRead, variable);
+            Report(context, call, variable);
             return true;
         }
 
@@ -522,6 +598,42 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    // Arguments evaluate BEFORE the callee runs: a read among them is a use no body effect
+    // can excuse, and a definite reset among them hands every later evaluation -- the body
+    // included -- the fresh value.
+    private static BodyEffect ArgumentsEffect(IInvocationOperation invocation, ISymbol variable, int floorPosition, out IOperation? read)
+    {
+        read = null;
+        var references = invocation.Arguments
+            .SelectMany(argument => argument.Value.DescendantsAndSelf())
+            .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                && operation.Syntax.SpanStart >= floorPosition
+                && !IsInsideNameOf(operation))
+            .OrderBy(operation => operation.Syntax.SpanStart);
+
+        foreach (var reference in references)
+        {
+            var reset = ResetShapeOf(reference, variable, invocation, out read);
+            if (reset is null)
+            {
+                read = reference;
+                return BodyEffect.Reads;
+            }
+
+            if (read is not null)
+            {
+                return BodyEffect.Reads; // the replacement is built FROM the transferred value
+            }
+
+            if (!IsConditionalWithin(reset, invocation))
+            {
+                return BodyEffect.Resets;
+            }
+        }
+
+        return BodyEffect.None;
     }
 
     private static bool IsDominatedByASkippedReinitialization(List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated, IOperation reference)
@@ -654,11 +766,18 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         if (current is IInvocationOperation invocation)
         {
-            var callEffect = LocalFunctionCallEffect(invocation.TargetMethod, variable, scope, inProgress);
-            if (callEffect == BodyEffect.Resets
-                && SiblingArgumentRead(invocation.Arguments, variable, region.Syntax.SpanStart) is { } argumentRead)
+            // Arguments run BEFORE the body: their reads report and their definite resets
+            // feed the body the fresh value.
+            var argumentsEffect = ArgumentsEffect(invocation, variable, region.Syntax.SpanStart, out var argumentRead);
+            if (argumentRead is not null)
             {
-                return (BodyEffect.Reads, argumentRead, null); // arguments run before the body's reset
+                return (BodyEffect.Reads, argumentRead, null);
+            }
+
+            var callEffect = LocalFunctionCallEffect(invocation.TargetMethod, variable, scope, inProgress);
+            if (argumentsEffect == BodyEffect.Resets)
+            {
+                return (BodyEffect.Resets, null, invocation);
             }
 
             return callEffect == BodyEffect.Reads
@@ -705,6 +824,23 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    // `[..operand]` enumerates the operand INTO the new collection: the operand OBJECT is
+    // never carried, but an inline container's elements are -- [.. new[] { list }] delivers
+    // the same list reference to the receiver. So only the operand's own carried parts
+    // unfold; a plain variable operand contributes nothing.
+    private static System.Collections.Generic.IEnumerable<IOperation?> SpreadCarriedParts(IOperation spread)
+    {
+        var operand = spread.ChildOperations.FirstOrDefault();
+        while (operand is IConversionOperation conversion)
+        {
+            operand = conversion.Operand;
+        }
+
+        return operand is not null && CarriedParts(operand) is { } parts
+            ? parts
+            : System.Linq.Enumerable.Empty<IOperation?>();
     }
 
     private static IOperation? ReadWithin(IOperation expression, ISymbol variable)
@@ -765,17 +901,18 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     // What invoking the delegate held by a LOCAL does: any lambda (or local function lifted
-    // into the delegate) ever stored in it that reads the transferred value makes the call a
-    // use -- `Action use = () => list.Add(1);` declared before the handoff runs after it.
-    // Never a reset: which stored callable actually runs is dynamic.
-    private static BodyEffect DelegateCallEffect(IInvocationOperation invocation, ISymbol variable, IOperation scope)
+    // into the delegate) that can be stored in it when the call runs and reads the
+    // transferred value makes the call a use -- `Action use = () => list.Add(1);` declared
+    // before the handoff runs after it. Never a reset: which stored callable actually runs
+    // is dynamic.
+    private static BodyEffect DelegateCallEffect(IInvocationOperation invocation, ISymbol variable, int transferPosition, IOperation scope)
     {
-        if (invocation.Instance is not ILocalReferenceOperation delegateLocal)
+        if (DelegateReceiver(invocation) is not { } delegateLocal)
         {
             return BodyEffect.None;
         }
 
-        var reads = StoredCallables(delegateLocal.Local, scope).Any(callable => callable switch
+        var reads = StoredCallables(delegateLocal, scope, invocation, transferPosition).Any(callable => callable switch
         {
             IAnonymousFunctionOperation lambda =>
                 EffectOf(lambda, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default), out _) == BodyEffect.Reads,
@@ -787,9 +924,32 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return reads ? BodyEffect.Reads : BodyEffect.None;
     }
 
-    // Every callable ever stored in the delegate local within the scope: its initializer and
-    // all reassignments, unwrapped from the delegate-creation/conversion shells.
-    private static System.Collections.Generic.IEnumerable<IOperation> StoredCallables(ISymbol delegateLocal, IOperation scope)
+    // The local the invocation calls through -- behind a ?. receiver too: use?.Invoke() puts
+    // a placeholder in Instance, and the real receiver hangs off the enclosing conditional
+    // access.
+    private static ISymbol? DelegateReceiver(IInvocationOperation invocation)
+    {
+        var receiver = invocation.Instance;
+        if (receiver is IConditionalAccessInstanceOperation)
+        {
+            for (var parent = invocation.Parent; parent is not null; parent = parent.Parent)
+            {
+                if (parent is IConditionalAccessOperation conditionalAccess)
+                {
+                    receiver = conditionalAccess.Operation;
+                    break;
+                }
+            }
+        }
+
+        return ReferencedVariable(receiver);
+    }
+
+    // Every callable stored in the delegate local that can still be its value AT THE CALL:
+    // stores in a sibling arm of the transfer never run on the transferred path, and a store
+    // that only happens after the call cannot be what it invoked -- unless a loop carries it
+    // back around.
+    private static System.Collections.Generic.IEnumerable<IOperation> StoredCallables(ISymbol delegateLocal, IOperation scope, IInvocationOperation call, int transferPosition)
     {
         foreach (var operation in scope.DescendantsAndSelf())
         {
@@ -804,11 +964,31 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 _ => null,
             };
 
+            if (stored is null
+                || IsInASiblingArmOfTheTransfer(operation, transferPosition)
+                || (operation.Syntax.SpanStart >= call.Syntax.Span.End && !SharesALoopWith(operation, call)))
+            {
+                continue;
+            }
+
             if (Callable(stored) is { } callable)
             {
                 yield return callable;
             }
         }
+    }
+
+    private static bool SharesALoopWith(IOperation store, IOperation call)
+    {
+        for (var parent = call.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is ILoopOperation && parent.Syntax.Span.Contains(store.Syntax.SpanStart))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static IOperation? Callable(IOperation? stored)
@@ -832,14 +1012,25 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     // Whether control can reach past the operation without executing it, judged within the
-    // region entered at its top: any conditional/loop/switch/try ancestor below the region
-    // root makes it skippable -- and a nested function's body is deferred entirely.
+    // region entered at its top: any conditional/loop/switch ancestor below the region root
+    // makes it skippable, a nested function's body is deferred entirely, and a try counts
+    // only where a path can resume past a failure (catch regions, bodies WITH catches).
     private static bool IsConditionalWithin(IOperation operation, IOperation region)
     {
-        for (var parent = operation.Parent; parent is not null && !ReferenceEquals(parent, region); parent = parent.Parent)
+        for (IOperation child = operation; child.Parent is { } parent && !ReferenceEquals(parent, region); child = parent)
         {
+            if (parent is ITryOperation tryOperation)
+            {
+                if (!RunsToCompletionOrExits(tryOperation, child))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
             if (parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
-                or ILoopOperation or ITryOperation or IConditionalAccessOperation
+                or ILoopOperation or IConditionalAccessOperation
                 or IAnonymousFunctionOperation or ILocalFunctionOperation)
             {
                 return true;
@@ -1180,7 +1371,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         {
             var branches = parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
                 or ILoopOperation or ITryOperation or IConditionalAccessOperation;
-            if (!branches || (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Finally)))
+            if (!branches || (parent is ITryOperation tryOperation && RunsToCompletionOrExits(tryOperation, child)))
             {
                 continue;
             }
@@ -1192,6 +1383,16 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return true;
+    }
+
+    // A finally always runs, and a CATCHLESS try body either completes or leaves the scope
+    // entirely -- no path resumes past a failed reset inside them, so neither makes the reset
+    // conditional. A try body with catches CAN be resumed past (the handler swallows the
+    // failure), and a catch region itself runs only on exception.
+    private static bool RunsToCompletionOrExits(ITryOperation tryOperation, IOperation child)
+    {
+        return ReferenceEquals(child, tryOperation.Finally)
+            || (ReferenceEquals(child, tryOperation.Body) && tryOperation.Catches.IsEmpty);
     }
 
     private static void Report(OperationBlockAnalysisContext context, IOperation reference, ISymbol variable)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -85,21 +85,37 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     private static void ReportUsesAfter(OperationBlockAnalysisContext context, IOperation scope, ISymbol variable, int transferPosition)
     {
-        // Source-ordered walk of every later reference: a reference that is the TARGET of a
-        // simple assignment re-initializes the variable, so it and everything after it is a new
-        // value -- stop there.
+        // Source-ordered walk of every later reference. References in a MUTUALLY EXCLUSIVE
+        // sibling arm of the construct holding the transfer are excluded upfront: in
+        // `if (move) Transfer(list); else list.Add(1);` no path runs the else after the
+        // transfer. (Try constructs are not excluded -- an exception after the transfer
+        // reaches the handlers and finally.)
         var laterReferences = scope.DescendantsAndSelf()
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
-                && operation.Syntax.SpanStart >= transferPosition)
+                && operation.Syntax.SpanStart >= transferPosition
+                && !IsInASiblingArmOfTheTransfer(operation, transferPosition))
             .OrderBy(operation => operation.Syntax.SpanStart);
+
+        // Regions where a SKIPPED conditional reinitialization dominates: inside its own arm,
+        // after it, the variable is fresh on every path that reaches the reference
+        // (`if (reset) { list = new(); list.Add(1); }` -- the Add never sees the transferred
+        // list), so such references are clean while the scan continues past the arm.
+        List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated = null;
 
         foreach (var reference in laterReferences)
         {
-            switch (Classify(reference, variable, transferPosition, out var rhsUse))
+            if (IsDominatedByASkippedReinitialization(dominated, reference))
+            {
+                continue;
+            }
+
+            switch (Classify(reference, variable, transferPosition, scope, out var rhsUse))
             {
                 case ReferenceRole.FreshValueFromHere:
                     return; // a definite reinitialization: everything after is a new value
                 case ReferenceRole.ConditionalReinitialization:
+                    (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
+                        .Add((DominatingRegion(reference.Parent!).Syntax.Span, reference.Syntax.Span.End));
                     continue; // may not have run on the path that transferred: keep scanning
                 default:
                     Report(context, rhsUse ?? reference, variable);
@@ -108,14 +124,74 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    private static bool IsDominatedByASkippedReinitialization(List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>? dominated, IOperation reference)
+    {
+        if (dominated is null)
+        {
+            return false;
+        }
+
+        var start = reference.Syntax.SpanStart;
+        foreach (var (region, position) in dominated)
+        {
+            if (start >= position && region.Contains(start))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // The use is in an arm of an if/switch/?. whose SIBLING arm holds the transfer: the arms
+    // are mutually exclusive, so no execution path runs the use after the transfer. A use in a
+    // branch the transfer merely precedes stays reportable (some path runs it after).
+    private static bool IsInASiblingArmOfTheTransfer(IOperation use, int transferPosition)
+    {
+        for (IOperation child = use; child.Parent is { } parent; child = parent)
+        {
+            var mutuallyExclusiveArms = parent is IConditionalOperation or ISwitchOperation
+                or ISwitchExpressionOperation or IConditionalAccessOperation;
+            if (mutuallyExclusiveArms
+                && parent.Syntax.Span.Contains(transferPosition)
+                && !child.Syntax.Span.Contains(transferPosition))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // The region a skipped conditional reinitialization dominates: its nearest enclosing arm
+    // (or callback body -- a deferred reinitialization dominates only inside its own callback,
+    // where source order applies again).
+    private static IOperation DominatingRegion(IOperation reinitialization)
+    {
+        for (IOperation child = reinitialization; child.Parent is { } parent; child = parent)
+        {
+            if (parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
+                or ILoopOperation or ITryOperation or IConditionalAccessOperation
+                or IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return child;
+            }
+        }
+
+        return reinitialization;
+    }
+
     private enum ReferenceRole { Use, FreshValueFromHere, ConditionalReinitialization }
 
     // A reference that REINITIALIZES the variable ends tracking when it definitely executes
     // and is skipped when conditional (sibling arms may not run on the path that transferred).
     // Reinitializations are a simple-assignment target -- unless its RHS itself READS the
     // transferred value (`list = Clone(list)` builds the replacement from it: that read is the
-    // use to report) -- and an `out` argument, which the callee must assign and cannot read.
-    private static ReferenceRole Classify(IOperation reference, ISymbol variable, int transferPosition, out IOperation? rhsUse)
+    // use to report) -- and an `out` argument, which the callee must assign and cannot read;
+    // the out-assignment happens only when the callee RUNS, after every sibling argument was
+    // evaluated, so a sibling argument reading the variable is still a use of the transferred
+    // value.
+    private static ReferenceRole Classify(IOperation reference, ISymbol variable, int transferPosition, IOperation scope, out IOperation? rhsUse)
     {
         rhsUse = null;
 
@@ -123,19 +199,42 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         {
             rhsUse = assignment.Value.DescendantsAndSelf()
                 .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
-            return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(assignment, transferPosition);
+            return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(assignment, transferPosition, scope);
         }
 
         if (reference.Parent is IArgumentOperation { Parameter.RefKind: RefKind.Out } outArgument)
         {
-            return ReinitializationRole(outArgument, transferPosition);
+            rhsUse = SiblingArgumentRead(outArgument, variable);
+            return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(outArgument, transferPosition, scope);
         }
 
         return ReferenceRole.Use;
     }
 
-    private static ReferenceRole ReinitializationRole(IOperation reinitialization, int transferPosition)
+    private static IOperation? SiblingArgumentRead(IArgumentOperation outArgument, ISymbol variable)
     {
+        var arguments = outArgument.Parent switch
+        {
+            IInvocationOperation invocation => invocation.Arguments,
+            IObjectCreationOperation creation => creation.Arguments,
+            _ => ImmutableArray<IArgumentOperation>.Empty,
+        };
+
+        return arguments.Where(argument => !ReferenceEquals(argument, outArgument))
+            .SelectMany(argument => argument.Value.DescendantsAndSelf())
+            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+    }
+
+    private static ReferenceRole ReinitializationRole(IOperation reinitialization, int transferPosition, IOperation scope)
+    {
+        // A reinitialization inside a nested callback is DEFERRED: the outer flow cannot count
+        // on it having run (the mirror of scoping transfers to their own body). It still
+        // dominates within its own callback, where source order applies again.
+        if (!ReferenceEquals(EnclosingFunctionBody(reinitialization, scope), scope))
+        {
+            return ReferenceRole.ConditionalReinitialization;
+        }
+
         return IsOnTheTransfersConditionalLevel(reinitialization, transferPosition)
             ? ReferenceRole.FreshValueFromHere
             : ReferenceRole.ConditionalReinitialization;

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -36,10 +36,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         {
             foreach (var (variable, transferPosition, scanRoots, escaped, transfer) in Transfers(block))
             {
-                // A using-declared local is Disposed by the SENDER at scope end -- after the
-                // handoff, with no source reference to scan for: destroying the object the
+                // A using-declared local -- or an existing local/parameter handed to a using
+                // STATEMENT as its resource -- is Disposed by the SENDER at scope end, after
+                // the handoff, with no source reference to scan for: destroying the object the
                 // receiver now owns is a guaranteed use-after-transfer.
-                if (variable is ILocalSymbol { IsUsing: true })
+                if (variable is ILocalSymbol { IsUsing: true } || IsDisposedByAnEnclosingUsing(transfer, variable))
                 {
                     Report(context, transfer, variable);
                     continue;
@@ -87,6 +88,26 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    private static bool IsDisposedByAnEnclosingUsing(IOperation transfer, ISymbol variable)
+    {
+        for (var parent = transfer.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                break; // a using outside the callback disposes on the OUTER flow's schedule
+            }
+
+            if (parent is IUsingOperation usingOperation
+                && usingOperation.Resources.DescendantsAndSelf().Any(operation =>
+                    SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // The variables an argument expression can HAND OFF. An assignment transfers its target
     // (Transfer(list = new(...)) / Transfer(list ??= new(...)): the variable aliases the value
     // afterwards); a null-coalescing or conditional expression transfers whichever operand the
@@ -108,6 +129,28 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 break;
             case IConditionalOperation { WhenFalse: { } whenFalse } conditional:
                 foreach (var source in TransferSources(conditional.WhenTrue).Concat(TransferSources(whenFalse)))
+                {
+                    yield return source;
+                }
+
+                break;
+            case ISwitchExpressionOperation switchExpression:
+                foreach (var source in switchExpression.Arms.SelectMany(arm => TransferSources(arm.Value)))
+                {
+                    yield return source;
+                }
+
+                break;
+            case ITupleOperation tuple:
+                // Transfer((list, 0)): the tuple carries the same reference to the receiver.
+                foreach (var source in tuple.Elements.SelectMany(TransferSources))
+                {
+                    yield return source;
+                }
+
+                break;
+            case IConversionOperation conversion:
+                foreach (var source in TransferSources(conversion.Operand))
                 {
                     yield return source;
                 }
@@ -209,6 +252,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .SelectMany(root => root.DescendantsAndSelf())
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && operation.Syntax.SpanStart >= transferPosition
+                && !IsInsideNameOf(operation)
                 && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(operation, transferPosition)))
             .OrderBy(operation => operation.Syntax.SpanStart);
@@ -271,7 +315,38 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         {
             if (parent is ITryOperation { Body: { } body } && child is ICatchClauseOperation
                 && Covers(body, transferPosition)
-                && !body.Descendants().Any(operation => operation.Syntax.SpanStart >= transferPosition))
+                && !body.Descendants().Any(operation => operation.Syntax.SpanStart >= transferPosition
+                    && !IsWithinALocalFunction(operation, body)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // nameof(list) is a compile-time constant: the reference never reads the object at
+    // runtime, so it is neither a use nor read-evidence in the RHS/sibling-argument scans.
+    private static bool IsInsideNameOf(IOperation operation)
+    {
+        for (var parent = operation.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is INameOfOperation)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // A local-function DECLARATION does not execute (or throw) on the enclosing path: neither
+    // it nor its body counts as code that could reach a handler after the transfer.
+    private static bool IsWithinALocalFunction(IOperation operation, IOperation boundary)
+    {
+        for (var current = operation; current is not null && !ReferenceEquals(current, boundary); current = current.Parent)
+        {
+            if (current is ILocalFunctionOperation)
             {
                 return true;
             }
@@ -373,7 +448,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         if (reference.Parent is ISimpleAssignmentOperation assignment && ReferenceEquals(assignment.Target, reference))
         {
             rhsUse = assignment.Value.DescendantsAndSelf()
-                .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+                .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                    && !IsInsideNameOf(operation));
             return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(assignment, transferPosition, scope);
         }
 
@@ -388,7 +464,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         if (DeconstructionOf(reference) is { } deconstruction)
         {
             rhsUse = deconstruction.Value.DescendantsAndSelf()
-                .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+                .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                    && !IsInsideNameOf(operation));
             return rhsUse is not null ? ReferenceRole.Use : ReinitializationRole(deconstruction, transferPosition, scope);
         }
 
@@ -422,7 +499,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         return arguments.Where(argument => !ReferenceEquals(argument, outArgument))
             .SelectMany(argument => argument.Value.DescendantsAndSelf())
-            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
+            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                && !IsInsideNameOf(operation));
     }
 
     private static ReferenceRole ReinitializationRole(IOperation reinitialization, int transferPosition, IOperation scope)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -415,9 +415,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             // The enumerator iterates the collection captured at LOOP ENTRY: an iteration
             // that definitely reassigns before transferring hands off a different object
-            // than the one MoveNext keeps reading.
+            // than the one MoveNext keeps reading. A collection EXPRESSION built from the
+            // variable (list.Where(...)) keeps pulling from the same list -- and even an
+            // eager copy re-runs the transfer itself on the next iteration.
             if (parent is IForEachLoopOperation foreachLoop
-                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(foreachLoop.Collection), variable)
+                && ReadWithin(foreachLoop.Collection, variable) is not null
                 && !DefinitelyExitsAfter(foreachLoop, transferPosition)
                 && !DefinitelyReassignedBefore(foreachLoop.Body, variable, transfer))
             {
@@ -854,7 +856,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .Where(reference => reference is ILocalReferenceOperation or IParameterReferenceOperation
                 && DelegateSymbolOf(reference) is { } delegateSymbol
                 && reference.Syntax.SpanStart >= transferPosition
-                && EscapesTheScope(reference)
+                && EscapesTheScope(reference, scope)
                 && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
                 && !IsWithinALocalFunctionBody(reference, scanRoots)
@@ -1521,7 +1523,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // A delegate reference ESCAPES when it is returned, passed as an argument, or stored
     // into a non-local slot -- merely inspecting it (use != null) runs nothing, a local
     // copy is an alias resolved at ITS uses, and calls/stores are classified separately.
-    private static bool EscapesTheScope(IOperation reference)
+    private static bool EscapesTheScope(IOperation reference, IOperation scope)
     {
         for (IOperation child = reference; child.Parent is { } parent; child = parent)
         {
@@ -1544,8 +1546,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     continue;
                 case IReturnOperation { Kind: not OperationKind.YieldBreak }:
                     return true;
-                case IArgumentOperation:
-                    return true;
+                case IArgumentOperation argument:
+                    return !IsDroppedByAnInertLocalFunction(argument, scope);
                 case ISimpleAssignmentOperation assignment when !ReferenceEquals(child, assignment.Target):
                     return ReferencedVariable(assignment.Target) is null; // a non-local slot publishes
                 case ICompoundAssignmentOperation compound when !ReferenceEquals(child, compound.Target):
@@ -1556,6 +1558,32 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    // An argument to a SAME-SCOPE local function whose body never references the parameter
+    // is dropped, not published: nothing can run or store a delegate its callee never
+    // touches. Any reference at all keeps the escape (the body may invoke, store, or
+    // forward it), and methods outside the scope stay opaque escapes.
+    private static bool IsDroppedByAnInertLocalFunction(IArgumentOperation argument, IOperation scope)
+    {
+        if (argument.Parent is not IInvocationOperation { TargetMethod: { MethodKind: MethodKind.LocalFunction } target }
+            || argument.Parameter is not { } parameter)
+        {
+            return false;
+        }
+
+        var definition = target.OriginalDefinition;
+        var declaration = scope.DescendantsAndSelf().OfType<ILocalFunctionOperation>()
+            .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(operation.Symbol, definition));
+        if (declaration is null || parameter.Ordinal >= definition.Parameters.Length)
+        {
+            return false;
+        }
+
+        var declared = definition.Parameters[parameter.Ordinal];
+        return !declaration.DescendantsAndSelf().Any(operation =>
+            operation is IParameterReferenceOperation reference
+            && SymbolEqualityComparer.Default.Equals(reference.Parameter, declared));
     }
 
     private static ISymbol? DelegateReceiver(IInvocationOperation invocation)
@@ -1590,7 +1618,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return reference switch
         {
             IFieldReferenceOperation { Instance: null or IInstanceReferenceOperation } field => field.Field,
-            IPropertyReferenceOperation { Instance: null or IInstanceReferenceOperation } property => property.Property,
+            // Only a BACKING slot stores what its setter was handed: custom accessors may
+            // discard the assignment and manufacture something else entirely.
+            IPropertyReferenceOperation { Instance: null or IInstanceReferenceOperation } property
+                when SendableSymbolClassifier.HasBackingSlot(property.Property) => property.Property,
             _ => null,
         };
     }
@@ -1611,24 +1642,31 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         var stores = DelegateStores(delegateLocal, scope, consumer, transferPosition);
 
         // A definite overwrite replaces the whole invocation list: candidates begin at the
-        // LAST replace that runs on every path to the call.
+        // LAST replace that runs on every path TO THE CALL -- a branch-local overwrite
+        // counts when the call lives in the same arm (`if (flag) { use = ...; use(); }`).
         var killPoint = stores
-            .Where(store => store.Replaces && !IsConditionalWithin(store.Site, scope))
+            .Where(store => store.Replaces && !MakesTheStoreConditionalTowards(store.Site, consumer, scope))
             .Select(store => store.Site.Syntax.SpanStart)
             .DefaultIfEmpty(int.MinValue)
             .Max();
 
-        var survivors = SurvivingStoreIndices(stores, delegateLocal, scope, consumer);
+        var cancelled = CancelledComponents(stores, delegateLocal, scope, consumer);
 
         for (var index = 0; index < stores.Count; index++)
         {
             var (site, value, _) = stores[index];
-            if (site.Syntax.SpanStart < killPoint || !survivors.Contains(index))
+            if (site.Syntax.SpanStart < killPoint)
             {
                 continue;
             }
 
-            foreach (var resolved in ResolvedCallables(value, site, scope, transferPosition, visited))
+            var components = ResolvedCallables(value, site, scope, transferPosition, visited).ToList();
+            if (cancelled.TryGetValue(index, out var removedMethods))
+            {
+                RemoveLastOccurrences(components, removedMethods);
+            }
+
+            foreach (var resolved in components)
             {
                 yield return resolved;
             }
@@ -1657,29 +1695,85 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // A definite `-= M` strips ONE matching target -- the last prior add/assignment of M
-    // (only method groups are identifiable; removing a fresh lambda instance removes
-    // nothing). Duplicate subscriptions survive their single removal.
-    private static HashSet<int> SurvivingStoreIndices(
+    // A definite `-= M` strips ONE occurrence of M -- Delegate.Remove semantics: the last
+    // occurrence definitely present among the prior stores, combined invocation lists
+    // included (only method groups are identifiable; removing a fresh lambda instance
+    // removes nothing, and an occurrence under a conditional arm is not definitely there
+    // to strip). Duplicate subscriptions survive their single removal.
+    private static Dictionary<int, List<IMethodSymbol>> CancelledComponents(
         List<(IOperation Site, IOperation Value, bool Replaces)> stores, ISymbol delegateLocal, IOperation scope, IOperation consumer)
     {
-        var survivors = new HashSet<int>(Enumerable.Range(0, stores.Count));
+        var cancelled = new Dictionary<int, List<IMethodSymbol>>();
         foreach (var removal in DelegateRemovals(delegateLocal, scope, consumer).OrderBy(removal => removal.Position))
         {
             for (var index = stores.Count - 1; index >= 0; index--)
             {
-                if (survivors.Contains(index)
-                    && stores[index].Site.Syntax.SpanStart < removal.Position
-                    && Callable(stores[index].Value) is IMethodReferenceOperation storedGroup
-                    && SymbolEqualityComparer.Default.Equals(removal.Method, storedGroup.Method.OriginalDefinition))
+                if (stores[index].Site.Syntax.SpanStart < removal.Position
+                    && RemainingDefiniteOccurrences(stores[index].Value, removal.Method, cancelled, index) > 0)
                 {
-                    survivors.Remove(index);
+                    if (!cancelled.TryGetValue(index, out var methods))
+                    {
+                        cancelled[index] = methods = new List<IMethodSymbol>();
+                    }
+
+                    methods.Add(removal.Method);
                     break;
                 }
             }
         }
 
-        return survivors;
+        return cancelled;
+    }
+
+    private static int RemainingDefiniteOccurrences(
+        IOperation value, IMethodSymbol method, Dictionary<int, List<IMethodSymbol>> cancelled, int index)
+    {
+        var present = DefiniteMethodGroups(value)
+            .Count(group => SymbolEqualityComparer.Default.Equals(group.Method.OriginalDefinition, method));
+        var taken = cancelled.TryGetValue(index, out var methods)
+            ? methods.Count(taken => SymbolEqualityComparer.Default.Equals(taken, method))
+            : 0;
+        return present - taken;
+    }
+
+    // The method groups DEFINITELY in a stored value's invocation list: `+` combines carry
+    // both sides and wrappers are transparent, but a conditional's arms are ALTERNATIVES.
+    private static System.Collections.Generic.IEnumerable<IMethodReferenceOperation> DefiniteMethodGroups(IOperation? stored)
+    {
+        while (stored is IDelegateCreationOperation or IConversionOperation)
+        {
+            stored = stored is IDelegateCreationOperation creation ? creation.Target : ((IConversionOperation)stored).Operand;
+        }
+
+        switch (stored)
+        {
+            case IMethodReferenceOperation group:
+                yield return group;
+                break;
+            case IBinaryOperation { OperatorKind: BinaryOperatorKind.Add } combine:
+                foreach (var group in DefiniteMethodGroups(combine.LeftOperand).Concat(DefiniteMethodGroups(combine.RightOperand)))
+                {
+                    yield return group;
+                }
+
+                break;
+        }
+    }
+
+    private static void RemoveLastOccurrences(List<IOperation> components, List<IMethodSymbol> removedMethods)
+    {
+        foreach (var method in removedMethods)
+        {
+            for (var position = components.Count - 1; position >= 0; position--)
+            {
+                if (components[position] is IMethodReferenceOperation group
+                    && SymbolEqualityComparer.Default.Equals(group.Method.OriginalDefinition, method))
+                {
+                    components.RemoveAt(position);
+                    break;
+                }
+            }
+        }
     }
 
     private static List<(int Position, IMethodSymbol Method)> DelegateRemovals(ISymbol delegateLocal, IOperation scope, IOperation consumer)
@@ -1860,6 +1954,45 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     return null;
             }
         }
+    }
+
+    // Whether the store is conditional ON THE WAY TO the consumer: a conditional construct
+    // between them makes the overwrite skippable, but an arm the CONSUMER itself lives in
+    // ran on every path that reaches it -- from that ancestor upward, store and consumer
+    // share every branch. Nested function bodies stay deferred (they run on their own
+    // schedule), and a try body is definite only where a failure cannot resume past it.
+    private static bool MakesTheStoreConditionalTowards(IOperation store, IOperation consumer, IOperation scope)
+    {
+        for (IOperation child = store; child.Parent is { } parent && !ReferenceEquals(parent, scope); child = parent)
+        {
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return true;
+            }
+
+            if (child.Syntax.Span.Contains(consumer.Syntax.Span))
+            {
+                return false;
+            }
+
+            if (parent is ITryOperation tryOperation)
+            {
+                if (!RunsToCompletionOrExits(tryOperation, child))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
+                or ILoopOperation or IConditionalAccessOperation)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Whether control can reach past the operation without executing it, judged within the

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -139,21 +139,40 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             // wrapper, not the transferred object. A `lock (gate)` around the transfer is the
             // same shape: the compiler-generated Monitor.Exit touches the handed-off object
             // at scope end.
-            var scopeExitTarget = parent switch
+            var (scopeExitTarget, body) = parent switch
             {
-                IUsingOperation usingOperation => usingOperation.Resources,
-                ILockOperation lockOperation => lockOperation.LockedValue,
-                _ => null,
+                IUsingOperation usingOperation => ((IOperation?)usingOperation.Resources, usingOperation.Body),
+                ILockOperation lockOperation => ((IOperation?)lockOperation.LockedValue, lockOperation.Body),
+                _ => (null, null),
             };
 
+            // The construct captured the OBJECT at entry: after a definite reassignment the
+            // generated Dispose/Monitor.Exit touches the old object, not the one handed off.
             if (scopeExitTarget is not null
-                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(scopeExitTarget), variable))
+                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(scopeExitTarget), variable)
+                && !(body is not null && DefinitelyReassignedBefore(body, variable, transfer)))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // Whether the variable definitely no longer holds the captured object when the transfer
+    // runs: a reassignment that COMPLETES before it, unskippable within the region. The
+    // ASSIGNMENT's end decides -- `stream = MakeFrom(Sending.Transfer(stream))` transfers the
+    // old object while the reassignment is still in flight.
+    private static bool DefinitelyReassignedBefore(IOperation region, ISymbol variable, IOperation transfer)
+    {
+        var limit = transfer.Syntax.SpanStart;
+        return region.DescendantsAndSelf().Any(operation =>
+            operation.Parent is ISimpleAssignmentOperation assignment
+            && ReferenceEquals(assignment.Target, operation)
+            && assignment.Syntax.Span.End <= limit
+            && SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+            && !IsConditionalWithin(assignment, region)
+            && !ABranchCanSkip(assignment, region.Syntax.SpanStart, region));
     }
 
     // An enclosing foreach KEEPS READING its collection after the body iteration that
@@ -169,9 +188,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 break;
             }
 
+            // The enumerator iterates the collection captured at LOOP ENTRY: an iteration
+            // that definitely reassigns before transferring hands off a different object
+            // than the one MoveNext keeps reading.
             if (parent is IForEachLoopOperation foreachLoop
                 && SymbolEqualityComparer.Default.Equals(ReferencedVariable(foreachLoop.Collection), variable)
-                && !DefinitelyExitsAfter(foreachLoop, transferPosition))
+                && !DefinitelyExitsAfter(foreachLoop, transferPosition)
+                && !DefinitelyReassignedBefore(foreachLoop.Body, variable, transfer))
             {
                 return true;
             }
@@ -388,7 +411,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .Where(invocation => invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
                 && invocation.Syntax.SpanStart >= transferPosition
                 && !IsInASiblingArmOfTheTransfer(invocation, transferPosition)
-                && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition)))
+                && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition))
+                // A call written inside a local function that nothing ever invokes runs no
+                // more than the declaration around it does.
+                && !IsWithinAnUncalledLocalFunction(invocation, scanRoots, scope))
             .Select(invocation => (Operation: (IOperation)invocation,
                 CallEffect: (BodyEffect?)LocalFunctionCallEffect(invocation.TargetMethod, variable, scope)))
             .Where(call => call.CallEffect != BodyEffect.None);
@@ -459,6 +485,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        // Arguments run BEFORE the body's reset: Reset(list.Count) reads the transferred
+        // value first, and the reset cannot retroactively excuse it.
+        if (call is IInvocationOperation invocation && SiblingArgumentRead(invocation.Arguments, variable, transferPosition) is { } argumentRead)
+        {
+            Report(context, argumentRead, variable);
+            return true;
+        }
+
         if (ReinitializationRole(call, transferPosition, scope) != ReferenceRole.FreshValueFromHere)
         {
             (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
@@ -495,18 +529,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     // A catch handler observes a NON-ESCAPING transfer only through an exception thrown after
-    // it: when the transfer is the LAST operation of its try body, a completed handoff skips
-    // the handlers, and a throw from the transfer expression itself means no wrapper escaped.
-    // (Escaping thrown transfers scan their handlers deliberately: the throw carries the
-    // completed wrapper into them.)
+    // it: when nothing THROW-CAPABLE follows the handoff in the try body -- later code that
+    // cannot throw (`var x = 0;`) never reaches the handler with a completed wrapper, and a
+    // throw from the transfer expression itself means no wrapper escaped. (Escaping thrown
+    // transfers scan their handlers deliberately: the throw carries the completed wrapper
+    // into them.)
     private static bool IsInAnUnreachableCatch(IOperation use, int transferPosition)
     {
         for (IOperation child = use; child.Parent is { } parent; child = parent)
         {
             if (parent is ITryOperation { Body: { } body } && child is ICatchClauseOperation
                 && Covers(body, transferPosition)
-                && !body.Descendants().Any(operation => operation.Syntax.SpanStart >= transferPosition
-                    && !IsWithinANestedFunction(operation, body))
                 && !CanThrowAfterTheTransfer(body, transferPosition))
             {
                 return true;
@@ -538,16 +571,19 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     // What ENTERING the region does to the variable, scanned in source order from the top.
     // Reads: some path reads the transferred value (`read` is that reference -- possibly the
-    // RHS of a reassignment built FROM it). Resets: a non-reading reassignment that runs
-    // before any read on every path (not nested in a conditional/loop/try, no branch able to
-    // skip it) rewrites the variable. None: the region never touches the transferred value --
-    // reads a skipped conditional reset dominates (same arm, after it) see the fresh value.
+    // RHS/sibling argument of a reset built FROM it). Resets: a non-reading reset (simple
+    // assignment, out argument, deconstruction target) that runs before any read on every
+    // path (not nested in a conditional/loop/try, no branch able to skip it) rewrites the
+    // variable. None: the region never touches the transferred value -- reads a skipped
+    // conditional reset dominates (same arm, after it) see the fresh value, and references
+    // inside nested local functions the region never invokes cannot run at all.
     private static BodyEffect EffectOf(IOperation region, ISymbol variable, out IOperation? read)
     {
         read = null;
         var references = region.DescendantsAndSelf()
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
-                && !IsInsideNameOf(operation))
+                && !IsInsideNameOf(operation)
+                && !IsInAnUnreferencedNestedFunction(operation, region))
             .OrderBy(operation => operation.Syntax.SpanStart);
 
         var dominated = default(List<(Microsoft.CodeAnalysis.Text.TextSpan Region, int Position)>);
@@ -558,32 +594,112 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (reference.Parent is not ISimpleAssignmentOperation assignment
-                || !ReferenceEquals(assignment.Target, reference))
+            var reset = ResetShapeOf(reference, variable, region, out read);
+            if (reset is null)
             {
                 read = reference; // a plain read of the transferred value
                 return BodyEffect.Reads;
             }
 
-            read = assignment.Value.DescendantsAndSelf().FirstOrDefault(operation =>
-                SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
-                && !IsInsideNameOf(operation));
             if (read is not null)
             {
-                return BodyEffect.Reads; // the RHS builds the replacement FROM the transferred value
+                return BodyEffect.Reads; // the replacement is built FROM the transferred value
             }
 
-            if (!IsConditionalWithin(assignment, region)
-                && !ABranchCanSkip(assignment, region.Syntax.SpanStart, region))
+            if (!IsConditionalWithin(reset, region)
+                && !ABranchCanSkip(reset, region.Syntax.SpanStart, region))
             {
                 return BodyEffect.Resets; // rewrites before any read on every path
             }
 
             (dominated ??= new List<(Microsoft.CodeAnalysis.Text.TextSpan, int)>())
-                .Add((DominatingRegion(assignment).Syntax.Span, reference.Syntax.Span.End));
+                .Add((DominatingRegion(reset).Syntax.Span, reference.Syntax.Span.End));
         }
 
         return BodyEffect.None;
+    }
+
+    // The reset operation the reference belongs to (null when it is an ordinary read),
+    // mirroring the outer Classify's shapes: a simple-assignment target, an `out` argument
+    // (the callee must assign it and cannot read it), or a deconstruction target. `read`
+    // carries the reference that still reads the transferred value on the way in -- the
+    // reassignment's RHS or a sibling argument.
+    private static IOperation? ResetShapeOf(IOperation reference, ISymbol variable, IOperation region, out IOperation? read)
+    {
+        read = null;
+
+        if (reference.Parent is ISimpleAssignmentOperation assignment && ReferenceEquals(assignment.Target, reference))
+        {
+            read = ReadWithin(assignment.Value, variable);
+            return assignment;
+        }
+
+        if (reference.Parent is IArgumentOperation { Parameter.RefKind: RefKind.Out } outArgument)
+        {
+            read = SiblingArgumentRead(outArgument, variable, region.Syntax.SpanStart);
+            return outArgument;
+        }
+
+        if (DeconstructionOf(reference) is { } deconstruction)
+        {
+            read = ReadWithin(deconstruction.Value, variable);
+            return deconstruction;
+        }
+
+        return null;
+    }
+
+    private static IOperation? ReadWithin(IOperation expression, ISymbol variable)
+    {
+        return expression.DescendantsAndSelf().FirstOrDefault(operation =>
+            SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+            && !IsInsideNameOf(operation));
+    }
+
+    // A reference inside a nested local function that nothing in the region ever invokes (or
+    // lifts into a delegate) can never run by entering the region: the declaration alone
+    // executes nothing. Lambda bodies stay visible -- building the delegate is itself the
+    // escape.
+    private static bool IsInAnUnreferencedNestedFunction(IOperation reference, IOperation region)
+    {
+        for (var parent = reference.Parent; parent is not null && !ReferenceEquals(parent, region); parent = parent.Parent)
+        {
+            if (parent is ILocalFunctionOperation nested && !IsReferencedWithin(region, nested.Symbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsReferencedWithin(IOperation region, IMethodSymbol localFunction)
+    {
+        return region.DescendantsAndSelf().Any(operation => operation switch
+        {
+            IInvocationOperation invocation => SymbolEqualityComparer.Default.Equals(invocation.TargetMethod, localFunction),
+            IMethodReferenceOperation methodReference => SymbolEqualityComparer.Default.Equals(methodReference.Method, localFunction),
+            _ => false,
+        });
+    }
+
+    // The outer-scan variant: the boundary is the scan-root set instead of a single region.
+    private static bool IsWithinAnUncalledLocalFunction(IOperation operation, List<IOperation> scanRoots, IOperation scope)
+    {
+        for (var current = operation.Parent; current is not null; current = current.Parent)
+        {
+            if (current is ILocalFunctionOperation nested && !IsReferencedWithin(scope, nested.Symbol))
+            {
+                return true;
+            }
+
+            if (scanRoots.Contains(current))
+            {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     // Whether CALLING the local function reads the transferred value -- or definitely
@@ -862,10 +978,15 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             _ => ImmutableArray<IArgumentOperation>.Empty,
         };
 
-        // Position-filtered: when the same invocation performs the handoff
-        // (Reset(Sending.Transfer(list), out list)), the reference inside the transfer
-        // argument itself is the handoff, not a post-transfer read.
-        return arguments.Where(argument => !ReferenceEquals(argument, outArgument))
+        return SiblingArgumentRead(arguments.Where(argument => !ReferenceEquals(argument, outArgument)), variable, transferPosition);
+    }
+
+    // Position-filtered: when the same invocation performs the handoff
+    // (Reset(Sending.Transfer(list), out list)), the reference inside the transfer
+    // argument itself is the handoff, not a post-transfer read.
+    private static IOperation? SiblingArgumentRead(System.Collections.Generic.IEnumerable<IArgumentOperation> arguments, ISymbol variable, int transferPosition)
+    {
+        return arguments
             .SelectMany(argument => argument.Value.DescendantsAndSelf())
             .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && operation.Syntax.SpanStart >= transferPosition

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -27,14 +27,19 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterOperationBlockAction(AnalyzeBlock);
+        // The classifier caches verdicts per type symbol, so it is scoped to one compilation.
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var classifier = new SendableSymbolClassifier();
+            compilationStart.RegisterOperationBlockAction(blockContext => AnalyzeBlock(blockContext, classifier));
+        });
     }
 
-    private static void AnalyzeBlock(OperationBlockAnalysisContext context)
+    private static void AnalyzeBlock(OperationBlockAnalysisContext context, SendableSymbolClassifier classifier)
     {
         foreach (var block in context.OperationBlocks)
         {
-            foreach (var (variable, transferPosition, scanRoots, escaped, transfer, scope) in Transfers(block))
+            foreach (var (variable, transferPosition, scanRoots, escaped, transfer, scope) in Transfers(block, classifier))
             {
                 // A using-declared local -- or an existing local/parameter handed to a using
                 // STATEMENT as its resource -- is Disposed by the SENDER at scope end, after
@@ -73,7 +78,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // stores resolve against the BODY even when the scanned regions are narrower (an
     // escaping `return Pair(Sending.Transfer(list), Use());` still calls a Use declared
     // outside the return expression).
-    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> Transfers(IOperation block)
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> Transfers(IOperation block, SendableSymbolClassifier classifier)
     {
         foreach (var operation in block.DescendantsAndSelf())
         {
@@ -93,7 +98,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             foreach (var source in TransferSources(argument))
             {
-                if (ReferencedVariable(source) is not { } variable)
+                if (TrackedVariableOf(source, classifier) is not { } variable)
                 {
                     continue;
                 }
@@ -104,6 +109,22 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
+    }
+
+    // The variable a source hands off -- none when it is not a local/parameter, and none
+    // when its type is deeply Sendable: such a source (an int tuple element, say) cannot
+    // alias mutable state with the receiver, and tracking it would bury the real handoffs
+    // beside it.
+    private static ISymbol? TrackedVariableOf(IOperation source, SendableSymbolClassifier classifier)
+    {
+        if (ReferencedVariable(source) is not { } variable)
+        {
+            return null;
+        }
+
+        return source.Type is { } sourceType && classifier.GetNotSendableReason(sourceType) is null
+            ? null
+            : variable;
     }
 
     private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> EntriesFor(
@@ -1379,6 +1400,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .DefaultIfEmpty(int.MinValue)
             .Max();
 
+        var removals = DelegateRemovals(delegateLocal, scope, consumer);
+
         foreach (var (site, value, _) in stores)
         {
             if (site.Syntax.SpanStart < killPoint)
@@ -1388,6 +1411,15 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             if (Callable(value) is { } callable)
             {
+                // A definite `-= M` after the store strips that target: only METHOD GROUPS
+                // are identifiable (removing a fresh lambda instance removes nothing).
+                if (callable is IMethodReferenceOperation storedGroup
+                    && removals.Any(removal => removal.Position > site.Syntax.SpanStart
+                        && SymbolEqualityComparer.Default.Equals(removal.Method, storedGroup.Method.OriginalDefinition)))
+                {
+                    continue;
+                }
+
                 yield return callable;
             }
             else if (ReferencedVariable(value) is { } alias)
@@ -1400,6 +1432,24 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
+    }
+
+    private static List<(int Position, IMethodSymbol Method)> DelegateRemovals(ISymbol delegateLocal, IOperation scope, IOperation consumer)
+    {
+        var removals = new List<(int Position, IMethodSymbol Method)>();
+        foreach (var operation in scope.DescendantsAndSelf())
+        {
+            if (operation is ICompoundAssignmentOperation { OperatorKind: BinaryOperatorKind.Subtract } removal
+                && SymbolEqualityComparer.Default.Equals(ReferencedVariable(removal.Target), delegateLocal)
+                && operation.Syntax.Span.End <= consumer.Syntax.SpanStart
+                && !IsConditionalWithin(removal, scope)
+                && Callable(removal.Value) is IMethodReferenceOperation methodReference)
+            {
+                removals.Add((operation.Syntax.SpanStart, methodReference.Method.OriginalDefinition));
+            }
+        }
+
+        return removals;
     }
 
     private static List<(IOperation Site, IOperation Value, bool Replaces)> DelegateStores(
@@ -1562,7 +1612,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             _ => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
                 or IPropertyReferenceOperation or IArrayElementReferenceOperation or IThrowOperation
                 or IDynamicInvocationOperation or IDynamicMemberReferenceOperation
-                or IDynamicIndexerAccessOperation or IDynamicObjectCreationOperation,
+                or IDynamicIndexerAccessOperation or IDynamicObjectCreationOperation
+                or IEventAssignmentOperation,
         };
     }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace MemoizR.Analyzers;
+
+// MZR005: a value wrapped in Sending<T> is TRANSFERRED -- the receiver may start owning and
+// mutating it on another flow the moment the wrapper escapes, so the sender must stop using it.
+// The check is method-local and source-ordered: every reference to the transferred local/
+// parameter AFTER the transfer is flagged, until a reassignment gives the variable a fresh
+// value. Deliberately a heuristic (source order approximates execution order; loop back-edges
+// and aliases can evade it) -- Swift proves this with region-based isolation in the type
+// system, which an analyzer cannot reproduce; the single-consumption check in Sending<T> is the
+// runtime backstop on the RECEIVER side.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.UseAfterTransfer);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationBlockAction(AnalyzeBlock);
+    }
+
+    private static void AnalyzeBlock(OperationBlockAnalysisContext context)
+    {
+        foreach (var block in context.OperationBlocks)
+        {
+            foreach (var (variable, transferPosition) in Transfers(block))
+            {
+                ReportUsesAfter(context, block, variable, transferPosition);
+            }
+        }
+    }
+
+    // Every Sending<T> creation (constructor or Sending.Transfer) whose argument is a
+    // local/parameter reference, with the position the transfer happens at.
+    private static IEnumerable<(ISymbol Variable, int Position)> Transfers(IOperation block)
+    {
+        foreach (var operation in block.DescendantsAndSelf())
+        {
+            var (isTransfer, argument) = operation switch
+            {
+                IObjectCreationOperation creation when IsSendingType(creation.Type) =>
+                    (true, creation.Arguments.FirstOrDefault()?.Value),
+                IInvocationOperation { TargetMethod.Name: "Transfer" } invocation when IsSendingHelper(invocation.TargetMethod) =>
+                    (true, invocation.Arguments.FirstOrDefault()?.Value),
+                _ => (false, null),
+            };
+
+            if (!isTransfer || ReferencedVariable(argument) is not { } variable)
+            {
+                continue;
+            }
+
+            yield return (variable, operation.Syntax.Span.End);
+        }
+    }
+
+    private static void ReportUsesAfter(OperationBlockAnalysisContext context, IOperation block, ISymbol variable, int transferPosition)
+    {
+        // Source-ordered walk of every later reference: a reference that is the TARGET of a
+        // simple assignment re-initializes the variable, so it and everything after it is a new
+        // value -- stop there.
+        var laterReferences = block.DescendantsAndSelf()
+            .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+                && operation.Syntax.SpanStart >= transferPosition)
+            .OrderBy(operation => operation.Syntax.SpanStart);
+
+        foreach (var reference in laterReferences)
+        {
+            if (reference.Parent is ISimpleAssignmentOperation assignment && ReferenceEquals(assignment.Target, reference))
+            {
+                return; // reassigned: the old, transferred value is gone
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.UseAfterTransfer,
+                reference.Syntax.GetLocation(),
+                variable.Name));
+            return; // one report per transfer keeps the noise proportional
+        }
+    }
+
+    private static ISymbol? ReferencedVariable(IOperation? operation)
+    {
+        return operation switch
+        {
+            ILocalReferenceOperation local => local.Local,
+            IParameterReferenceOperation parameter => parameter.Parameter,
+            IConversionOperation conversion => ReferencedVariable(conversion.Operand),
+            _ => null,
+        };
+    }
+
+    private static bool IsSendingType(ITypeSymbol? type)
+    {
+        return type is INamedTypeSymbol named
+            && named.OriginalDefinition is { Name: "Sending", Arity: 1 } definition
+            && definition.ContainingNamespace?.ToDisplayString() == "MemoizR"
+            && FactoryMethods.IsLibraryType(definition);
+    }
+
+    private static bool IsSendingHelper(IMethodSymbol method)
+    {
+        return method.ContainingType is { Name: "Sending", Arity: 0 } type
+            && type.ContainingNamespace?.ToDisplayString() == "MemoizR"
+            && FactoryMethods.IsLibraryType(type);
+    }
+}

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -116,9 +116,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             yield return (variable, transfer.Syntax.Span.End, scanRoots, escaped, transfer, enclosingBody);
         }
 
-        // A transfer inside a CALLED local function is sequenced before the caller's
-        // continuation: every call site acts as a transfer of its own. Lambdas stay
-        // deferred-scoped (they may run later or never).
+        // A transfer inside a CALLED local function or lambda is sequenced before the
+        // caller's continuation: every call site acts as a transfer of its own. A stored
+        // but never-invoked callable stays deferred-scoped.
         foreach (var propagated in CallSiteTransfers(enclosingBody, variable, transfer, block,
             new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)))
         {
@@ -133,7 +133,13 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> CallSiteTransfers(
         IOperation transferBody, ISymbol variable, IOperation anchor, IOperation block, HashSet<IMethodSymbol> visited)
     {
-        if (transferBody is not ILocalFunctionOperation declaration || !visited.Add(declaration.Symbol))
+        var functionSymbol = transferBody switch
+        {
+            ILocalFunctionOperation declaration => declaration.Symbol,
+            IAnonymousFunctionOperation lambda => lambda.Symbol,
+            _ => null,
+        };
+        if (functionSymbol is null || !visited.Add(functionSymbol))
         {
             yield break;
         }
@@ -141,15 +147,15 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         // A by-value parameter definitely reassigned before the handoff no longer aliases
         // ANY caller argument: the callee transferred its own fresh value.
         if (variable is IParameterSymbol parameterVariable
-            && SymbolEqualityComparer.Default.Equals(parameterVariable.ContainingSymbol.OriginalDefinition, declaration.Symbol)
-            && DefinitelyReassignedBefore(declaration, variable, anchor))
+            && SymbolEqualityComparer.Default.Equals(parameterVariable.ContainingSymbol.OriginalDefinition, functionSymbol)
+            && DefinitelyReassignedBefore(transferBody, variable, anchor))
         {
             yield break;
         }
 
         foreach (var invocation in block.DescendantsAndSelf().OfType<IInvocationOperation>())
         {
-            if (!InvokesTheDeclaration(invocation, declaration, block))
+            if (!InvokesTheBody(invocation, transferBody, functionSymbol, block))
             {
                 continue;
             }
@@ -160,7 +166,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue; // self-recursion: the body scan already covers it
             }
 
-            foreach (var entry in CallSiteEntries(invocation, callBody, variable, declaration, block, visited))
+            foreach (var entry in CallSiteEntries(invocation, callBody, variable, functionSymbol, block, visited))
             {
                 yield return entry;
             }
@@ -168,9 +174,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots, bool Escaped, IOperation Transfer, IOperation Scope)> CallSiteEntries(
-        IInvocationOperation invocation, IOperation callBody, ISymbol variable, ILocalFunctionOperation declaration, IOperation block, HashSet<IMethodSymbol> visited)
+        IInvocationOperation invocation, IOperation callBody, ISymbol variable, IMethodSymbol functionSymbol, IOperation block, HashSet<IMethodSymbol> visited)
     {
-        foreach (var callVariable in CallSiteVariables(invocation, variable, declaration))
+        foreach (var callVariable in CallSiteVariables(invocation, variable, functionSymbol))
         {
             if (callBody is ILocalFunctionOperation)
             {
@@ -190,26 +196,28 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool InvokesTheDeclaration(IInvocationOperation invocation, ILocalFunctionOperation declaration, IOperation block)
+    private static bool InvokesTheBody(IInvocationOperation invocation, IOperation transferBody, IMethodSymbol functionSymbol, IOperation block)
     {
-        // move() runs Move when the delegate local can hold it at the call.
+        // move() runs the body when the delegate local can hold it at the call -- a stored
+        // METHOD GROUP matches by symbol, a stored LAMBDA by the operation itself.
         if (invocation.TargetMethod.MethodKind == MethodKind.DelegateInvoke)
         {
             return DelegateReceiver(invocation) is { } receiver
                 && StoredCallables(receiver, block, invocation, transferPosition: 0, new HashSet<ISymbol>(SymbolEqualityComparer.Default))
-                    .OfType<IMethodReferenceOperation>()
-                    .Any(reference => SymbolEqualityComparer.Default.Equals(reference.Method.OriginalDefinition, declaration.Symbol));
+                    .Any(callable => ReferenceEquals(callable, transferBody)
+                        || (callable is IMethodReferenceOperation methodReference
+                            && SymbolEqualityComparer.Default.Equals(methodReference.Method.OriginalDefinition, functionSymbol)));
         }
 
-        return SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.OriginalDefinition, declaration.Symbol);
+        return SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.OriginalDefinition, functionSymbol);
     }
 
     // The caller-side variable the transferred callee variable aliases at THIS call: a
     // captured local stays itself; a PARAMETER maps to the matching argument's sources.
-    private static IEnumerable<ISymbol> CallSiteVariables(IInvocationOperation invocation, ISymbol variable, ILocalFunctionOperation declaration)
+    private static IEnumerable<ISymbol> CallSiteVariables(IInvocationOperation invocation, ISymbol variable, IMethodSymbol functionSymbol)
     {
         if (variable is not IParameterSymbol parameter
-            || !SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol.OriginalDefinition, declaration.Symbol))
+            || !SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol.OriginalDefinition, functionSymbol))
         {
             yield return variable;
             yield break;
@@ -333,6 +341,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             && ReferenceEquals(assignment.Target, operation)
             && assignment.Syntax.Span.End <= limit
             && SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
+            // A replacement built FROM the variable (x = x, x = Wrap(x)) is not provably a
+            // different object: the alias may survive.
+            && ReadWithin(assignment.Value, variable) is null
             && !IsConditionalWithin(assignment, region)
             && !ABranchCanSkip(assignment, region.Syntax.SpanStart, region));
     }
@@ -461,10 +472,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IAnonymousObjectCreationOperation anonymous => anonymous.Initializers.Select(initializer =>
                 (IOperation?)(initializer is ISimpleAssignmentOperation member ? member.Value : initializer)),
             IObjectCreationOperation creation => ObjectCreationCarriedParts(creation),
-            // box with { Value = list }: the receiver's CLONE carries the same reference in
-            // its slot. The operand itself stays a leaf like a spread's: the original object
-            // is not handed off, only its contents are copied into the clone.
-            IWithOperation { Initializer: { } withInitializer } => InitializerCarriedParts(withInitializer),
+            // box with { Value = list }: the receiver's CLONE copies the operand's stored
+            // contents, then applies the initializer -- an INLINE operand's carried parts
+            // are in the clone; a variable operand stays a leaf (its object is not handed
+            // off, only copied from).
+            IWithOperation withOperation => WithCarriedParts(withOperation),
             IConversionOperation conversion => new[] { conversion.Operand },
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are
@@ -708,7 +720,24 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                     new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)) == BodyEffect.Reads)
             .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
 
-        var orderedUses = laterReferences.Concat(callableCalls).Concat(methodGroupEscapes)
+        // A stored delegate that CAPTURED the transferred variable and escapes after the
+        // handoff (returned, passed on, stored elsewhere) can run later against the
+        // receiver-owned object. Calls are classified separately, and a bare store target
+        // rewrites the local without running anything.
+        var delegateEscapes = scanRoots
+            .SelectMany(root => root.DescendantsAndSelf())
+            .OfType<ILocalReferenceOperation>()
+            .Where(reference => reference.Local.Type is { TypeKind: TypeKind.Delegate }
+                && reference.Syntax.SpanStart >= transferPosition
+                && !IsAStoreTargetOrInvokeReceiver(reference)
+                && !IsInsideNameOf(reference)
+                && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
+                && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
+                && !IsWithinALocalFunctionBody(reference, scanRoots)
+                && AnyStoredCallableReads(reference.Local, variable, reference, 0, scope))
+            .Select(reference => (Operation: (IOperation)reference, CallEffect: (BodyEffect?)BodyEffect.Reads));
+
+        var orderedUses = laterReferences.Concat(callableCalls).Concat(methodGroupEscapes).Concat(delegateEscapes)
             .OrderBy(use => use.Operation.Syntax.SpanStart);
 
         // Regions where a SKIPPED conditional reinitialization dominates: inside its own arm,
@@ -1087,22 +1116,33 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 indexer.Arguments.Select(argument => (IOperation?)argument.Value).Concat(new[] { (IOperation?)member.Value }),
             ISimpleAssignmentOperation member when StoresIntoACompilerKnownSlot(member) => new[] { (IOperation?)member.Value },
             // Child = { Value = list }: writes INTO the object the transferred payload
-            // already reaches -- the nested initializer carries by the same rules.
-            IMemberInitializerOperation { Initializer: { } nested } => InitializerCarriedParts(nested),
+            // already reaches -- when Child is a RETAINED slot. A computed member hands out
+            // a temporary the payload never keeps.
+            IMemberInitializerOperation { Initializer: { } nested } memberInitializer
+                when RetainsItsSlot(memberInitializer.InitializedMember) => InitializerCarriedParts(nested),
             IInvocationOperation add when IsFrameworkDeclared(add.TargetMethod.ContainingType) =>
                 add.Arguments.Select(argument => (IOperation?)argument.Value),
             _ => System.Linq.Enumerable.Empty<IOperation?>(),
         });
     }
 
-    // Types living in the SAME ASSEMBLY as System.Object (the core library): their
-    // collection contracts store what they are handed. A System.* NAMESPACE proves nothing --
-    // any referenced assembly can declare one.
+    // Types from the framework's own collection assemblies: their contracts store what
+    // they are handed. Anchored on the CORE LIBRARY's assembly identity plus the framework
+    // collection assemblies by exact name -- a System.* NAMESPACE in a user assembly proves
+    // nothing.
     private static bool IsFrameworkDeclared(INamedTypeSymbol? type)
     {
         if (type is null)
         {
             return false;
+        }
+
+        if (type.ContainingAssembly?.Identity.Name is
+            "System.Runtime" or "System.Collections" or "System.Collections.Concurrent"
+            or "System.Collections.Immutable" or "System.Collections.Specialized"
+            or "System.Collections.NonGeneric" or "netstandard" or "mscorlib")
+        {
+            return true;
         }
 
         for (ITypeSymbol? current = type; current is not null; current = current.BaseType)
@@ -1114,6 +1154,29 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static System.Collections.Generic.IEnumerable<IOperation?> WithCarriedParts(IWithOperation withOperation)
+    {
+        var operand = withOperation.Operand;
+        while (operand is IConversionOperation conversion)
+        {
+            operand = conversion.Operand;
+        }
+
+        var operandParts = operand is not null && CarriedParts(operand) is { } parts
+            ? parts
+            : System.Linq.Enumerable.Empty<IOperation?>();
+
+        return withOperation.Initializer is { } initializer
+            ? operandParts.Concat(InitializerCarriedParts(initializer))
+            : operandParts;
+    }
+
+    private static bool RetainsItsSlot(IOperation? member)
+    {
+        return member is IFieldReferenceOperation
+            || (member is IPropertyReferenceOperation property && SendableSymbolClassifier.HasBackingSlot(property.Property));
     }
 
     private static bool StoresIntoACompilerKnownSlot(ISimpleAssignmentOperation member)
@@ -1210,23 +1273,38 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             return BodyEffect.None;
         }
 
-        var candidates = StoredCallables(delegateLocal, scope, invocation, transferPosition,
-            new HashSet<ISymbol>(SymbolEqualityComparer.Default));
-        var reads = candidates.Any(callable => callable switch
-        {
-            IAnonymousFunctionOperation lambda =>
-                EffectOf(lambda, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default), out _) == BodyEffect.Reads,
-            IMethodReferenceOperation { Method: { MethodKind: MethodKind.LocalFunction } method } =>
-                LocalFunctionCallEffect(method, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)) == BodyEffect.Reads,
-            _ => false,
-        });
+        return AnyStoredCallableReads(delegateLocal, variable, invocation, transferPosition, scope)
+            ? BodyEffect.Reads
+            : BodyEffect.None;
+    }
 
-        return reads ? BodyEffect.Reads : BodyEffect.None;
+    private static bool AnyStoredCallableReads(ISymbol delegateLocal, ISymbol variable, IOperation consumer, int transferPosition, IOperation scope)
+    {
+        return StoredCallables(delegateLocal, scope, consumer, transferPosition, new HashSet<ISymbol>(SymbolEqualityComparer.Default))
+            .Any(callable => callable switch
+            {
+                IAnonymousFunctionOperation lambda =>
+                    EffectOf(lambda, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default), out _) == BodyEffect.Reads,
+                IMethodReferenceOperation { Method: { MethodKind: MethodKind.LocalFunction } method } =>
+                    LocalFunctionCallEffect(method, variable, scope, new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)) == BodyEffect.Reads,
+                _ => false,
+            });
     }
 
     // The local the invocation calls through -- behind a ?. receiver too: use?.Invoke() puts
     // a placeholder in Instance, and the real receiver hangs off the enclosing conditional
     // access.
+    private static bool IsAStoreTargetOrInvokeReceiver(ILocalReferenceOperation reference)
+    {
+        return reference.Parent switch
+        {
+            IAssignmentOperation assignment when ReferenceEquals(assignment.Target, reference) => true,
+            IInvocationOperation invocation when ReferenceEquals(invocation.Instance, reference) => true,
+            IConditionalAccessOperation conditionalAccess when ReferenceEquals(conditionalAccess.Operation, reference) => true,
+            _ => false,
+        };
+    }
+
     private static ISymbol? DelegateReceiver(IInvocationOperation invocation)
     {
         var receiver = invocation.Instance;

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -214,13 +214,31 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             if (dominatingPart is not null
                 && parent.Syntax.Span.Contains(transferPosition)
                 && !child.Syntax.Span.Contains(transferPosition)
-                && !dominatingPart.Syntax.Span.Contains(transferPosition))
+                && !dominatingPart.Syntax.Span.Contains(transferPosition)
+                && !IsInACaseGuard(parent, transferPosition))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // A `when` guard is arm-SELECTION machinery, not an arm: a failing guard falls through to
+    // later cases, so a transfer inside one has already run when a later arm executes --
+    // `case 0 when Sending.Transfer(list) is null:` followed by `default: list.Add(1);` is a
+    // real use after transfer.
+    private static bool IsInACaseGuard(IOperation construct, int transferPosition)
+    {
+        var guards = construct switch
+        {
+            ISwitchOperation @switch => @switch.Cases.SelectMany(c => c.Clauses)
+                .Select(clause => (clause as IPatternCaseClauseOperation)?.Guard),
+            ISwitchExpressionOperation switchExpression => switchExpression.Arms.Select(arm => arm.Guard),
+            _ => System.Linq.Enumerable.Empty<IOperation?>(),
+        };
+
+        return guards.Any(guard => guard is not null && guard.Syntax.Span.Contains(transferPosition));
     }
 
     // The region a skipped conditional reinitialization dominates: its nearest enclosing arm

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -146,7 +146,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         // A by-value parameter definitely reassigned before the handoff no longer aliases
         // ANY caller argument: the callee transferred its own fresh value.
-        if (variable is IParameterSymbol parameterVariable
+        // (ref/out parameters write THROUGH to the caller's slot: the alias survives any
+        // reassignment, so only by-value parameters lose it.)
+        if (variable is IParameterSymbol { RefKind: RefKind.None } parameterVariable
             && SymbolEqualityComparer.Default.Equals(parameterVariable.ContainingSymbol.OriginalDefinition, functionSymbol)
             && DefinitelyReassignedBefore(transferBody, variable, anchor))
         {
@@ -336,16 +338,15 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     private static bool DefinitelyReassignedBefore(IOperation region, ISymbol variable, IOperation transfer)
     {
         var limit = transfer.Syntax.SpanStart;
-        return region.DescendantsAndSelf().Any(operation =>
-            operation.Parent is ISimpleAssignmentOperation assignment
-            && ReferenceEquals(assignment.Target, operation)
-            && assignment.Syntax.Span.End <= limit
-            && SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
-            // A replacement built FROM the variable (x = x, x = Wrap(x)) is not provably a
-            // different object: the alias may survive.
-            && ReadWithin(assignment.Value, variable) is null
-            && !IsConditionalWithin(assignment, region)
-            && !ABranchCanSkip(assignment, region.Syntax.SpanStart, region));
+        return region.DescendantsAndSelf()
+            .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable))
+            .Any(reference => ResetShapeOf(reference, variable, region, out var read) is { } reset
+                // A replacement built FROM the variable (x = x, x = Wrap(x)) is not provably
+                // a different object: the alias may survive.
+                && read is null
+                && reset.Syntax.Span.End <= limit
+                && !IsConditionalWithin(reset, region)
+                && !ABranchCanSkip(reset, region.Syntax.SpanStart, region));
     }
 
     // An enclosing foreach KEEPS READING its collection after the body iteration that
@@ -783,8 +784,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .OfType<ILocalReferenceOperation>()
             .Where(reference => reference.Local.Type is { TypeKind: TypeKind.Delegate }
                 && reference.Syntax.SpanStart >= transferPosition
-                && !IsAStoreTargetOrInvokeReceiver(reference)
-                && !IsInsideNameOf(reference)
+                && EscapesTheScope(reference)
                 && !IsInASiblingArmOfTheTransfer(reference, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(reference, transferPosition))
                 && !IsWithinALocalFunctionBody(reference, scanRoots)
@@ -853,7 +853,11 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .SelectMany(argument => argument.Value.DescendantsAndSelf())
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && operation.Syntax.SpanStart >= floorPosition
-                && !IsInsideNameOf(operation))
+                && !IsInsideNameOf(operation)
+                // An OUT write lands only when the callee returns -- AFTER its body ran --
+                // so it can never feed the body a fresh value. The call-site reference is
+                // classified as a reinitialization by the direct scan instead.
+                && operation.Parent is not IArgumentOperation { Parameter.RefKind: RefKind.Out })
             .OrderBy(operation => operation.Syntax.SpanStart);
 
         foreach (var reference in references)
@@ -1099,8 +1103,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
         foreach (var argument in creation.Arguments)
         {
+            // Only the SYNTHESIZED positional property stores its parameter (its declaring
+            // syntax IS the parameter); an explicitly redeclared property replaces the
+            // storage and may never read it.
             if (argument.Parameter is { } parameter
-                && recordType.GetMembers(parameter.Name).OfType<IPropertySymbol>().Any(SendableSymbolClassifier.HasBackingSlot))
+                && recordType.GetMembers(parameter.Name).OfType<IPropertySymbol>().Any(property =>
+                    SendableSymbolClassifier.HasBackingSlot(property)
+                    && property.DeclaringSyntaxReferences.Any(reference =>
+                        reference.GetSyntax() is Microsoft.CodeAnalysis.CSharp.Syntax.ParameterSyntax)))
             {
                 yield return argument.Value;
             }
@@ -1299,15 +1309,33 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // The local the invocation calls through -- behind a ?. receiver too: use?.Invoke() puts
     // a placeholder in Instance, and the real receiver hangs off the enclosing conditional
     // access.
-    private static bool IsAStoreTargetOrInvokeReceiver(ILocalReferenceOperation reference)
+    // A delegate reference ESCAPES when it is returned, passed as an argument, or stored
+    // into a non-local slot -- merely inspecting it (use != null) runs nothing, a local
+    // copy is an alias resolved at ITS uses, and calls/stores are classified separately.
+    private static bool EscapesTheScope(ILocalReferenceOperation reference)
     {
-        return reference.Parent switch
+        for (IOperation child = reference; child.Parent is { } parent; child = parent)
         {
-            IAssignmentOperation assignment when ReferenceEquals(assignment.Target, reference) => true,
-            IInvocationOperation invocation when ReferenceEquals(invocation.Instance, reference) => true,
-            IConditionalAccessOperation conditionalAccess when ReferenceEquals(conditionalAccess.Operation, reference) => true,
-            _ => false,
-        };
+            switch (parent)
+            {
+                case IConversionOperation or IDelegateCreationOperation or ITupleOperation
+                    or IArrayInitializerOperation or IObjectOrCollectionInitializerOperation
+                    or IArrayCreationOperation or IAnonymousObjectCreationOperation:
+                    continue; // wrappers: the payload rides along
+                case IReturnOperation { Kind: not OperationKind.YieldBreak }:
+                    return true;
+                case IArgumentOperation:
+                    return true;
+                case ISimpleAssignmentOperation assignment when !ReferenceEquals(child, assignment.Target):
+                    return ReferencedVariable(assignment.Target) is null; // a non-local slot publishes
+                case ICompoundAssignmentOperation compound when !ReferenceEquals(child, compound.Target):
+                    return ReferencedVariable(compound.Target) is null;
+                default:
+                    return false;
+            }
+        }
+
+        return false;
     }
 
     private static ISymbol? DelegateReceiver(IInvocationOperation invocation)
@@ -1511,6 +1539,8 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return region.DescendantsAndSelf().Any(operation =>
             operation.Syntax.Span.End > transferPosition
             && !IsWithinANestedFunction(operation, region)
+            // An op in a mutually exclusive sibling arm never runs on the transferred path.
+            && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
             && CanThrow(operation));
     }
 
@@ -1779,7 +1809,10 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         var reinitPosition = reinitialization.Syntax.SpanStart;
         return scope.DescendantsAndSelf().Any(operation =>
-            operation.Syntax.SpanStart >= transferPosition
+            // An op WRAPPING the transfer (MayThrow(Sending.Transfer(list))) completes -- and
+            // can fail -- after the wrapper exists; the transfer itself (ending exactly AT the
+            // position) cannot have let the wrapper escape when it throws.
+            operation.Syntax.Span.End > transferPosition
             && operation.Syntax.Span.End <= reinitPosition
             // A jump in a mutually exclusive sibling arm of the transfer never runs on the
             // path that transferred (`if (move) Transfer(list); else break;`): it cannot skip
@@ -1790,12 +1823,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     private static bool CanSkipPast(IOperation operation, int reinitPosition, IOperation scope)
     {
-        // A caught FAILURE resumes AFTER its try: any throw-capable operation (an explicit
-        // throw, a call that may fail, ...) skips a reset that try still contains.
         if (CanThrow(operation))
         {
-            return NearestCatchingTry(operation) is { } catchingTry
-                && catchingTry.Syntax.Span.Contains(reinitPosition);
+            return ACaughtFailureCanResumePast(operation, reinitPosition);
         }
 
         // Returning exits the enclosing function past the reset. Inside a CALLED body's scan
@@ -1825,6 +1855,41 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             if (exits)
             {
                 return parent.Syntax.Span.Contains(reinitPosition);
+            }
+        }
+
+        return false;
+    }
+
+    // A caught FAILURE resumes AFTER its try: any throw-capable operation (an explicit
+    // throw, a call that may fail, ...) skips a reset that try still contains. An EXPLICIT
+    // throw carries its type -- a catch that cannot catch it absorbs nothing -- and it
+    // governs its whole subtree (the operand evaluating is not an independent failure path
+    // worth modeling).
+    private static bool ACaughtFailureCanResumePast(IOperation operation, int reinitPosition)
+    {
+        if (operation is not IThrowOperation && IsInsideAThrow(operation))
+        {
+            return false;
+        }
+
+        return NearestCatchingTry(operation) is { } catchingTry
+            && catchingTry.Syntax.Span.Contains(reinitPosition)
+            && (operation is not IThrowOperation thrown || CatchesTheThrow(catchingTry, thrown));
+    }
+
+    private static bool IsInsideAThrow(IOperation operation)
+    {
+        for (var parent = operation.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent is IThrowOperation)
+            {
+                return true;
+            }
+
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return false;
             }
         }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -34,17 +34,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     {
         foreach (var block in context.OperationBlocks)
         {
-            foreach (var (variable, transferPosition, scope) in Transfers(block))
+            foreach (var (variable, transferPosition, scanRoots) in Transfers(block))
             {
-                ReportUsesAfter(context, scope, variable, transferPosition);
+                ReportUsesAfter(context, scanRoots, variable, transferPosition);
             }
         }
     }
 
     // Every Sending<T> creation (constructor or Sending.Transfer) whose argument is a
-    // local/parameter reference, with the position the transfer happens at and the scope its
+    // local/parameter reference, with the position the transfer happens at and the regions the
     // report walk covers.
-    private static IEnumerable<(ISymbol Variable, int Position, IOperation Scope)> Transfers(IOperation block)
+    private static IEnumerable<(ISymbol Variable, int Position, List<IOperation> ScanRoots)> Transfers(IOperation block)
     {
         foreach (var operation in block.DescendantsAndSelf())
         {
@@ -62,36 +62,47 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var scope = EnclosingFunctionBody(operation, block);
-            if (EscapesTheScope(operation, scope))
+            var scanRoots = ScanRootsFor(operation, EnclosingFunctionBody(operation, block));
+            if (scanRoots.Count > 0)
             {
-                continue;
+                yield return (variable, operation.Syntax.Span.End, scanRoots);
             }
-
-            yield return (variable, operation.Syntax.Span.End, scope);
         }
     }
 
-    // A transfer the flow immediately leaves behind (`return Sending.Transfer(list);` /
-    // `throw`) has no sender-side continuation in its scope: every later reference is
-    // unreachable on the path that transferred. (break/continue are NOT exits: control
-    // resumes after the loop, where later uses remain reachable.)
-    private static bool EscapesTheScope(IOperation transfer, IOperation scope)
+    // Where the sender-side scan looks. Normally the whole scope; a transfer the flow
+    // immediately leaves behind (`return Sending.Transfer(list);` / `throw`) is only still
+    // observable from the FINALLY blocks of enclosing tries, which run after the return
+    // expression evaluated -- no finally, no sender-side continuation at all. (break/continue
+    // are NOT exits: control resumes after the loop, where later uses remain reachable, so
+    // they keep the full scope.)
+    private static List<IOperation> ScanRootsFor(IOperation transfer, IOperation scope)
     {
-        for (var parent = transfer.Parent; parent is not null && !ReferenceEquals(parent, scope); parent = parent.Parent)
+        var roots = new List<IOperation>();
+        var escapes = false;
+        for (var parent = transfer.Parent; parent is not null; parent = parent.Parent)
         {
-            if (parent is IReturnOperation or IThrowOperation)
-            {
-                return true;
-            }
-
-            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            if (ReferenceEquals(parent, scope) || parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
             {
                 break;
             }
+
+            if (parent is IReturnOperation or IThrowOperation)
+            {
+                escapes = true;
+            }
+            else if (escapes && parent is ITryOperation { Finally: { } finallyBlock })
+            {
+                roots.Add(finallyBlock); // inner finallys first: they execute first
+            }
         }
 
-        return false;
+        if (!escapes)
+        {
+            roots.Add(scope);
+        }
+
+        return roots;
     }
 
     // Transfer(list = new(...)): after the statement the variable ALIASES the transferred
@@ -118,14 +129,17 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return block;
     }
 
-    private static void ReportUsesAfter(OperationBlockAnalysisContext context, IOperation scope, ISymbol variable, int transferPosition)
+    private static void ReportUsesAfter(OperationBlockAnalysisContext context, List<IOperation> scanRoots, ISymbol variable, int transferPosition)
     {
+        var scope = scanRoots[scanRoots.Count - 1]; // the outermost root is the reinit scope boundary
+
         // Source-ordered walk of every later reference. References in a MUTUALLY EXCLUSIVE
         // sibling arm of the construct holding the transfer are excluded upfront: in
         // `if (move) Transfer(list); else list.Add(1);` no path runs the else after the
         // transfer. (Try constructs are not excluded -- an exception after the transfer
         // reaches the handlers and finally.)
-        var laterReferences = scope.DescendantsAndSelf()
+        var laterReferences = scanRoots
+            .SelectMany(root => root.DescendantsAndSelf())
             .Where(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable)
                 && operation.Syntax.SpanStart >= transferPosition
                 && !IsInASiblingArmOfTheTransfer(operation, transferPosition))

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -302,10 +302,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IAnonymousObjectCreationOperation anonymous => anonymous.Initializers.Select(initializer =>
                 (IOperation?)(initializer is ISimpleAssignmentOperation member ? member.Value : initializer)),
             IObjectCreationOperation { Initializer: { } objectInitializer } => objectInitializer.Initializers
-                .OfType<ISimpleAssignmentOperation>()
-                .Where(member => member.Target is IFieldReferenceOperation
-                    || (member.Target is IPropertyReferenceOperation property && SendableSymbolClassifier.HasBackingSlot(property.Property)))
-                .Select(member => (IOperation?)member.Value),
+                .SelectMany(element => element switch
+                {
+                    // Member writes carry through compiler-known slots only; a collection
+                    // initializer's Add elements carry like collection-expression elements.
+                    ISimpleAssignmentOperation member when StoresIntoACompilerKnownSlot(member) => new[] { (IOperation?)member.Value },
+                    IInvocationOperation add => add.Arguments.Select(argument => (IOperation?)argument.Value),
+                    _ => System.Linq.Enumerable.Empty<IOperation?>(),
+                }),
             IConversionOperation conversion => new[] { conversion.Operand },
             // Transfer([list]): matched by SYNTAX -- ICollectionExpressionOperation is not
             // public in the Roslyn this analyzer compiles against, but the children are
@@ -364,9 +368,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     // Crossing a try on the way out: the handlers/finally that observe the escape become
-    // scan roots, and the escape itself survives -- unless it is a throw this try's own
-    // catches ABSORB, which never leaves the method: control resumes right after the try,
-    // and the sender-side scan must too (null ends the escape).
+    // scan roots, and the escape itself survives -- unless this try's own catches ABSORB
+    // its failure path, which then never leaves the method: control resumes right after
+    // the try, and the sender-side scan must too (null ends the escape).
     private static IOperation? CrossTryTowardScope(List<IOperation> roots, ITryOperation tryOperation, IOperation child, IOperation escape, int transferPosition)
     {
         // A return whose expression can throw AFTER building the wrapper
@@ -376,13 +380,34 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             || CanThrowAfterTheTransfer(escape, transferPosition);
         AddHandlerRoots(roots, tryOperation, child, escapedByThrow: reachesHandlers);
 
-        if (escape is IThrowOperation thrown && ReferenceEquals(child, tryOperation.Body)
-            && CatchesTheThrow(tryOperation, thrown))
+        if (reachesHandlers && ReferenceEquals(child, tryOperation.Body)
+            && EscapeIsAbsorbed(tryOperation, escape))
         {
             return null;
         }
 
         return escape;
+    }
+
+    // A THROW is absorbed by an unfiltered catch matching its type. A RETURN's failure path
+    // (its expression throwing after the wrapper exists) carries an UNKNOWABLE exception
+    // type, so only a catch-everything absorbs it -- and the return may also complete
+    // normally, but the post-try code the resume path runs is reachable either way.
+    private static bool EscapeIsAbsorbed(ITryOperation tryOperation, IOperation escape)
+    {
+        if (escape is IThrowOperation thrown)
+        {
+            return CatchesTheThrow(tryOperation, thrown);
+        }
+
+        return tryOperation.Catches.Any(catchClause => catchClause.Filter is null
+            && (catchClause.ExceptionType is not { } caughtType || CatchesEverything(caughtType)));
+    }
+
+    private static bool CatchesEverything(ITypeSymbol caughtType)
+    {
+        return caughtType.SpecialType == SpecialType.System_Object
+            || caughtType is INamedTypeSymbol { Name: "Exception", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } };
     }
 
     // Whether the throw DEFINITELY lands in one of the try's handlers: an unfiltered catch
@@ -834,6 +859,12 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    private static bool StoresIntoACompilerKnownSlot(ISimpleAssignmentOperation member)
+    {
+        return member.Target is IFieldReferenceOperation
+            || (member.Target is IPropertyReferenceOperation property && SendableSymbolClassifier.HasBackingSlot(property.Property));
+    }
+
     // `[..operand]` enumerates the operand INTO the new collection: the operand OBJECT is
     // never carried, but an inline container's elements are -- [.. new[] { list }] delivers
     // the same list reference to the receiver. So only the operand's own carried parts
@@ -1089,7 +1120,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             operation.Syntax.Span.End > transferPosition
             && !IsWithinANestedFunction(operation, region)
             && operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
-                or IPropertyReferenceOperation or IArrayElementReferenceOperation);
+                or IPropertyReferenceOperation or IArrayElementReferenceOperation or IFieldReferenceOperation);
     }
 
     // The use is in an arm of an if/switch/?. whose SIBLING arm holds the transfer: the arms
@@ -1176,7 +1207,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         var reinitRoot = reinitialization is IArgumentOperation { Parent: { } call } ? call : reinitialization;
         var canThrow = reinitRoot.DescendantsAndSelf()
             .Any(operation => operation is IInvocationOperation or IObjectCreationOperation or IAwaitOperation
-                or IPropertyReferenceOperation or IArrayElementReferenceOperation);
+                or IPropertyReferenceOperation or IArrayElementReferenceOperation or IFieldReferenceOperation);
         if (!canThrow)
         {
             return null;
@@ -1329,24 +1360,37 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     // `while (c) { Transfer(list); if (skip) break; list = new(); }`: the break exits the loop
     // PAST the reassignment, so the transferred value survives into the code after the loop. A
-    // reinitialization is not definite when a break/continue/goto sits between the transfer
-    // and it and jumps out of a construct that also contains it -- a break leaving a switch
-    // that closes BEFORE the reinitialization skips nothing.
+    // reinitialization is not definite when a break/continue/goto -- or a CAUGHT throw, whose
+    // handler resumes after its try -- sits between the transfer and it and jumps out of a
+    // construct that also contains it; a break leaving a switch that closes BEFORE the
+    // reinitialization skips nothing.
     private static bool ABranchCanSkip(IOperation reinitialization, int transferPosition, IOperation scope)
     {
         var reinitPosition = reinitialization.Syntax.SpanStart;
-        return scope.DescendantsAndSelf().OfType<IBranchOperation>().Any(branch =>
-            branch.Syntax.SpanStart >= transferPosition
-            && branch.Syntax.Span.End <= reinitPosition
-            // A branch in a mutually exclusive sibling arm of the transfer never runs on the
+        return scope.DescendantsAndSelf().Any(operation =>
+            operation.Syntax.SpanStart >= transferPosition
+            && operation.Syntax.Span.End <= reinitPosition
+            // A jump in a mutually exclusive sibling arm of the transfer never runs on the
             // path that transferred (`if (move) Transfer(list); else break;`): it cannot skip
             // anything on that path.
-            && !IsInASiblingArmOfTheTransfer(branch, transferPosition)
-            && CanSkipPast(branch, reinitPosition));
+            && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
+            && CanSkipPast(operation, reinitPosition));
     }
 
-    private static bool CanSkipPast(IBranchOperation branch, int reinitPosition)
+    private static bool CanSkipPast(IOperation operation, int reinitPosition)
     {
+        // A caught throw resumes AFTER its try: it skips a reset that try still contains.
+        if (operation is IThrowOperation)
+        {
+            return NearestCatchingTry(operation) is { } catchingTry
+                && catchingTry.Syntax.Span.Contains(reinitPosition);
+        }
+
+        if (operation is not IBranchOperation branch)
+        {
+            return false;
+        }
+
         if (branch.BranchKind == BranchKind.GoTo)
         {
             return true; // an arbitrary target is assumed able to skip the reinitialization
@@ -1364,6 +1408,25 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static ITryOperation? NearestCatchingTry(IOperation thrown)
+    {
+        for (IOperation child = thrown; child.Parent is { } parent; child = parent)
+        {
+            if (parent is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return null; // a deferred body's throw does not run on this path
+            }
+
+            if (parent is ITryOperation tryOperation && ReferenceEquals(child, tryOperation.Body)
+                && tryOperation.Catches.Length > 0)
+            {
+                return tryOperation;
+            }
+        }
+
+        return null;
     }
 
     // True when the reassignment DEFINITELY executes on the path that transferred: walking up

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -1551,23 +1551,32 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var item in Callables(value))
+            foreach (var resolved in ResolvedCallables(value, site, scope, transferPosition, visited))
             {
-                // Action use = use2 (alone or inside a combine): the copy SNAPSHOTS what the
-                // source holds AT THE COPY -- stores landing in the source afterwards are
-                // not in use's invocation list.
-                if (ReferencedVariable(item) is { } alias)
-                {
-                    foreach (var carried in StoredCallables(alias, scope, site, transferPosition, visited))
-                    {
-                        yield return carried;
-                    }
+                yield return resolved;
+            }
+        }
+    }
 
-                    continue;
+    private static System.Collections.Generic.IEnumerable<IOperation> ResolvedCallables(
+        IOperation value, IOperation site, IOperation scope, int transferPosition, HashSet<ISymbol> visited)
+    {
+        foreach (var item in Callables(value))
+        {
+            // Action use = use2 (alone or inside a combine): the copy SNAPSHOTS what the
+            // source holds AT THE COPY -- stores landing in the source afterwards are not
+            // in use's invocation list.
+            if (ReferencedVariable(item) is { } alias)
+            {
+                foreach (var carried in StoredCallables(alias, scope, site, transferPosition, visited))
+                {
+                    yield return carried;
                 }
 
-                yield return item;
+                continue;
             }
+
+            yield return item;
         }
     }
 

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -451,7 +451,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             IArrayCreationOperation { Initializer: { } initializer } => initializer.ElementValues,
             IAnonymousObjectCreationOperation anonymous => anonymous.Initializers.Select(initializer =>
                 (IOperation?)(initializer is ISimpleAssignmentOperation member ? member.Value : initializer)),
-            IObjectCreationOperation { Initializer: { } objectInitializer } => InitializerCarriedParts(objectInitializer),
+            IObjectCreationOperation creation => ObjectCreationCarriedParts(creation),
             // box with { Value = list }: the receiver's CLONE carries the same reference in
             // its slot. The operand itself stays a leaf like a spread's: the original object
             // is not handed off, only its contents are copied into the clone.
@@ -670,7 +670,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             .SelectMany(root => root.DescendantsAndSelf())
             .OfType<IInvocationOperation>()
             .Where(invocation => invocation.TargetMethod.MethodKind is MethodKind.LocalFunction or MethodKind.DelegateInvoke
-                && invocation.Syntax.SpanStart >= transferPosition
+                // A call WRAPPING the transfer (Use(Sending.Transfer(list))) starts before it,
+                // but its body runs only after all arguments -- the handoff included.
+                && (invocation.Syntax.SpanStart >= transferPosition || Covers(invocation, transferPosition))
                 && !IsInASiblingArmOfTheTransfer(invocation, transferPosition)
                 && (escaped || !IsInAnUnreachableCatch(invocation, transferPosition))
                 && !IsWithinALocalFunctionBody(invocation, scanRoots))
@@ -1010,6 +1012,34 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    // Everything an object creation deterministically stores: its initializer's
+    // compiler-known slots -- and, for a POSITIONAL RECORD, the primary constructor's
+    // arguments, each stored in its same-named auto-property.
+    private static System.Collections.Generic.IEnumerable<IOperation?> ObjectCreationCarriedParts(IObjectCreationOperation creation)
+    {
+        if (creation.Initializer is { } initializer)
+        {
+            foreach (var part in InitializerCarriedParts(initializer))
+            {
+                yield return part;
+            }
+        }
+
+        if (creation.Constructor is not { ContainingType: { IsRecord: true } recordType })
+        {
+            yield break;
+        }
+
+        foreach (var argument in creation.Arguments)
+        {
+            if (argument.Parameter is { } parameter
+                && recordType.GetMembers(parameter.Name).OfType<IPropertySymbol>().Any(SendableSymbolClassifier.HasBackingSlot))
+            {
+                yield return argument.Value;
+            }
+        }
+    }
+
     // Member writes carry through compiler-known slots only; an INDEXER initializer
     // (["x"] = list) stores value AND keys into the collection; a collection initializer's
     // Add elements carry like collection expressions.
@@ -1160,14 +1190,14 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     // back around), a definite `=` overwrite KILLS every earlier target, `-=` never adds
     // one, and a plain delegate-to-delegate copy carries the SOURCE local's candidates.
     private static System.Collections.Generic.IEnumerable<IOperation> StoredCallables(
-        ISymbol delegateLocal, IOperation scope, IInvocationOperation call, int transferPosition, HashSet<ISymbol> visited)
+        ISymbol delegateLocal, IOperation scope, IOperation consumer, int transferPosition, HashSet<ISymbol> visited)
     {
         if (!visited.Add(delegateLocal))
         {
             yield break;
         }
 
-        var stores = DelegateStores(delegateLocal, scope, call, transferPosition);
+        var stores = DelegateStores(delegateLocal, scope, consumer, transferPosition);
 
         // A definite overwrite replaces the whole invocation list: candidates begin at the
         // LAST replace that runs on every path to the call.
@@ -1190,8 +1220,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
             }
             else if (ReferencedVariable(value) is { } alias)
             {
-                // Action use = use2: the copy carries whatever the SOURCE could hold.
-                foreach (var carried in StoredCallables(alias, scope, call, transferPosition, visited))
+                // Action use = use2: the copy SNAPSHOTS what the source holds AT THE COPY --
+                // stores landing in the source afterwards are not in use's invocation list.
+                foreach (var carried in StoredCallables(alias, scope, site, transferPosition, visited))
                 {
                     yield return carried;
                 }
@@ -1200,7 +1231,7 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
     }
 
     private static List<(IOperation Site, IOperation Value, bool Replaces)> DelegateStores(
-        ISymbol delegateLocal, IOperation scope, IInvocationOperation call, int transferPosition)
+        ISymbol delegateLocal, IOperation scope, IOperation consumer, int transferPosition)
     {
         var stores = new List<(IOperation Site, IOperation Value, bool Replaces)>();
         foreach (var operation in scope.DescendantsAndSelf())
@@ -1223,7 +1254,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
             if (matched is { } store
                 && !IsInASiblingArmOfTheTransfer(operation, transferPosition)
-                && (operation.Syntax.SpanStart < call.Syntax.Span.End || SharesALoopWith(operation, call)))
+                && (operation.Syntax.SpanStart < consumer.Syntax.Span.End || SharesALoopWith(operation, consumer))
+                // A store inside a local function nothing ever invokes never executed.
+                && !IsInAnUnreferencedNestedFunction(operation, scope))
             {
                 stores.Add((operation, store.Value, store.Replaces));
             }
@@ -1232,9 +1265,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         return stores;
     }
 
-    private static bool SharesALoopWith(IOperation store, IOperation call)
+    private static bool SharesALoopWith(IOperation store, IOperation consumer)
     {
-        for (var parent = call.Parent; parent is not null; parent = parent.Parent)
+        for (var parent = consumer.Parent; parent is not null; parent = parent.Parent)
         {
             if (parent is ILoopOperation && parent.Syntax.Span.Contains(store.Syntax.SpanStart))
             {
@@ -1609,8 +1642,9 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
 
     private static bool CanSkipPast(IOperation operation, int reinitPosition, IOperation scope)
     {
-        // A caught throw resumes AFTER its try: it skips a reset that try still contains.
-        if (operation is IThrowOperation)
+        // A caught FAILURE resumes AFTER its try: any throw-capable operation (an explicit
+        // throw, a call that may fail, ...) skips a reset that try still contains.
+        if (CanThrow(operation))
         {
             return NearestCatchingTry(operation) is { } catchingTry
                 && catchingTry.Syntax.Span.Contains(reinitPosition);

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -82,18 +82,45 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
                 // the replacement, which is exactly a use after transfer).
                 var rhsUse = assignment.Value.DescendantsAndSelf()
                     .FirstOrDefault(operation => SymbolEqualityComparer.Default.Equals(ReferencedVariable(operation), variable));
-                if (rhsUse is null)
+                if (rhsUse is not null)
+                {
+                    Report(context, rhsUse, variable);
+                    return;
+                }
+
+                // ...and only if it DEFINITELY executes: a reassignment inside a branch the
+                // transfer is not part of (`if (reset) list = new();`) leaves the other path
+                // still using the transferred value, so the scan continues past it (without
+                // flagging the write target itself).
+                if (IsOnTheTransfersConditionalLevel(assignment, transferPosition))
                 {
                     return;
                 }
 
-                Report(context, rhsUse, variable);
-                return;
+                continue;
             }
 
             Report(context, reference, variable);
             return; // one report per transfer keeps the noise proportional
         }
+    }
+
+    // True when no branching construct separates the reassignment from the transfer: every
+    // conditional/loop/switch/try ancestor of the assignment must also span the transfer, so
+    // both sit on the same conditional level and source order implies execution order.
+    private static bool IsOnTheTransfersConditionalLevel(IOperation assignment, int transferPosition)
+    {
+        for (var parent = assignment.Parent; parent is not null; parent = parent.Parent)
+        {
+            var branches = parent is IConditionalOperation or ISwitchOperation or ISwitchExpressionOperation
+                or ILoopOperation or ITryOperation or IConditionalAccessOperation;
+            if (branches && !parent.Syntax.Span.Contains(transferPosition))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static void Report(OperationBlockAnalysisContext context, IOperation reference, ISymbol variable)

--- a/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
+++ b/MemoizR.Analyzers/UseAfterTransferAnalyzer.cs
@@ -384,8 +384,44 @@ public sealed class UseAfterTransferAnalyzer : DiagnosticAnalyzer
         }
 
         return IsOnTheTransfersConditionalLevel(reinitialization, transferPosition)
+                && !ABranchCanSkip(reinitialization, transferPosition, scope)
             ? ReferenceRole.FreshValueFromHere
             : ReferenceRole.ConditionalReinitialization;
+    }
+
+    // `while (c) { Transfer(list); if (skip) break; list = new(); }`: the break exits the loop
+    // PAST the reassignment, so the transferred value survives into the code after the loop. A
+    // reinitialization is not definite when a break/continue/goto sits between the transfer
+    // and it and jumps out of a construct that also contains it -- a break leaving a switch
+    // that closes BEFORE the reinitialization skips nothing.
+    private static bool ABranchCanSkip(IOperation reinitialization, int transferPosition, IOperation scope)
+    {
+        var reinitPosition = reinitialization.Syntax.SpanStart;
+        return scope.DescendantsAndSelf().OfType<IBranchOperation>().Any(branch =>
+            branch.Syntax.SpanStart >= transferPosition
+            && branch.Syntax.Span.End <= reinitPosition
+            && CanSkipPast(branch, reinitPosition));
+    }
+
+    private static bool CanSkipPast(IBranchOperation branch, int reinitPosition)
+    {
+        if (branch.BranchKind == BranchKind.GoTo)
+        {
+            return true; // an arbitrary target is assumed able to skip the reinitialization
+        }
+
+        for (var parent = branch.Parent; parent is not null; parent = parent.Parent)
+        {
+            var exits = branch.BranchKind == BranchKind.Break
+                ? parent is ILoopOperation or ISwitchOperation
+                : parent is ILoopOperation;
+            if (exits)
+            {
+                return parent.Syntax.Span.Contains(reinitPosition);
+            }
+        }
+
+        return false;
     }
 
     // True when the reassignment DEFINITELY executes on the path that transferred: walking up

--- a/MemoizR.Reactive/AdvancedReaction.cs
+++ b/MemoizR.Reactive/AdvancedReaction.cs
@@ -1,5 +1,6 @@
 namespace MemoizR.Reactive;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class AdvancedReaction : ReactionBase
 {
     private readonly Func<Task> fn;

--- a/MemoizR.Reactive/Reaction.cs
+++ b/MemoizR.Reactive/Reaction.cs
@@ -1,5 +1,6 @@
 namespace MemoizR.Reactive;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class Reaction : ReactionBase
 {
     private readonly Func<Task> action;

--- a/MemoizR.StructuredConcurrency/ConcurrentMap.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentMap.cs
@@ -1,5 +1,6 @@
 namespace MemoizR.StructuredConcurrency;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class ConcurrentMap<T> : MemoBase<IEnumerable<T>>
 {
     private readonly IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns;

--- a/MemoizR.StructuredConcurrency/ConcurrentMap.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentMap.cs
@@ -7,7 +7,10 @@ public sealed class ConcurrentMap<T> : MemoBase<IEnumerable<T>>
 
     internal ConcurrentMap(IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns, Context context) : base(context)
     {
-        this.fns = fns;
+        // Snapshot: the params array arrives caller-owned, and [Sendable] promises internal
+        // synchronization -- a caller swapping elements must not change the computation set a
+        // recompute is enumerating.
+        this.fns = fns.ToArray();
     }
 
     public void Cancel()

--- a/MemoizR.StructuredConcurrency/ConcurrentMapReduce.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentMapReduce.cs
@@ -8,7 +8,9 @@ public sealed class ConcurrentMapReduce<T> : MemoBase<T>
 
     internal ConcurrentMapReduce(IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns, Func<T, T, T?> reduce, Context context) : base(context)
     {
-        this.fns = fns;
+        // Snapshot: see ConcurrentMap -- the caller keeps the params array and must not be able
+        // to swap the computation set out from under a recompute.
+        this.fns = fns.ToArray();
         this.reduce = reduce;
     }
 

--- a/MemoizR.StructuredConcurrency/ConcurrentMapReduce.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentMapReduce.cs
@@ -1,5 +1,6 @@
 namespace MemoizR.StructuredConcurrency;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class ConcurrentMapReduce<T> : MemoBase<T>
 {
     private readonly IReadOnlyCollection<Func<IStructuredResourceGroup, Task<T>>> fns;

--- a/MemoizR.StructuredConcurrency/ConcurrentRace.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentRace.cs
@@ -7,6 +7,7 @@ namespace MemoizR.StructuredConcurrency;
 // observers straight to CacheDirty: a race result is non-memoized, so observers cannot verify
 // "did it really change?" via a cheap re-check and must recompute. The inherited stateCell is
 // intentionally unused; State here is only a cycle-detection marker.
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class ConcurrentRace<T, I> : MemoHandlR<T>, IMemoizR, IStampedGetR<T>
 {
     private CacheState State { get; set; } = CacheState.CacheDirty;

--- a/MemoizR.StructuredConcurrency/ConcurrentRace.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentRace.cs
@@ -22,7 +22,9 @@ public sealed class ConcurrentRace<T, I> : MemoHandlR<T>, IMemoizR, IStampedGetR
         Context context) : base(context)
     {
         this.action = action;
-        this.fns = fns;
+        // Snapshot: see ConcurrentMap -- the caller keeps the params array and must not be able
+        // to swap the racing set out from under a recompute.
+        this.fns = fns.ToArray();
     }
 
     public void Cancel()

--- a/MemoizR.Tests/ActorEngineTests.cs
+++ b/MemoizR.Tests/ActorEngineTests.cs
@@ -583,8 +583,17 @@ public class ActorEngineTests
         Assert.Equal(10, await c.Get());
     }
 
-    private sealed class ThrowsOnEquals(int seed)
+    private sealed class ThrowsOnEquals
     {
+        // A readonly field, not a primary-constructor capture: captures compile to WRITABLE
+        // fields, which the (now default) strict Sendable check rightly rejects.
+        private readonly int seed;
+
+        public ThrowsOnEquals(int seed)
+        {
+            this.seed = seed;
+        }
+
         public override bool Equals(object? obj) => throw new InvalidOperationException("equals boom");
 
         public override int GetHashCode() => seed;

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -294,6 +294,17 @@ public class StrictSendableModeTests
         Assert.NotNull(await deepButClean.Get());
     }
 
+    [Fact(Timeout = 10000)]
+    public async Task PolymorphicRecursion_WithAStoredParameter_IsRejectedNotAssumed()
+    {
+        // The divergent chain's SECOND level substitutes Value to List<int>: the walk must
+        // inspect the first re-instantiation's members before cutting, or the shared mutable
+        // list hides behind the cycle assumption.
+        await Task.Yield(); // xunit requires async for Timeout, the termination backstop
+        var f = new MemoFactory();
+        Assert.Throws<InvalidOperationException>(() => f.CreateSignal(new RecursiveBoxWithValue<int>()));
+    }
+
     [Fact]
     public void DefaultFactory_Checks_AndDisableIsTheEscapeHatch()
     {
@@ -377,6 +388,16 @@ internal sealed class RecursiveBox<T>
 // recursive step SHRINKS, so the divergence cut must let the walk reach the bottom.
 internal sealed class WrapBox<T>
 {
+    public T? Value { get; init; }
+}
+
+// Polymorphic recursion that ALSO stores its parameter: the divergent chain's second level
+// substitutes Value to List<int>, so the walk must inspect the first re-instantiation's own
+// members before cutting.
+internal sealed class RecursiveBoxWithValue<T>
+{
+    public RecursiveBoxWithValue<List<T>>? Next { get; init; }
+
     public T? Value { get; init; }
 }
 

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -267,6 +267,18 @@ public class ValidateWrittenValuesTests
     }
 
     [Fact]
+    public async Task FrozenSetInstances_KeepTheGreenListVerdict()
+    {
+        // ToFrozenSet hands out internal implementations (FrozenSet<T> is deliberately
+        // abstract): the instance is still the green-listed frozen collection, whatever
+        // specialized subtype the runtime picked.
+        var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks | MemoFactoryOptions.ValidateWrittenValues);
+        var signal = f.CreateSignal(System.Collections.Frozen.FrozenSet.ToFrozenSet(new[] { 1 }));
+        await signal.Set(System.Collections.Frozen.FrozenSet.ToFrozenSet(new[] { 2, 3 }));
+        Assert.Equal(2, (await signal.Get())!.Count);
+    }
+
+    [Fact]
     public void FrameworkImplementations_OfGreenListedTypes_AreSendable()
     {
         // The green-list trust covers same-assembly framework implementations only: a USER

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -233,6 +233,28 @@ public class ValidateWrittenValuesTests
         var relative = f.CreateEagerRelativeSignal<OpenBase>(new OpenBase());
         await Assert.ThrowsAsync<InvalidOperationException>(() => relative.Set(_ => new MutableChild()));
     }
+
+    [Fact]
+    public async Task FrameworkPolymorphicValues_KeepTheGreenListVerdict()
+    {
+        // typeof(int) is a System.RuntimeType: an internal runtime implementation of the
+        // green-listed Type. The write check sees the INSTANCE's type, so the entry's trust
+        // must extend to the runtime's own subclasses or every Signal<Type> write throws.
+        var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks | MemoFactoryOptions.ValidateWrittenValues);
+        var signal = f.CreateSignal<Type>(typeof(int));
+        await signal.Set(typeof(string));
+        Assert.Equal(typeof(string), await signal.Get());
+    }
+
+    [Fact]
+    public void FrameworkImplementations_OfGreenListedTypes_AreSendable()
+    {
+        // The green-list trust covers same-assembly framework implementations only: a USER
+        // subclass of a green-listed type still walks structurally -- that is the smuggle
+        // surface ValidateWrittenValues exists to catch.
+        Assert.True(SendableChecker.IsSendable(typeof(int).GetType(), out var reason), reason);
+        Assert.False(SendableChecker.IsSendable(typeof(MutableChild)));
+    }
 }
 
 public class SendingTransferTests

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -258,11 +258,14 @@ public class SendingTransferTests
 public class StrictSendableModeTests
 {
     [Fact]
-    public void DefaultFactory_DoesNotCheck()
+    public void DefaultFactory_Checks_AndDisableIsTheEscapeHatch()
     {
+        // The Swift 6 language-mode analog (issue #145 part A4): strict IS the default.
         var f = new MemoFactory();
-        var signal = f.CreateSignal(new List<int>()); // compatibility: lax by default
-        Assert.NotNull(signal);
+        Assert.Throws<InvalidOperationException>(() => f.CreateSignal(new List<int>()));
+
+        var migrating = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks);
+        Assert.NotNull(migrating.CreateSignal(new List<int>()));
     }
 
     [Fact]
@@ -311,7 +314,7 @@ public class StrictSendableModeTests
         // Strictness is a per-factory creation policy, not a context property.
         var key = $"strict-{Guid.NewGuid():N}";
         var strict = new MemoFactory(key, MemoFactoryOptions.StrictSendableChecks);
-        var lax = new MemoFactory(key);
+        var lax = new MemoFactory(key, MemoFactoryOptions.DisableSendableChecks);
 
         Assert.Same(strict.Context, lax.Context);
         Assert.Throws<InvalidOperationException>(() => strict.CreateSignal(new List<int>()));

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -279,6 +279,24 @@ public class ValidateWrittenValuesTests
     }
 
     [Fact]
+    public void AsyncTasks_BehindTheNonGenericSurface_StillCheckTheirResult()
+    {
+        // Declared as plain Task the creation check passes, but the INSTANCE is an internal
+        // subtype of Task<List<int>>: trusting the implementation must not skip the
+        // green-listed generic base's arguments, or a cast re-opens the upcast-smuggling
+        // hole this option exists to close.
+        var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks | MemoFactoryOptions.ValidateWrittenValues);
+        var ex = Assert.Throws<InvalidOperationException>(() => f.CreateSignal<Task>(ComputeListAsync()));
+        Assert.Contains("List", ex.Message);
+
+        static async Task<List<int>> ComputeListAsync()
+        {
+            await Task.Yield();
+            return new List<int> { 1 };
+        }
+    }
+
+    [Fact]
     public void FrameworkImplementations_OfGreenListedTypes_AreSendable()
     {
         // The green-list trust covers same-assembly framework implementations only: a USER

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -268,6 +268,17 @@ public class SendingTransferTests
 
 public class StrictSendableModeTests
 {
+    [Fact(Timeout = 10000)]
+    public async Task PolymorphicRecursion_TerminatesTheStructuralWalk()
+    {
+        // RecursiveBox<T> exposes RecursiveBox<List<T>>: every level is a FRESH closed type,
+        // so the per-instance cycle set never repeats -- the same-definition path cap must cut
+        // the walk. The closed type stores only readonly boxes, so strict mode accepts it.
+        var f = new MemoFactory();
+        var signal = f.CreateSignal(new RecursiveBox<int>());
+        Assert.NotNull(await signal.Get());
+    }
+
     [Fact]
     public void DefaultFactory_Checks_AndDisableIsTheEscapeHatch()
     {
@@ -339,6 +350,14 @@ internal sealed record SendablePerson(string Name, int Age);
 internal record SendableOpenRecord(string Name, int Age);
 
 // Immutable, deliberately NON-sealed: the declared type passes creation-time checks...
+// Polymorphic recursion: the member re-instantiates the declaration with a GROWING argument,
+// so a naive per-closed-type cycle set never terminates (see the same-definition path cap in
+// SendableChecker/SendableSymbolClassifier).
+internal sealed class RecursiveBox<T>
+{
+    public RecursiveBox<List<T>>? Next { get; init; }
+}
+
 internal class OpenBase
 {
     public string Name { get; init; } = "";

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -216,6 +216,17 @@ public class ValidateWrittenValuesTests
     }
 
     [Fact]
+    public async Task DisableSendableChecks_AlsoDisablesWriteValidation()
+    {
+        // The migration escape hatch is COMPLETE: opting out of the Sendable checks must not
+        // leave write-time validation armed, or migrating code would still throw on Set.
+        var f = new MemoFactory(options: MemoFactoryOptions.ValidateWrittenValues | MemoFactoryOptions.DisableSendableChecks);
+        var signal = f.CreateSignal<OpenBase>(new OpenBase());
+        await signal.Set(new MutableChild());
+        Assert.NotNull(signal);
+    }
+
+    [Fact]
     public async Task EagerRelativeSignal_ValidatesTheComputedResult()
     {
         var f = new MemoFactory(options: MemoFactoryOptions.ValidateWrittenValues);

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -184,6 +184,77 @@ public class SendableCheckerTests
     }
 }
 
+public class ValidateWrittenValuesTests
+{
+    [Fact]
+    public async Task SmuggledMutableSubclass_IsRejectedAtTheWrite()
+    {
+        var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks | MemoFactoryOptions.ValidateWrittenValues);
+        var signal = f.CreateSignal<OpenBase>(new OpenBase()); // declared type passes the creation check
+
+        // The runtime type of the written instance is what the declared-type check cannot see.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => signal.Set(new MutableChild()));
+
+        await signal.Set(new OpenBase()); // a well-behaved instance still writes fine
+    }
+
+    [Fact]
+    public async Task WithoutTheOption_RuntimeTypesAreNotChecked()
+    {
+        var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks);
+        var signal = f.CreateSignal<OpenBase>(new OpenBase());
+        await signal.Set(new MutableChild()); // documented hole when the option is off
+        Assert.NotNull(signal);
+    }
+
+    [Fact]
+    public async Task ActorSignal_ValidatesWrites_Too()
+    {
+        var f = new MemoFactory(options: MemoFactoryOptions.ValidateWrittenValues);
+        var signal = f.CreateActorSignal<OpenBase>(new OpenBase());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => signal.Set(new MutableChild()));
+    }
+
+    [Fact]
+    public async Task EagerRelativeSignal_ValidatesTheComputedResult()
+    {
+        var f = new MemoFactory(options: MemoFactoryOptions.ValidateWrittenValues);
+        var relative = f.CreateEagerRelativeSignal<OpenBase>(new OpenBase());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => relative.Set(_ => new MutableChild()));
+    }
+}
+
+public class SendingTransferTests
+{
+    [Fact]
+    public void Sending_IsSendable_EvenWhenThePayloadIsNot()
+    {
+        // The whole point of the wrapper: transfer semantics stand in for immutability.
+        Assert.True(SendableChecker.IsSendable(typeof(Sending<List<int>>), out var reason), reason);
+    }
+
+    [Fact]
+    public void StrictFactory_AcceptsSendingOfNonSendablePayload()
+    {
+        var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks);
+        var signal = f.CreateSignal(Sending.Transfer(new List<int> { 1, 2 }));
+        Assert.NotNull(signal);
+    }
+
+    [Fact]
+    public async Task Receive_HandsOverTheValue_ExactlyOnce()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var sending = Sending.Transfer(list);
+
+        var received = await Task.Run(() => sending.Receive()); // one owner, on another flow
+        Assert.Same(list, received);
+
+        // A second receive would mean two owners -- exactly the aliasing the type prevents.
+        Assert.Throws<InvalidOperationException>(() => sending.Receive());
+    }
+}
+
 public class StrictSendableModeTests
 {
     [Fact]
@@ -252,6 +323,18 @@ internal sealed record SendablePerson(string Name, int Age);
 
 // Deliberately NOT sealed: exercises the synthesized `protected virtual Type EqualityContract`.
 internal record SendableOpenRecord(string Name, int Age);
+
+// Immutable, deliberately NON-sealed: the declared type passes creation-time checks...
+internal class OpenBase
+{
+    public string Name { get; init; } = "";
+}
+
+// ...and this is what an upcast smuggles past them: mutable subclass state.
+internal sealed class MutableChild : OpenBase
+{
+    public int Mutable;
+}
 
 internal sealed class PlainInitDto
 {

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -279,6 +279,21 @@ public class StrictSendableModeTests
         Assert.NotNull(await signal.Get());
     }
 
+    [Fact(Timeout = 10000)]
+    public async Task FiniteDeepGenericNesting_IsStillFullyChecked()
+    {
+        // Hand-written nesting repeats the definition but SHRINKS at every level: the
+        // divergence cut must not fire, so the walk reaches the List at the bottom and strict
+        // mode rejects the graph.
+        var f = new MemoFactory();
+        Assert.Throws<InvalidOperationException>(
+            () => f.CreateSignal(new WrapBox<WrapBox<WrapBox<WrapBox<WrapBox<List<int>>>>>>()));
+
+        // And the shrinking walk accepts a genuinely Sendable deep composition.
+        var deepButClean = f.CreateSignal(new WrapBox<WrapBox<WrapBox<WrapBox<WrapBox<int>>>>>());
+        Assert.NotNull(await deepButClean.Get());
+    }
+
     [Fact]
     public void DefaultFactory_Checks_AndDisableIsTheEscapeHatch()
     {
@@ -351,11 +366,18 @@ internal record SendableOpenRecord(string Name, int Age);
 
 // Immutable, deliberately NON-sealed: the declared type passes creation-time checks...
 // Polymorphic recursion: the member re-instantiates the declaration with a GROWING argument,
-// so a naive per-closed-type cycle set never terminates (see the same-definition path cap in
-// SendableChecker/SendableSymbolClassifier).
+// so a naive per-closed-type cycle set never terminates (see the same-definition divergence
+// cut in SendableChecker/SendableSymbolClassifier).
 internal sealed class RecursiveBox<T>
 {
     public RecursiveBox<List<T>>? Next { get; init; }
+}
+
+// A plain wrapper for FINITE hand-written nesting (WrapBox<WrapBox<...<List<int>>>>): each
+// recursive step SHRINKS, so the divergence cut must let the walk reach the bottom.
+internal sealed class WrapBox<T>
+{
+    public T? Value { get; init; }
 }
 
 internal class OpenBase

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -247,6 +247,26 @@ public class ValidateWrittenValuesTests
     }
 
     [Fact]
+    public async Task AsyncReturnedTasks_KeepTheGreenListVerdict()
+    {
+        // A suspended async method returns an AsyncStateMachineBox: an internal Task subtype
+        // whose generic arguments carry the compiler-generated state machine -- captured
+        // mutable locals included. The instance is still the green-listed Task: its arguments
+        // are runtime plumbing, not the declared surface the creation check vetted.
+        var f = new MemoFactory(options: MemoFactoryOptions.StrictSendableChecks | MemoFactoryOptions.ValidateWrittenValues);
+        var signal = f.CreateSignal(ComputeAsync());
+        var task = await signal.Get();
+        Assert.Equal(1, await task!);
+
+        static async Task<int> ComputeAsync()
+        {
+            var buffer = new List<int> { 1 }; // lives on in the state machine across the await
+            await Task.Yield();
+            return buffer.Count;
+        }
+    }
+
+    [Fact]
     public void FrameworkImplementations_OfGreenListedTypes_AreSendable()
     {
         // The green-list trust covers same-assembly framework implementations only: a USER

--- a/MemoizR.Tests/SendableTests.cs
+++ b/MemoizR.Tests/SendableTests.cs
@@ -306,6 +306,17 @@ public class StrictSendableModeTests
     }
 
     [Fact]
+    public void NativeIntegers_ArePrimitives_AndPassStrictMode()
+    {
+        // typeof(IntPtr).IsPrimitive is true, so the runtime walk's primitive short-circuit
+        // accepts nint/nuint before any field reflection -- in lockstep with the analyzer's
+        // System_IntPtr/System_UIntPtr acceptance.
+        var f = new MemoFactory();
+        Assert.NotNull(f.CreateSignal(nint.Zero));
+        Assert.NotNull(f.CreateSignal(nuint.MinValue));
+    }
+
+    [Fact]
     public void DefaultFactory_Checks_AndDisableIsTheEscapeHatch()
     {
         // The Swift 6 language-mode analog (issue #145 part A4): strict IS the default.

--- a/MemoizR.Tests/StructuredMapTests.cs
+++ b/MemoizR.Tests/StructuredMapTests.cs
@@ -50,7 +50,10 @@ namespace MemoizR.Tests.StructuredConcurrency
         [Fact(Timeout = 1000)]
         public async Task TestConcurrentMapWithDiamondDependencies()
         {
-            var f = new MemoFactory();
+            // Memos composed over a ConcurrentMap are typed IEnumerable<T> -- an interface, which
+            // the (now default) strict Sendable checks reject by principle. Known migration
+            // friction: compose over an immutable type, or opt out per factory as here.
+            var f = new MemoFactory(options: MemoFactoryOptions.DisableSendableChecks);
 
             var v1 = f.CreateSignal(1);
             var v2 = f.CreateSignal(2);

--- a/MemoizR.Tests/StructuredMapTests.cs
+++ b/MemoizR.Tests/StructuredMapTests.cs
@@ -1,3 +1,4 @@
+using MemoizR.StructuredConcurrency;
 using Xunit;
 
 namespace MemoizR.Tests.StructuredConcurrency
@@ -19,6 +20,23 @@ namespace MemoizR.Tests.StructuredConcurrency
 
             Assert.Equal([1, 2], value);
             Assert.IsNotType<int[]>(value, exactMatch: false);
+        }
+
+        // The nodes are [Sendable]: the computation set must be the construction-time snapshot,
+        // not the caller's live array -- swapping an element after creation must change nothing
+        // (a swap DURING a recompute would otherwise change the set mid-enumeration).
+        [Fact(Timeout = 10000)]
+        public async Task ConcurrentMap_SnapshotsTheParamsArray_CallerSwapsChangeNothing()
+        {
+            var f = new MemoFactory();
+            var fns = new Func<IStructuredResourceGroup, Task<int>>[] { async _ => 1 };
+            var map = f.CreateConcurrentMap(fns);
+            var reduce = f.CreateConcurrentMapReduce(fns);
+
+            fns[0] = async _ => 42;
+
+            Assert.Equal([1], await map.Get());
+            Assert.Equal(1, await reduce.Get());
         }
 
         [Fact(Timeout = 1000)]

--- a/MemoizR/ActorMemo.cs
+++ b/MemoizR/ActorMemo.cs
@@ -18,6 +18,7 @@ namespace MemoizR;
 /// wait like any other reader. Waiting holds no lock and no actor, so the lock-ordering
 /// analysis of concurrency.md §9 has nothing to analyze here.
 /// </summary>
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class ActorMemo<T> : ActorValueNode<T>
 {
     private readonly Func<Task<T>> fn;

--- a/MemoizR/ActorSignal.cs
+++ b/MemoizR/ActorSignal.cs
@@ -8,15 +8,31 @@ namespace MemoizR;
 /// interfaces: the two engines must not be mixed in one graph, and keeping the types apart
 /// makes the mistake impossible to compile.
 /// </summary>
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class ActorSignal<T> : ActorValueNode<T>
 {
-    internal ActorSignal(T value, Context context)
+    // See Signal<T>: MemoFactoryOptions.ValidateWrittenValues (per-node, factory-governed).
+    private readonly bool validateWrittenValues;
+
+    internal ActorSignal(T value, Context context, bool validateWrittenValues = false)
         : base(value, context, CacheState.CacheClean)
     {
+        this.validateWrittenValues = validateWrittenValues;
+        ValidateWrittenValue(value);
+    }
+
+    private void ValidateWrittenValue(T value)
+    {
+        if (validateWrittenValues && value is not null)
+        {
+            SendableChecker.EnsureSendable(value.GetType());
+        }
     }
 
     public Task Set(T value)
     {
+        ValidateWrittenValue(value);
+
         // The actor engine's equivalent of the lock engine's exclusive-inside-upgradeable
         // rejection: a Set from inside a computation is a feedback loop -- it would invalidate
         // the very evaluation in progress, dooming its commit by design. Detected on the flow,

--- a/MemoizR/DedicatedThreadExecutor.cs
+++ b/MemoizR/DedicatedThreadExecutor.cs
@@ -18,6 +18,7 @@ namespace MemoizR;
 /// onto the captured context) are re-thrown on the thread pool, preserving the platform's
 /// "async-void exceptions are fatal" convention without wedging the executor's queue.
 /// </remarks>
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class DedicatedThreadExecutor : IExecutor, IDisposable
 {
     private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> queue = new();

--- a/MemoizR/EagerRelativeSignal.cs
+++ b/MemoizR/EagerRelativeSignal.cs
@@ -1,5 +1,6 @@
 namespace MemoizR;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class EagerRelativeSignal<T> : MemoHandlR<T>, IStampedGetR<T>
 {
     private Lock Lock { get; } = new();
@@ -8,8 +9,13 @@ public sealed class EagerRelativeSignal<T> : MemoHandlR<T>, IStampedGetR<T>
     // Guarded by Lock; a plain counter so Set does not walk the published stamp's event tree.
     private long trigger;
 
-    internal EagerRelativeSignal(T value, Context context) : base(context)
+    // See Signal<T>: MemoFactoryOptions.ValidateWrittenValues, applied to fn's result.
+    private readonly bool validateWrittenValues;
+
+    internal EagerRelativeSignal(T value, Context context, bool validateWrittenValues = false) : base(context)
     {
+        this.validateWrittenValues = validateWrittenValues;
+        ValidateWrittenValue(value);
         if (context.StampsEnabled)
         {
             SetValueAndStamp(value, CausalityStamp.ForSignal(Id, 0, context.Epoch));
@@ -17,6 +23,14 @@ public sealed class EagerRelativeSignal<T> : MemoHandlR<T>, IStampedGetR<T>
         else
         {
             SetValueUnstamped(value);
+        }
+    }
+
+    private void ValidateWrittenValue(T value)
+    {
+        if (validateWrittenValues && value is not null)
+        {
+            SendableChecker.EnsureSendable(value.GetType());
         }
     }
 
@@ -45,13 +59,15 @@ public sealed class EagerRelativeSignal<T> : MemoHandlR<T>, IStampedGetR<T>
                     // CacheDirty (there is no equality short-cut here), so the trigger mirrors
                     // exactly what observers are told (issue #39). A stamps-disabled context
                     // builds no stamp at all.
+                    var next = fn(Value);
+                    ValidateWrittenValue(next);
                     if (Context.StampsEnabled)
                     {
-                        SetValueAndStamp(fn(Value), CausalityStamp.ForSignal(Id, ++trigger, Context.Epoch));
+                        SetValueAndStamp(next, CausalityStamp.ForSignal(Id, ++trigger, Context.Epoch));
                     }
                     else
                     {
-                        SetValueUnstamped(fn(Value));
+                        SetValueUnstamped(next);
                     }
                 }
 

--- a/MemoizR/GraphActor.cs
+++ b/MemoizR/GraphActor.cs
@@ -18,6 +18,7 @@ namespace MemoizR;
 /// other executor-isolated state. The loop parks on its own channel when idle and holds no
 /// external roots, so an unreachable actor (its Context dropped) is collectable, loop and all.
 /// </remarks>
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class GraphActor : IExecutor
 {
     private readonly Channel<Action> turns = Channel.CreateUnbounded<Action>(

--- a/MemoizR/MemoFactory.cs
+++ b/MemoizR/MemoFactory.cs
@@ -1,5 +1,6 @@
 namespace MemoizR;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class MemoFactory
 {
     private static readonly Lock contextsLock = new();
@@ -160,7 +161,7 @@ public sealed class MemoFactory
     public Signal<T> CreateSignal<T>(string label, T value)
     {
         EnsureSendableIfStrict<T>();
-        return new(value, Context)
+        return new(value, Context, Options.HasFlag(MemoFactoryOptions.ValidateWrittenValues))
         {
             Label = label
         };
@@ -174,7 +175,7 @@ public sealed class MemoFactory
     public EagerRelativeSignal<T> CreateEagerRelativeSignal<T>(string label, T value)
     {
         EnsureSendableIfStrict<T>();
-        return new(value, Context)
+        return new(value, Context, Options.HasFlag(MemoFactoryOptions.ValidateWrittenValues))
         {
             Label = label
         };
@@ -190,7 +191,7 @@ public sealed class MemoFactory
     public ActorSignal<T> CreateActorSignal<T>(T value)
     {
         EnsureSendableIfStrict<T>();
-        return new(value, Context);
+        return new(value, Context, Options.HasFlag(MemoFactoryOptions.ValidateWrittenValues));
     }
 
     /// <summary>

--- a/MemoizR/MemoFactory.cs
+++ b/MemoizR/MemoFactory.cs
@@ -211,7 +211,9 @@ public sealed class MemoFactory
     // friend assembly) enforce the same contract for their nodes.
     internal void EnsureSendableIfStrict<T>()
     {
-        if (Options.HasFlag(MemoFactoryOptions.StrictSendableChecks))
+        // Strict is the DEFAULT (issue #145 part A4, the Swift 6 language-mode analog);
+        // DisableSendableChecks is the migration escape hatch.
+        if (!Options.HasFlag(MemoFactoryOptions.DisableSendableChecks))
         {
             SendableChecker.EnsureSendable(typeof(T));
         }

--- a/MemoizR/MemoFactory.cs
+++ b/MemoizR/MemoFactory.cs
@@ -16,12 +16,18 @@ public sealed class MemoFactory
     // factory itself so the association is discoverable and dies with the factory -- it
     // previously sat in a static side-table in another assembly, which rooted every registered
     // factory forever.
-    internal IExecutor? Executor { get; set; }
+    // VOLATILE: the factory is [Sendable], so its mutable configuration must at least publish
+    // cleanly across flows -- a reaction built on one flow sees the executor registered on
+    // another (reference reads cannot tear; semantics are last-write-wins, i.e. configure the
+    // factory before sharing it, which the Add* docs already advise).
+    private volatile IExecutor? executor;
+    internal IExecutor? Executor { get => executor; set => executor = value; }
 
     // The TimeProvider reactions built from this factory schedule their debounce delays on
     // (set via MemoizR.Reactive's AddTimeProvider). Null means TimeProvider.System. Tests inject
     // a FakeTimeProvider so debounce windows elapse under test control instead of wall-clock time.
-    internal TimeProvider? TimeProvider { get; set; }
+    private volatile TimeProvider? timeProvider;
+    internal TimeProvider? TimeProvider { get => timeProvider; set => timeProvider = value; }
 
     /// <summary>
     /// Options are per-factory, not per-context: strictness governs how THIS factory creates

--- a/MemoizR/MemoFactory.cs
+++ b/MemoizR/MemoFactory.cs
@@ -161,7 +161,7 @@ public sealed class MemoFactory
     public Signal<T> CreateSignal<T>(string label, T value)
     {
         EnsureSendableIfStrict<T>();
-        return new(value, Context, Options.HasFlag(MemoFactoryOptions.ValidateWrittenValues))
+        return new(value, Context, ShouldValidateWrittenValues)
         {
             Label = label
         };
@@ -175,7 +175,7 @@ public sealed class MemoFactory
     public EagerRelativeSignal<T> CreateEagerRelativeSignal<T>(string label, T value)
     {
         EnsureSendableIfStrict<T>();
-        return new(value, Context, Options.HasFlag(MemoFactoryOptions.ValidateWrittenValues))
+        return new(value, Context, ShouldValidateWrittenValues)
         {
             Label = label
         };
@@ -191,7 +191,7 @@ public sealed class MemoFactory
     public ActorSignal<T> CreateActorSignal<T>(T value)
     {
         EnsureSendableIfStrict<T>();
-        return new(value, Context, Options.HasFlag(MemoFactoryOptions.ValidateWrittenValues));
+        return new(value, Context, ShouldValidateWrittenValues);
     }
 
     /// <summary>
@@ -209,6 +209,13 @@ public sealed class MemoFactory
     // Strict-mode boundary check (issue #36): every node type whose value crosses flows funnels
     // its creation through this. Internal so the structured-concurrency factory extensions (a
     // friend assembly) enforce the same contract for their nodes.
+    // ValidateWrittenValues rides ON TOP of the Sendable checks, so the migration escape hatch
+    // must switch both off: a factory that opted out via DisableSendableChecks would otherwise
+    // still throw on later writes -- an incomplete escape hatch (review finding on #147).
+    private bool ShouldValidateWrittenValues =>
+        Options.HasFlag(MemoFactoryOptions.ValidateWrittenValues)
+        && !Options.HasFlag(MemoFactoryOptions.DisableSendableChecks);
+
     internal void EnsureSendableIfStrict<T>()
     {
         // Strict is the DEFAULT (issue #145 part A4, the Swift 6 language-mode analog);

--- a/MemoizR/MemoFactoryOptions.cs
+++ b/MemoizR/MemoFactoryOptions.cs
@@ -9,9 +9,10 @@ public enum MemoFactoryOptions
     /// <summary>
     /// Validate at node creation that the value type handed to a signal/memo/concurrent node is
     /// Sendable (deeply immutable or thread-safe -- see <see cref="SendableChecker"/>), throwing
-    /// otherwise. The runtime analog of Swift's strict concurrency checking (issue #36): MemoizR
-    /// publishes value references tear-free across flows, but only a Sendable type makes the
-    /// object behind the reference safe to share. Off by default for compatibility.
+    /// otherwise. The runtime analog of Swift's strict concurrency checking (issue #36).
+    /// Since the Swift-6-parity step (issue #145 part A4) this is the DEFAULT -- the flag is
+    /// kept for source compatibility and as an explicit statement of intent; opt out with
+    /// <see cref="DisableSendableChecks"/> during migration.
     /// </summary>
     StrictSendableChecks = 1 << 0,
 
@@ -35,4 +36,11 @@ public enum MemoFactoryOptions
     /// <see cref="StrictSendableChecks"/>.
     /// </summary>
     ValidateWrittenValues = 1 << 2,
+
+    /// <summary>
+    /// Opt OUT of the (default) creation-time Sendable checks -- the migration escape hatch,
+    /// the analog of staying on Swift 5's language mode. Values of non-Sendable types are then
+    /// shared across flows unchecked, exactly as before the Swift-6-parity step.
+    /// </summary>
+    DisableSendableChecks = 1 << 3,
 }

--- a/MemoizR/MemoFactoryOptions.cs
+++ b/MemoizR/MemoFactoryOptions.cs
@@ -45,6 +45,9 @@ public enum MemoFactoryOptions
     /// shared across flows unchecked, exactly as before the Swift-6-parity step. Takes
     /// precedence over <see cref="StrictSendableChecks"/> and
     /// <see cref="ValidateWrittenValues"/>: opting out switches off ALL Sendable validation.
+    /// The analyzers honor a VISIBLE opt-out too: MZR001/MZR006 skip creations on a factory
+    /// constructed with this flag in sight (an inline receiver, or a local/field/property
+    /// initializer in the same file); factories the build cannot see behind stay checked.
     /// </summary>
     DisableSendableChecks = 1 << 3,
 }

--- a/MemoizR/MemoFactoryOptions.cs
+++ b/MemoizR/MemoFactoryOptions.cs
@@ -29,8 +29,9 @@ public enum MemoFactoryOptions
     DisableCausalityStamps = 1 << 1,
 
     /// <summary>
-    /// Additionally validate, on every signal write (and the creation value), that the WRITTEN
-    /// INSTANCE'S RUNTIME TYPE is Sendable -- closing the subclass-smuggling hole the
+    /// Additionally validate, on every SIGNAL write (and the creation value) -- memo outputs
+    /// are the computation's own doing and publish unchecked -- that the WRITTEN INSTANCE'S
+    /// RUNTIME TYPE is Sendable -- closing the subclass-smuggling hole the
     /// creation-time check cannot see (a mutable subclass behind an upcast; see MZR006 and ADR
     /// 0003). Costs one cached type probe per Set, so it is a separate opt-in on top of
     /// <see cref="StrictSendableChecks"/>. Ignored when <see cref="DisableSendableChecks"/>

--- a/MemoizR/MemoFactoryOptions.cs
+++ b/MemoizR/MemoFactoryOptions.cs
@@ -26,4 +26,13 @@ public enum MemoFactoryOptions
     /// different stamp setting throws.
     /// </summary>
     DisableCausalityStamps = 1 << 1,
+
+    /// <summary>
+    /// Additionally validate, on every signal write (and the creation value), that the WRITTEN
+    /// INSTANCE'S RUNTIME TYPE is Sendable -- closing the subclass-smuggling hole the
+    /// creation-time check cannot see (a mutable subclass behind an upcast; see MZR006 and ADR
+    /// 0003). Costs one cached type probe per Set, so it is a separate opt-in on top of
+    /// <see cref="StrictSendableChecks"/>.
+    /// </summary>
+    ValidateWrittenValues = 1 << 2,
 }

--- a/MemoizR/MemoFactoryOptions.cs
+++ b/MemoizR/MemoFactoryOptions.cs
@@ -33,14 +33,17 @@ public enum MemoFactoryOptions
     /// INSTANCE'S RUNTIME TYPE is Sendable -- closing the subclass-smuggling hole the
     /// creation-time check cannot see (a mutable subclass behind an upcast; see MZR006 and ADR
     /// 0003). Costs one cached type probe per Set, so it is a separate opt-in on top of
-    /// <see cref="StrictSendableChecks"/>.
+    /// <see cref="StrictSendableChecks"/>. Ignored when <see cref="DisableSendableChecks"/>
+    /// is set: the migration escape hatch switches off ALL Sendable validation.
     /// </summary>
     ValidateWrittenValues = 1 << 2,
 
     /// <summary>
     /// Opt OUT of the (default) creation-time Sendable checks -- the migration escape hatch,
     /// the analog of staying on Swift 5's language mode. Values of non-Sendable types are then
-    /// shared across flows unchecked, exactly as before the Swift-6-parity step.
+    /// shared across flows unchecked, exactly as before the Swift-6-parity step. Takes
+    /// precedence over <see cref="StrictSendableChecks"/> and
+    /// <see cref="ValidateWrittenValues"/>: opting out switches off ALL Sendable validation.
     /// </summary>
     DisableSendableChecks = 1 << 3,
 }

--- a/MemoizR/MemoFactoryOptions.cs
+++ b/MemoizR/MemoFactoryOptions.cs
@@ -46,8 +46,9 @@ public enum MemoFactoryOptions
     /// precedence over <see cref="StrictSendableChecks"/> and
     /// <see cref="ValidateWrittenValues"/>: opting out switches off ALL Sendable validation.
     /// The analyzers honor a VISIBLE opt-out too: MZR001/MZR006 skip creations on a factory
-    /// constructed with this flag in sight (an inline receiver, or a local/field/property
-    /// initializer in the same file); factories the build cannot see behind stay checked.
+    /// constructed with this flag in a compile-time-constant options argument in sight (an
+    /// inline receiver, or the same-file initializer of a local/readonly field/get-only
+    /// property that is never reassigned); factories the build cannot see behind stay checked.
     /// </summary>
     DisableSendableChecks = 1 << 3,
 }

--- a/MemoizR/MemoizR.cs
+++ b/MemoizR/MemoizR.cs
@@ -1,5 +1,6 @@
 namespace MemoizR;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class MemoizR<T> : MemoBase<T>
 {
     private readonly Func<CancellationTokenSource, Task<T>> fn;

--- a/MemoizR/SendableChecker.cs
+++ b/MemoizR/SendableChecker.cs
@@ -215,11 +215,12 @@ public static class SendableChecker
         // Box<List<T>> member), which the re-entry check above can never catch. Its signature
         // is a NON-SHRINKING re-occurrence of the same definition: finite hand-written nesting
         // (Box<Box<Box<List<int>>>>) strictly shrinks at every recursive step and is walked to
-        // the bottom however deep it goes, while a divergent expansion re-enters its own
-        // definition at the same size or larger and is cut on the second occurrence (landing
-        // on the cycle assumption above).
+        // the bottom however deep it goes. A divergent expansion is walked through its FIRST
+        // re-instantiation -- substituted members can flip the verdict exactly one level down
+        // (Box<T> { Box<List<T>> Next; T Value; } hides the List in the second level's Value)
+        // -- and cut at the second, landing on the cycle assumption above.
         if (DefinitionOf(type) is { } definition
-            && inProgress.Any(entry => entry != type && DefinitionOf(entry) == definition && TypeSize(entry) <= TypeSize(type)))
+            && inProgress.Count(entry => entry != type && DefinitionOf(entry) == definition && TypeSize(entry) <= TypeSize(type)) >= 2)
         {
             inProgress.Remove(type);
             return null;

--- a/MemoizR/SendableChecker.cs
+++ b/MemoizR/SendableChecker.cs
@@ -211,6 +211,18 @@ public static class SendableChecker
             return null;
         }
 
+        // POLYMORPHIC recursion constructs a FRESH closed type per level (Box<T> exposing a
+        // Box<List<T>> member), which the re-entry check above can never catch: the same
+        // DEFINITION re-entering the path more than a handful of times is treated as the same
+        // cycle -- deeper re-instantiations substitute the same declared members, and realistic
+        // nesting of one generic within itself stays far below the bound.
+        if (DefinitionOf(type) is { } definition
+            && inProgress.Count(entry => DefinitionOf(entry) == definition) > 4)
+        {
+            inProgress.Remove(type);
+            return null;
+        }
+
         try
         {
             for (var t = type; t != null && t != typeof(object) && t != typeof(ValueType); t = t.BaseType)
@@ -228,6 +240,11 @@ public static class SendableChecker
         {
             inProgress.Remove(type);
         }
+    }
+
+    private static Type? DefinitionOf(Type type)
+    {
+        return type.IsGenericType ? type.GetGenericTypeDefinition() : null;
     }
 
     private static string? CheckDeclaredMembers(Type type, Type declaringLevel, HashSet<Type> inProgress)

--- a/MemoizR/SendableChecker.cs
+++ b/MemoizR/SendableChecker.cs
@@ -149,16 +149,16 @@ public static class SendableChecker
 
         // The runtime hands out internal implementations of green-listed types: typeof(int) is
         // a System.RuntimeType, an async method's Task is an AsyncStateMachineBox whose
-        // generic arguments carry the compiler-generated state machine, captured locals and
-        // all. The write-time check (ValidateWrittenValues) sees those instance types, so the
-        // green-list verdict extends to subtypes declared in the SAME ASSEMBLY as their entry
-        // -- trusted wholesale like the entry itself, type arguments included: they are
-        // runtime plumbing, not the declared surface (the DECLARED type's arguments were
-        // already vetted by the creation-time check). A USER subclass lives in a user assembly
-        // and still walks structurally: exactly the smuggle surface the write check exists to
-        // catch. (No analyzer mirror: declared types can never name these internals, so the
-        // lockstep contract is untouched.)
-        if (KnownSendable.Any(entry => !entry.IsValueType && entry.IsAssignableFrom(type) && type.Assembly == entry.Assembly))
+        // generic arguments carry the compiler-generated state machine, and ToFrozenSet picks
+        // a specialized FrozenSet subtype. The write-time check (ValidateWrittenValues) sees
+        // those instance types, so the green-list verdict extends to subtypes declared in the
+        // SAME ASSEMBLY as their entry -- trusted wholesale like the entry itself, type
+        // arguments included: they are runtime plumbing, not the declared surface (the
+        // DECLARED type's arguments were already vetted by the creation-time check). A USER
+        // subclass lives in a user assembly and still walks structurally: exactly the smuggle
+        // surface the write check exists to catch. (No analyzer mirror: declared types can
+        // never name these internals, so the lockstep contract is untouched.)
+        if (IsFrameworkImplementationOfAGreenListedType(type))
         {
             return null;
         }
@@ -182,6 +182,26 @@ public static class SendableChecker
         }
 
         return CheckFields(type, inProgress);
+    }
+
+    private static bool IsFrameworkImplementationOfAGreenListedType(Type type)
+    {
+        if (KnownSendable.Any(entry => !entry.IsValueType && entry.IsAssignableFrom(type) && type.Assembly == entry.Assembly))
+        {
+            return true;
+        }
+
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (baseType.IsGenericType
+                && KnownSendableGenericDefinitions.Contains(baseType.GetGenericTypeDefinition())
+                && type.Assembly == baseType.GetGenericTypeDefinition().Assembly)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Categories that can never be verified structurally, whatever their fields say.

--- a/MemoizR/SendableChecker.cs
+++ b/MemoizR/SendableChecker.cs
@@ -212,12 +212,14 @@ public static class SendableChecker
         }
 
         // POLYMORPHIC recursion constructs a FRESH closed type per level (Box<T> exposing a
-        // Box<List<T>> member), which the re-entry check above can never catch: the same
-        // DEFINITION re-entering the path more than a handful of times is treated as the same
-        // cycle -- deeper re-instantiations substitute the same declared members, and realistic
-        // nesting of one generic within itself stays far below the bound.
+        // Box<List<T>> member), which the re-entry check above can never catch. Its signature
+        // is a NON-SHRINKING re-occurrence of the same definition: finite hand-written nesting
+        // (Box<Box<Box<List<int>>>>) strictly shrinks at every recursive step and is walked to
+        // the bottom however deep it goes, while a divergent expansion re-enters its own
+        // definition at the same size or larger and is cut on the second occurrence (landing
+        // on the cycle assumption above).
         if (DefinitionOf(type) is { } definition
-            && inProgress.Count(entry => DefinitionOf(entry) == definition) > 4)
+            && inProgress.Any(entry => entry != type && DefinitionOf(entry) == definition && TypeSize(entry) <= TypeSize(type)))
         {
             inProgress.Remove(type);
             return null;
@@ -245,6 +247,18 @@ public static class SendableChecker
     private static Type? DefinitionOf(Type type)
     {
         return type.IsGenericType ? type.GetGenericTypeDefinition() : null;
+    }
+
+    // The number of type nodes in the constructed reference: Box<List<int>> is 3. Finite
+    // nesting shrinks this at every recursive step; polymorphic recursion grows it.
+    private static int TypeSize(Type type)
+    {
+        if (type.IsArray)
+        {
+            return 1 + TypeSize(type.GetElementType()!);
+        }
+
+        return type.IsGenericType ? 1 + type.GetGenericArguments().Sum(TypeSize) : 1;
     }
 
     private static string? CheckDeclaredMembers(Type type, Type declaringLevel, HashSet<Type> inProgress)

--- a/MemoizR/SendableChecker.cs
+++ b/MemoizR/SendableChecker.cs
@@ -147,6 +147,20 @@ public static class SendableChecker
             return CheckTypeArguments(type, inProgress);
         }
 
+        // The runtime hands out internal implementations of green-listed types: typeof(int) is
+        // a System.RuntimeType, a continuation is a ContinuationTaskFromTask. The write-time
+        // check (ValidateWrittenValues) sees those instance types, so the green-list verdict
+        // extends to subtypes declared in the SAME ASSEMBLY as their entry -- they are the
+        // implementation the entry vouches for, unnameable from user code. A USER subclass
+        // lives in a user assembly and still walks structurally: that is exactly the smuggle
+        // surface the write check exists to catch. (No analyzer mirror: declared types can
+        // never name these internals, so the lockstep contract is untouched.) Type arguments
+        // of a generic implementation are still checked, like the definitions above.
+        if (KnownSendable.Any(entry => !entry.IsValueType && entry.IsAssignableFrom(type) && type.Assembly == entry.Assembly))
+        {
+            return CheckTypeArguments(type, inProgress);
+        }
+
         // The trust escape hatch comes before the structural rejections so that an interface or
         // internally-synchronized class can be opted in.
         if (type.IsDefined(typeof(SendableAttribute), inherit: false))

--- a/MemoizR/SendableChecker.cs
+++ b/MemoizR/SendableChecker.cs
@@ -160,7 +160,13 @@ public static class SendableChecker
         // never name these internals, so the lockstep contract is untouched.)
         if (IsFrameworkImplementationOfAGreenListedType(type))
         {
-            return null;
+            // Trusted -- except that the green-listed GENERIC bases it implements are still
+            // its visible contract: CreateSignal<Task>(ComputeListAsync()) hands an internal
+            // subtype of Task<List<int>> through the non-generic Task surface, and skipping
+            // the base's arguments would re-open the upcast-smuggling hole ValidateWrittenValues
+            // exists to close. The implementation's OWN arguments (state machines, comparers)
+            // stay unchecked plumbing.
+            return CheckGreenListedBaseArguments(type, inProgress);
         }
 
         // The trust escape hatch comes before the structural rejections so that an interface or
@@ -182,6 +188,20 @@ public static class SendableChecker
         }
 
         return CheckFields(type, inProgress);
+    }
+
+    private static string? CheckGreenListedBaseArguments(Type type, HashSet<Type> inProgress)
+    {
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (baseType.IsGenericType && KnownSendableGenericDefinitions.Contains(baseType.GetGenericTypeDefinition())
+                && CheckTypeArguments(baseType, inProgress) is { } reason)
+            {
+                return reason;
+            }
+        }
+
+        return null;
     }
 
     private static bool IsFrameworkImplementationOfAGreenListedType(Type type)

--- a/MemoizR/SendableChecker.cs
+++ b/MemoizR/SendableChecker.cs
@@ -148,17 +148,19 @@ public static class SendableChecker
         }
 
         // The runtime hands out internal implementations of green-listed types: typeof(int) is
-        // a System.RuntimeType, a continuation is a ContinuationTaskFromTask. The write-time
-        // check (ValidateWrittenValues) sees those instance types, so the green-list verdict
-        // extends to subtypes declared in the SAME ASSEMBLY as their entry -- they are the
-        // implementation the entry vouches for, unnameable from user code. A USER subclass
-        // lives in a user assembly and still walks structurally: that is exactly the smuggle
-        // surface the write check exists to catch. (No analyzer mirror: declared types can
-        // never name these internals, so the lockstep contract is untouched.) Type arguments
-        // of a generic implementation are still checked, like the definitions above.
+        // a System.RuntimeType, an async method's Task is an AsyncStateMachineBox whose
+        // generic arguments carry the compiler-generated state machine, captured locals and
+        // all. The write-time check (ValidateWrittenValues) sees those instance types, so the
+        // green-list verdict extends to subtypes declared in the SAME ASSEMBLY as their entry
+        // -- trusted wholesale like the entry itself, type arguments included: they are
+        // runtime plumbing, not the declared surface (the DECLARED type's arguments were
+        // already vetted by the creation-time check). A USER subclass lives in a user assembly
+        // and still walks structurally: exactly the smuggle surface the write check exists to
+        // catch. (No analyzer mirror: declared types can never name these internals, so the
+        // lockstep contract is untouched.)
         if (KnownSendable.Any(entry => !entry.IsValueType && entry.IsAssignableFrom(type) && type.Assembly == entry.Assembly))
         {
-            return CheckTypeArguments(type, inProgress);
+            return null;
         }
 
         // The trust escape hatch comes before the structural rejections so that an interface or

--- a/MemoizR/Sending.cs
+++ b/MemoizR/Sending.cs
@@ -1,0 +1,55 @@
+namespace MemoizR;
+
+/// <summary>
+/// Transfer semantics for a non-Sendable value (the analog of Swift's <c>sending</c> parameters,
+/// SE-0430 / region-based isolation, SE-0414): the sender promises to stop touching the value,
+/// so ONE receiver on another flow may own it -- disjointness by handover instead of
+/// immutability. The wrapper is <see cref="SendableAttribute">[Sendable]</see>, so strict mode
+/// accepts a <c>Sending&lt;T&gt;</c> signal/memo value even when <typeparamref name="T"/> is not
+/// Sendable itself.
+///
+/// The runtime enforces SINGLE consumption (<see cref="Receive"/> throws on the second call and
+/// drops the reference after the first), and the MZR005 analyzer flags uses of the transferred
+/// variable after the transfer in the same method. Unlike Swift's compiler-checked regions this
+/// is a best-effort contract: a sender that keeps an alias through another path can still race
+/// -- the wrapper narrows the hole, it cannot close it (documented in ADR 0003).
+/// </summary>
+[Sendable]
+public sealed class Sending<T>
+{
+    private T? value;
+    private int received;
+
+    public Sending(T value)
+    {
+        this.value = value;
+    }
+
+    /// <summary>
+    /// Takes ownership of the transferred value. Callable exactly once: a second receive would
+    /// mean two owners, which is the aliasing this type exists to prevent. The stored reference
+    /// is dropped so the wrapper does not keep the transferred object alive.
+    /// </summary>
+    public T Receive()
+    {
+        if (Interlocked.Exchange(ref received, 1) != 0)
+        {
+            throw new InvalidOperationException(
+                "This Sending<T> was already received. A transferred value has exactly one owner: " +
+                "receive it once and pass the received value on, or transfer it again explicitly.");
+        }
+
+        var transferred = value!;
+        value = default;
+        return transferred;
+    }
+}
+
+/// <summary>Factory sugar so the type argument is inferred: <c>Sending.Transfer(list)</c>.</summary>
+public static class Sending
+{
+    public static Sending<T> Transfer<T>(T value)
+    {
+        return new(value);
+    }
+}

--- a/MemoizR/Signal.cs
+++ b/MemoizR/Signal.cs
@@ -1,5 +1,6 @@
 namespace MemoizR;
 
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class Signal<T> : MemoHandlR<T>, IStampedGetR<T?>
 {
     private Lock Lock { get; } = new();
@@ -9,8 +10,15 @@ public sealed class Signal<T> : MemoHandlR<T>, IStampedGetR<T?>
     // stamp's event tree just to recover the value this node itself bumped last.
     private long trigger;
 
-    internal Signal(T value, Context context) : base(context)
+    // Creation-time factory option (MemoFactoryOptions.ValidateWrittenValues): validate each
+    // written instance's RUNTIME type, closing the subclass-smuggling hole the declared-type
+    // check cannot see. Per-node because strictness is per-factory.
+    private readonly bool validateWrittenValues;
+
+    internal Signal(T value, Context context, bool validateWrittenValues = false) : base(context)
     {
+        this.validateWrittenValues = validateWrittenValues;
+        ValidateWrittenValue(value);
         if (context.StampsEnabled)
         {
             SetValueAndStamp(value, CausalityStamp.ForSignal(Id, 0, context.Epoch));
@@ -21,8 +29,18 @@ public sealed class Signal<T> : MemoHandlR<T>, IStampedGetR<T?>
         }
     }
 
+    private void ValidateWrittenValue(T value)
+    {
+        if (validateWrittenValues && value is not null)
+        {
+            SendableChecker.EnsureSendable(value.GetType());
+        }
+    }
+
     public async Task Set(T value)
     {
+        ValidateWrittenValue(value);
+
         // Resolve the scope once and keep it strongly rooted for the whole write: repeated getter
         // access can resolve different instances (weak registry + resurrection), which would hand
         // the body a ContextLock other than the one held here.

--- a/MemoizR/SynchronizationContextExecutor.cs
+++ b/MemoizR/SynchronizationContextExecutor.cs
@@ -11,6 +11,7 @@ namespace MemoizR;
 /// (the UI contexts do), best-effort false for contexts that post to foreign threads without
 /// setting Current -- a missed assertion there reports not-isolated, which is the safe direction.
 /// </remarks>
+[Sendable] // internally synchronized by design: safe to share across flows (and to hold in statics, see MZR004)
 public sealed class SynchronizationContextExecutor(SynchronizationContext synchronizationContext) : IExecutor
 {
     public void Enqueue(Action work)

--- a/docs/adr/0003-sendable-checking-and-isolation-assertions.md
+++ b/docs/adr/0003-sendable-checking-and-isolation-assertions.md
@@ -21,6 +21,13 @@
   hole where user types declared inside `System.Collections.*` bypassed the structural walk;
   this also correctly trusts the deliberately-abstract `FrozenDictionary`/`FrozenSet`, which the
   category rejection had been refusing.
+- Updated: 2026-07-02 (issue #145, part A) — MemoizR's nodes, factories and executors are
+  `[Sendable]` (internally synchronized by design), so holding them in statics is sanctioned;
+  `Sending<T>` adds transfer semantics for non-Sendable values (the SE-0430 analog: [Sendable]
+  wrapper, single-consumption `Receive()`, MZR005 flags sender-side use-after-transfer); and
+  `MemoFactoryOptions.ValidateWrittenValues` opt-in validates each written instance's RUNTIME
+  type on `Set`, closing the subclass-smuggling hole at the write for those who enable it
+  (MZR006 hints at it from the compile-time side).
 - Deciders: MemoizR maintainers
 - Issue: [#36 — Strengthen data-race safety guarantees](https://github.com/timonkrebs/MemoizR/issues/36)
 

--- a/docs/adr/0003-sendable-checking-and-isolation-assertions.md
+++ b/docs/adr/0003-sendable-checking-and-isolation-assertions.md
@@ -113,7 +113,11 @@ Design points:
 - **Per-factory, not per-context.** Strictness governs how *this* factory creates nodes; a
   strict and a lax factory may deliberately share one keyed context (e.g. migrating a codebase
   incrementally, exactly like Swift's per-module `-strict-concurrency` staging).
-- **Off by default.** Existing users see zero behavior change.
+- **On by default since the Swift-6-parity step** (issue #145 part A4 — the language-mode
+  analog): a guarantee is only a guarantee when it holds without opt-in.
+  `MemoFactoryOptions.DisableSendableChecks` is the migration escape hatch (the analog of
+  staying on Swift 5's language mode); `StrictSendableChecks` remains as an explicit statement
+  of intent.
 - Reactions are not enforcement points: they store no new value type — the values they read were
   validated where their source nodes were created.
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -166,8 +166,11 @@ type**. Flagged: non-readonly static fields, settable static properties, static 
 slots), and readonly/get-only statics whose TYPE is not Sendable (one shared mutable object
 graph). Not flagged: consts, Sendable readonly statics — and MemoizR's own nodes, factories and
 executors, which are `[Sendable]` by design, so the rule's own fix suggestion ("lift it into a
-Signal") passes the rule. The whole analyzer stays silent in compilations that do not reference
-the real MemoizR assembly.
+Signal") passes the rule. A static whose type is an unbound type parameter is flagged as
+unverifiable: MZR001's benefit of the doubt relies on the closed instantiation being checked at
+its own creation site, and a static has no such site — every closed `C<T>` mints a fresh
+process-wide slot no rule ever sees again. The whole analyzer stays silent in compilations that
+do not reference the real MemoizR assembly.
 
 ### MZR005 — use after transfer (the SE-0430 analog)
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -136,6 +136,37 @@ lock. (The cost is a false negative for a nested function invoked synchronously 
 computation; the runtime exception still guards that path. MZR002 keeps the full walk: a
 captured-state write is a data race whenever the callback runs, deferred or not.)
 
+### MZR004 — static state next to the graph (the SE-0412 analog proper)
+
+Swift 6 rejects every non-isolated mutable global, because a global is reachable from every
+isolation domain. The analog: in files that use MemoizR (a `using` directive for the MemoizR
+namespaces — the rule's mandate boundary), a static must be an **immutable slot of a Sendable
+type**. Flagged: non-readonly static fields, settable static properties, static events (mutable
+slots), and readonly/get-only statics whose TYPE is not Sendable (one shared mutable object
+graph). Not flagged: consts, Sendable readonly statics — and MemoizR's own nodes, factories and
+executors, which are `[Sendable]` by design, so the rule's own fix suggestion ("lift it into a
+Signal") passes the rule. The whole analyzer stays silent in compilations that do not reference
+the real MemoizR assembly.
+
+### MZR005 — use after transfer (the SE-0430 analog)
+
+`Sending<T>` hands a non-Sendable value across flows by TRANSFER: the wrapper is `[Sendable]`
+(strict mode accepts `Sending<List<int>>`), `Receive()` enforces single consumption at runtime,
+and MZR005 flags method-local uses of the transferred variable after the transfer, in source
+order, stopping at a reassignment. Deliberately a heuristic — Swift proves this with
+region-based isolation in the type system; source order approximates execution order, and
+aliases or loop back-edges can evade the rule. The receiver-side runtime check is the backstop.
+
+### MZR006 — subclass smuggling (Info)
+
+Sendable verdicts are computed from the DECLARED type, so a mutable subclass behind an upcast
+passes creation-time checks — ADR 0003's documented limitation, which Swift closes by requiring
+Sendable classes to be `final`. MZR006 hints (Info severity: non-sealed records are idiomatic,
+and the hole needs an actual mutable subclass to bite) at non-sealed, non-abstract class type
+arguments at creation sites; green-listed framework types (`Uri` is not sealed) are exempt. The
+runtime counterpart is `MemoFactoryOptions.ValidateWrittenValues`, which validates each written
+instance's runtime type on `Set`.
+
 ### Testing strategy
 
 The analyzer tests compile snippets in-memory **against the real MemoizR assemblies**

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -38,13 +38,18 @@ parallel — for free.
 (`MemoFactoryOptions.DisableSendableChecks`); with an Error default, a creation on such a
 factory must not fail the build on the very checks its runtime disabled, or migration would
 need a project-wide suppression on top of the documented option. Receiver resolution is
-best-effort and conservative in the safe direction (`FactoryOptOut`): the factory's
-construction must be *in sight* — an inline `new MemoFactory(options: …DisableSendableChecks)`
-receiver, or a local/field/property whose initializer in the *same file* is one (analyzers may
-not call `Compilation.GetSemanticModel`, which keeps cross-file initializers out of reach).
-Anything unresolvable — a factory parameter, a reassigned local, options computed elsewhere —
-keeps the checks on: a missed opt-out costs one suppression, a wrong opt-out would silently
-drop the rule. MZR006 honors the same opt-out (smuggling is a hole in checks that factory
+best-effort and conservative in the safe direction (`FactoryOptOut`), demanding *definite*
+evidence on three axes: the factory's construction must be in sight — an inline
+`new MemoFactory(options: …DisableSendableChecks)` receiver, or a local / readonly field /
+get-only property whose initializer in the *same file* is one (analyzers may not call
+`Compilation.GetSemanticModel`, which keeps cross-file initializers out of reach; settable
+slots could be repointed from anywhere) — the options argument must *fold to a constant*
+carrying the flag (a conditional `useLax ? DisableSendableChecks : None` still runs strict on
+one path), and any write to the receiver symbol elsewhere in the file revokes the
+initializer's authority (the local may have been repointed at a strict factory before the
+creation). Anything short of that — a factory parameter, options computed at runtime — keeps
+the checks on: a missed opt-out costs one suppression, a wrong opt-out would silently drop
+the rule. MZR006 honors the same opt-out (smuggling is a hole in checks that factory
 disabled); MZR002/003 do not, because they diagnose races and deterministic runtime throws
 that exist regardless of Sendable checking.
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -40,10 +40,13 @@ factory must not fail the build on the very checks its runtime disabled, or migr
 need a project-wide suppression on top of the documented option. Receiver resolution is
 best-effort and conservative in the safe direction (`FactoryOptOut`), demanding *definite*
 evidence on three axes: the factory's construction must be in sight — an inline
-`new MemoFactory(options: …DisableSendableChecks)` receiver, or a local / readonly field /
-get-only property whose initializer in the *same file* is one (analyzers may not call
-`Compilation.GetSemanticModel`, which keeps cross-file initializers out of reach; settable
-slots could be repointed from anywhere) — the options argument must *fold to a constant*
+`new MemoFactory(options: …DisableSendableChecks)` receiver (followed through the library's
+fluent configuration chain: `AddExecutor`/`AddTimeProvider` mutate and return the same
+factory), or a local / readonly field / get-only property whose initializer in the *same file*
+is one (analyzers may not call `Compilation.GetSemanticModel`, which keeps cross-file
+initializers out of reach; settable slots could be repointed from anywhere, and a member of a
+partial type split across files is not trusted either, since another file's constructor can
+overwrite the visible initializer) — the options argument must *fold to a constant*
 carrying the flag (a conditional `useLax ? DisableSendableChecks : None` still runs strict on
 one path), and any write to the receiver symbol elsewhere in the file revokes the
 initializer's authority (the local may have been repointed at a strict factory before the
@@ -166,11 +169,14 @@ type**. Flagged: non-readonly static fields, settable static properties, static 
 slots), and readonly/get-only statics whose TYPE is not Sendable (one shared mutable object
 graph). Not flagged: consts, Sendable readonly statics — and MemoizR's own nodes, factories and
 executors, which are `[Sendable]` by design, so the rule's own fix suggestion ("lift it into a
-Signal") passes the rule. A static whose type is an unbound type parameter is flagged as
-unverifiable: MZR001's benefit of the doubt relies on the closed instantiation being checked at
-its own creation site, and a static has no such site — every closed `C<T>` mints a fresh
-process-wide slot no rule ever sees again. The whole analyzer stays silent in compilations that
-do not reference the real MemoizR assembly.
+Signal") passes the rule. A static whose type contains an unbound type parameter — `T` itself,
+or nested as in `ImmutableArray<T>` — is flagged as unverifiable: MZR001's benefit of the doubt
+relies on the closed instantiation being checked at its own creation site, and a static has no
+such site — every closed `C<T>` mints a fresh process-wide slot no rule ever sees again.
+`[Sendable]`-trusted types shield their arguments (a `Signal<T>` static is internally
+synchronized for any `T`, and the closed `T` is checked at the `CreateSignal` call that built
+the instance). The whole analyzer stays silent in compilations that do not reference the real
+MemoizR assembly.
 
 ### MZR005 — use after transfer (the SE-0430 analog)
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -167,7 +167,10 @@ Sendable classes to be `final`. MZR006 hints (Info severity: non-sealed records 
 and the hole needs an actual mutable subclass to bite) at non-sealed, non-abstract class type
 arguments at creation sites; green-listed framework types (`Uri` is not sealed) are exempt. The
 runtime counterpart is `MemoFactoryOptions.ValidateWrittenValues`, which validates each written
-instance's runtime type on `Set`.
+instance's runtime type on `Set` — SIGNAL writes only (memo outputs are the computation's own
+doing and publish unchecked), which is why the MZR006 hint only suggests the option at signal
+creation sites. The nested type arguments of Sendable containers (`ImmutableArray<OpenBase>`)
+are unfolded: the container passes the green-lists, the element type is the smuggle surface.
 
 ### Testing strategy
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -34,6 +34,20 @@ classified by a symbol-based port of `SendableChecker`. Checking the method's `T
 uniformly covers `ConcurrentRace`'s resolver result `R` — handed to every racing child in
 parallel — for free.
 
+**The escape hatch is honored at build time too.** The runtime accepts a per-factory opt-out
+(`MemoFactoryOptions.DisableSendableChecks`); with an Error default, a creation on such a
+factory must not fail the build on the very checks its runtime disabled, or migration would
+need a project-wide suppression on top of the documented option. Receiver resolution is
+best-effort and conservative in the safe direction (`FactoryOptOut`): the factory's
+construction must be *in sight* — an inline `new MemoFactory(options: …DisableSendableChecks)`
+receiver, or a local/field/property whose initializer in the *same file* is one (analyzers may
+not call `Compilation.GetSemanticModel`, which keeps cross-file initializers out of reach).
+Anything unresolvable — a factory parameter, a reassigned local, options computed elsewhere —
+keeps the checks on: a missed opt-out costs one suppression, a wrong opt-out would silently
+drop the rule. MZR006 honors the same opt-out (smuggling is a hole in checks that factory
+disabled); MZR002/003 do not, because they diagnose races and deterministic runtime throws
+that exist regardless of Sendable checking.
+
 **The lockstep contract.** `SendableSymbolClassifier` (symbols) and `SendableChecker`
 (reflection) implement the same classification and must be edited together; a type one accepts
 and the other throws on erodes trust in both. Two deliberate divergences exist, both forced by
@@ -170,7 +184,11 @@ runtime counterpart is `MemoFactoryOptions.ValidateWrittenValues`, which validat
 instance's runtime type on `Set` — SIGNAL writes only (memo outputs are the computation's own
 doing and publish unchecked), which is why the MZR006 hint only suggests the option at signal
 creation sites. The nested type arguments of Sendable containers (`ImmutableArray<OpenBase>`)
-are unfolded: the container passes the green-lists, the element type is the smuggle surface.
+are unfolded: the container passes the green-lists, the element type is the smuggle surface —
+and since `ValidateWrittenValues` sees only the written instance's OWN runtime type, the hint
+for a nested surface says the runtime guard cannot reach it instead of suggesting the option.
+Creations on a factory that visibly opts out (`DisableSendableChecks`, see MZR001) get no hint
+at all: smuggling is a hole in checks that factory disabled.
 
 ### Testing strategy
 
@@ -224,5 +242,7 @@ Costs / accepted limitations:
 - **Flagging reads of captured mutable state** (full SE-0412 strictness). Rejected for v1: the
   false-positive rate on idiomatic code would push users to disable MZR002 wholesale, which is
   worse than the narrower write-only rule that survives contact with real codebases.
-- **Error severity by default.** Rejected: this layer is the Swift-5.x-style migration step;
-  projects opt into `error` per rule via `.editorconfig` when ready (the Swift 6 posture).
+- **Error severity by default.** Rejected at v1 as the Swift-5.x-style migration step, then
+  adopted for MZR001–003 by issue #145 part A4 alongside the runtime default-on switch (the
+  Swift 6 posture); `.editorconfig` downgrades and the `DisableSendableChecks` factory opt-out
+  (honored by the analyzers where the construction is visible) are the migration path.

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -169,9 +169,14 @@ isolation domain. The analog: in files that use MemoizR (a `using` directive for
 namespaces — the rule's mandate boundary), a static must be an **immutable slot of a Sendable
 type**. Flagged: non-readonly static fields, settable static properties, static events (mutable
 slots), and readonly/get-only statics whose TYPE is not Sendable (one shared mutable object
-graph). Not flagged: consts, Sendable readonly statics — and MemoizR's own nodes, factories and
-executors, which are `[Sendable]` by design, so the rule's own fix suggestion ("lift it into a
-Signal") passes the rule. A static whose type contains an unbound type parameter — `T` itself,
+graph). Not flagged: consts, computed static getters (an expression-bodied getter owns no slot
+— fresh values share nothing, and a getter handing out other static state is flagged at that
+state's own declaration), Sendable readonly statics — and MemoizR's own nodes, factories and
+executors, which are `[Sendable]` by design (and all sealed), so the rule's own fix suggestion
+("lift it into a Signal") passes the rule. A static slot that PASSES the rule but whose type
+contains a smuggle surface (`static readonly OpenBase Cache` can store a mutable subclass, with
+no creation site where MZR006 would hint and no runtime write validation ever seeing the slot)
+gets the MZR006 Info hint at the static, with the same noise calculus as creation sites. A static whose type contains an unbound type parameter — `T` itself,
 or nested as in `ImmutableArray<T>` — is flagged as unverifiable: MZR001's benefit of the doubt
 relies on the closed instantiation being checked at its own creation site, and a static has no
 such site — every closed `C<T>` mints a fresh process-wide slot no rule ever sees again.
@@ -214,10 +219,13 @@ and since `ValidateWrittenValues` sees only the written instance's OWN runtime t
 for a nested surface says the runtime guard cannot reach it instead of suggesting the option.
 Creations on a factory that visibly opts out (`DisableSendableChecks`, see MZR001) get no hint
 at all: smuggling is a hole in checks that factory disabled. `[Sendable]`-attributed types
-shield their type arguments from the walk — `Sending<T>` deliberately wraps a non-Sendable
-payload for transfer, so hinting about the payload would misread the escape hatch — and the
-walk has no depth cap (the declared type tree is finite; a cap would silently drop the hint
-exactly for the deep compositions MZR001 accepts).
+shield their type arguments and members from the walk — `Sending<T>` deliberately wraps a
+non-Sendable payload for transfer, so hinting about the payload would misread the escape hatch
+— and the walk has no depth cap (the type graph is finite and a visited set breaks
+self-referential cycles; a cap would silently drop the hint exactly for the deep compositions
+MZR001 accepts). Besides generic type arguments, the walk visits the MEMBER types of
+source-declared types: a sealed Sendable DTO (`sealed record Box(OpenBase Value)`) hides the
+same hole one member deep, where `ValidateWrittenValues` sees only the runtime type `Box`.
 
 ### Testing strategy
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -185,9 +185,15 @@ MemoizR assembly.
 `Sending<T>` hands a non-Sendable value across flows by TRANSFER: the wrapper is `[Sendable]`
 (strict mode accepts `Sending<List<int>>`), `Receive()` enforces single consumption at runtime,
 and MZR005 flags method-local uses of the transferred variable after the transfer, in source
-order, stopping at a reassignment. Deliberately a heuristic — Swift proves this with
-region-based isolation in the type system; source order approximates execution order, and
-aliases or loop back-edges can evade the rule. The receiver-side runtime check is the backstop.
+order, stopping at a reassignment. The scan is path-aware within its heuristic: uses in a
+mutually exclusive sibling arm of the transfer's construct are unreachable and not flagged,
+uses dominated by a conditional reinitialization (inside its arm, after it) are clean, `out`
+arguments reinitialize like assignments (after their sibling arguments — which are evaluated
+first — were checked for reads), reinitializations inside deferred callbacks don't count for
+the outer flow (mirroring transfers being scoped to their own callback body), and a `finally`
+arm counts as definite. Still deliberately a heuristic — Swift proves this with region-based
+isolation in the type system; source order approximates execution order, and aliases or loop
+back-edges can evade the rule. The receiver-side runtime check is the backstop.
 
 ### MZR006 — subclass smuggling (Info)
 
@@ -195,8 +201,11 @@ Sendable verdicts are computed from the DECLARED type, so a mutable subclass beh
 passes creation-time checks — ADR 0003's documented limitation, which Swift closes by requiring
 Sendable classes to be `final`. MZR006 hints (Info severity: non-sealed records are idiomatic,
 and the hole needs an actual mutable subclass to bite) at non-sealed, non-abstract class type
-arguments at creation sites; green-listed framework types (`Uri` is not sealed) are exempt. The
-runtime counterpart is `MemoFactoryOptions.ValidateWrittenValues`, which validates each written
+arguments at creation sites; green-listed framework types (`Uri` is not sealed) are exempt.
+Abstract classes and interfaces are normally MZR001's (Error) territory — except when a
+`[Sendable]` assertion lets them pass: the attribute is deliberately not inherited, so the
+assertion binds the declaring author and not every subclass or implementer, and MZR006 hints
+exactly there. The runtime counterpart is `MemoFactoryOptions.ValidateWrittenValues`, which validates each written
 instance's runtime type on `Set` — SIGNAL writes only (memo outputs are the computation's own
 doing and publish unchecked), which is why the MZR006 hint only suggests the option at signal
 creation sites. The nested type arguments of Sendable containers (`ImmutableArray<OpenBase>`)

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -41,9 +41,11 @@ need a project-wide suppression on top of the documented option. Receiver resolu
 best-effort and conservative in the safe direction (`FactoryOptOut`), demanding *definite*
 evidence on three axes: the factory's construction must be in sight — an inline
 `new MemoFactory(options: …DisableSendableChecks)` receiver (followed through the library's
-fluent configuration chain: `AddExecutor`/`AddTimeProvider` mutate and return the same
-factory), or a local / readonly field / get-only property whose initializer in the *same file*
-is one (analyzers may not call `Compilation.GetSemanticModel`, which keeps cross-file
+fluent configuration chain — the named whitelist `AddExecutor`/`AddSynchronizationContext`/
+`AddTimeProvider`/`AddWpfDispatcher` mutates and returns the same factory, applied to direct
+receivers and initializer values alike; generic passthroughs like `Untrack<T>` return their
+delegate's result and are not followed), or a local / readonly field / get-only property whose
+initializer in the *same file* is one (analyzers may not call `Compilation.GetSemanticModel`, which keeps cross-file
 initializers out of reach; settable slots could be repointed from anywhere, and a member of a
 partial type split across files is not trusted either, since another file's constructor can
 overwrite the visible initializer) — the options argument must *fold to a constant*
@@ -202,7 +204,11 @@ are unfolded: the container passes the green-lists, the element type is the smug
 and since `ValidateWrittenValues` sees only the written instance's OWN runtime type, the hint
 for a nested surface says the runtime guard cannot reach it instead of suggesting the option.
 Creations on a factory that visibly opts out (`DisableSendableChecks`, see MZR001) get no hint
-at all: smuggling is a hole in checks that factory disabled.
+at all: smuggling is a hole in checks that factory disabled. `[Sendable]`-attributed types
+shield their type arguments from the walk — `Sending<T>` deliberately wraps a non-Sendable
+payload for transfer, so hinting about the payload would misread the escape hatch — and the
+walk has no depth cap (the declared type tree is finite; a cap would silently drop the hint
+exactly for the deep compositions MZR001 accepts).
 
 ### Testing strategy
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -19,9 +19,11 @@ deliberately does and does not flag, and the constraints Roslyn imposes.
 
 A new `MemoizR.Analyzers` project (netstandard2.0, Roslyn 4.8 floor so any SDK ≥ 8 can load it)
 ships **inside the MemoizR NuGet package** (`analyzers/dotnet/cs`), so every consumer gets the
-rules on build with no extra reference. All rules default to **Warning** — the Swift 5.x
-"strict concurrency warnings" migration posture — and are configurable per project via
-`.editorconfig` (`dotnet_diagnostic.MZR001.severity = error|suggestion|none`).
+rules on build with no extra reference. Since the Swift-6-parity step (issue #145 part A4),
+MZR001–003 default to **Error** — the Swift 6 language-mode posture, matching the runtime
+checks being on by default — while the newer heuristic rules stay softer (MZR004/005 Warning,
+MZR006 Info). Everything is configurable per project via `.editorconfig`
+(`dotnet_diagnostic.MZR001.severity = warning|suggestion|none` is the migration posture).
 
 ### MZR001 — non-Sendable value type at a creation site
 


### PR DESCRIPTION
Implements part A of #145 (the closable gaps toward Swift 6 data-race-safety parity), in two commits — the second is the breaking default flip and can be dropped independently if it should wait for a dedicated major release.

## Commit 1 — A1–A3 (additive)

### A1 — MZR004, the SE-0412 analog proper
Swift 6 rejects every non-isolated mutable global. MZR004 flags statics in **MemoizR-using files** (the mandate boundary: a `using MemoizR…` directive; the analyzer is entirely silent in compilations that don't reference the real MemoizR assembly) that are:
- **mutable slots** — non-readonly fields, settable properties, events — even of Sendable types, or
- **readonly slots of non-Sendable type** (one shared mutable object graph).

To make the rule's own fix suggestion ("lift it into a Signal") pass the rule, MemoizR's nodes, factories and executors are now **`[Sendable]`** — they are internally synchronized by design, so `static readonly Signal<int>` / `static readonly MemoFactory` is the sanctioned pattern.

### A2 — `Sending<T>`, the SE-0430 analog
Transfer semantics for non-Sendable values: the `[Sendable]` wrapper is accepted by strict mode even when `T` is not Sendable itself, `Receive()` enforces **single consumption** at runtime (second call throws; the reference is dropped), and **MZR005** flags sender-side uses of the transferred variable after the transfer (method-local, source-ordered, stops at a reassignment). Documented as a best-effort heuristic — Swift proves this with region-based isolation in the type system, which an analyzer cannot reproduce.

### A3 — subclass smuggling, both halves
- **MZR006 (Info):** a non-sealed class type argument at a creation site can smuggle a mutable subclass past the declared-type checks (Swift requires Sendable classes to be `final`). Info severity because non-sealed records are idiomatic; green-listed framework types (`Uri` is not sealed) are exempt.
- **`MemoFactoryOptions.ValidateWrittenValues`:** opt-in runtime counterpart — validates each written instance's **runtime type** on `Set` (Signal, EagerRelativeSignal fn results, ActorSignal, and creation values), catching exactly what the declared-type check structurally cannot see.

## Commit 2 — A4 (BREAKING, separable)

The Swift 6 language-mode analog: a guarantee is only a guarantee when it holds without opt-in.
- Sendable creation checks are **on by default**; `MemoFactoryOptions.DisableSendableChecks` is the migration escape hatch, `StrictSendableChecks` remains as an explicit statement of intent.
- **MZR001–003 default to Error** (the newer heuristic rules stay softer: MZR004/005 Warning, MZR006 Info); downgradable per project via `.editorconfig` during migration.
- Known friction, found migrating this repo's own suite and documented in the changelog: memos composed over `ConcurrentMap` results are typed `IEnumerable<T>` — an interface, rejected by principle — so they need an immutable composition type or the per-factory opt-out.

## Out of scope (as recorded in #145)
A5 (actor-engine parity) waits on the prototype-graduation decision; A6 is the documented-blind-spots list; part B items are proposed as explicit non-goals documentation.

## Verification
311 core + 64 analyzer tests pass (new coverage for every rule and the runtime mode, including differential cases), cognitive-complexity gate clean, Coyote systematic tests pass. ADRs 0003/0004, the analyzer release notes and the changelog are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nomj8HYBn6xAoEXrQ6yKFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nomj8HYBn6xAoEXrQ6yKFW)_