### PR TITLE
MemoizR.Distributed v0, stamp opt-out flag, and the benchmarks harness

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,6 +68,7 @@ jobs:
         coyote rewrite MemoizR.dll
         coyote rewrite MemoizR.Reactive.dll
         coyote rewrite MemoizR.StructuredConcurrency.dll
+        coyote rewrite MemoizR.Distributed.dll
         coyote rewrite MemoizR.Tests.dll
     # Only the systematic concurrency test runs against the rewritten assemblies, where
     # Coyote can fully control scheduling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- `MemoFactoryOptions.DisableCausalityStamps`: opt a context out of causality-stamp tracking
+  entirely (issue #39). Signals stop bumping triggers, evaluations never open a capture, and
+  every node publishes the honest no-claim (unverifiable) evidence; values and glitch freedom
+  are unchanged, and the recompute paths measure below the pre-stamps baseline. The flag binds
+  to the context: factories sharing a keyed context must agree on it (a mismatch throws), and
+  a disabled context cannot be exported to peers.
+- `benchmarks/MemoizR.Benchmarks`: the micro-harness behind the overhead numbers (hot-path
+  ns/op and B/op for sets, clean reads and recomputes), runnable against any checkout via
+  `-p:MemoizRPath=` for before/after comparisons.
 - First data-race safety layer for the user boundary (issue #36, see ADR 0003): a `[Sendable]`
   attribute, structural verification via `SendableChecker`, and an opt-in
   `MemoFactoryOptions.StrictSendableChecks` factory mode that rejects, at node creation,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- `MemoizR.Distributed` (new package, issue #148): the bridge layer over the causality
+  stamps. `Export` pushes stale advertisements on value changes and answers pulls with the
+  untorn (value, evidence, sequence) triple of one publication (plus an optional heartbeat
+  for evidence-only transitions); `RemoteSignal<T>` adopts deliveries under a protocol that
+  makes reordered, at-least-once transports harmless — per-publication sequences totally
+  order deliveries (including the dependency-oscillation shapes stamps cannot order),
+  incarnation epochs detect host restarts (held evidence is discarded, never merged, and an
+  `OnPeerReset` hook resubscribes), and abandoned epochs drop late traffic from dead
+  incarnations; `DistributedBarrier` renders only consistent, verified snapshots and re-pulls
+  the lagging mirror itself. The sample migrated to the package.
+- Per-node publication sequence in the core value box: strictly increasing per publication,
+  carried by distributed payloads as the per-node total order that causality stamps
+  deliberately do not provide.
 - `MemoFactoryOptions.DisableCausalityStamps`: opt a context out of causality-stamp tracking
   entirely (issue #39). Signals stop bumping triggers, evaluations never open a capture, and
   every node publishes the honest no-claim (unverifiable) evidence; values and glitch freedom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   order deliveries (including the dependency-oscillation shapes stamps cannot order),
   incarnation epochs detect host restarts (held evidence is discarded, never merged, and an
   `OnPeerReset` hook resubscribes), and abandoned epochs drop late traffic from dead
-  incarnations; `DistributedBarrier` renders only consistent, verified snapshots and re-pulls
-  the lagging mirror itself. The sample migrated to the package.
+  incarnations; `DistributedBarrier` renders only consistent, verified snapshots, re-pulls
+  the lagging mirror itself, and renders a stamp-inconsistent pair that a full re-pull round
+  AFFIRMED (the core's documented conservative stamp under-claim is a spurious glitch, not a
+  lag). The sample migrated to the package.
 - Per-node publication sequence in the core value box: strictly increasing per publication,
   carried by distributed payloads as the per-node total order that causality stamps
   deliberately do not provide.

--- a/MemoizR.Distributed/DetachedFlow.cs
+++ b/MemoizR.Distributed/DetachedFlow.cs
@@ -1,0 +1,26 @@
+namespace MemoizR.Distributed;
+
+// Runs work on a fresh top-level flow, never inheriting the caller's ExecutionContext. The
+// callers are inside a reaction evaluation, and the context lock's holdership is AsyncLocal
+// state that would otherwise travel into the detached task: its lock acquisitions would be
+// refused as recursive inside the reaction's upgradeable scope -- or worse, granted as
+// same-scope recursion CONCURRENTLY with the still-running reaction, the corruption the
+// reaction machinery itself guards against with fresh scopes. A suppressed flow simply queues
+// behind the reaction's lock, like any transport-thread work.
+internal static class DetachedFlow
+{
+    internal static void Run(Func<Task> work)
+    {
+        if (ExecutionContext.IsFlowSuppressed())
+        {
+            Start();
+            return;
+        }
+        using (ExecutionContext.SuppressFlow())
+        {
+            Start();
+        }
+
+        void Start() => _ = Task.Run(work);
+    }
+}

--- a/MemoizR.Distributed/DistributedBarrier.cs
+++ b/MemoizR.Distributed/DistributedBarrier.cs
@@ -133,23 +133,12 @@ public static class DistributedBarrier
     private static void Schedule(Func<Task> repull, Action<Exception>? onRepullError)
     {
         // The re-pull is bridge work, not reaction work: the barrier evaluates while its flow
-        // holds the context lock in UPGRADEABLE mode, and that holdership travels with the
-        // ExecutionContext into Task.Run -- an inherited flow reaching Local.Set before the
-        // reaction unwinds would be refused as a recursive exclusive acquisition inside the
-        // upgradeable scope (a race the catch below would misreport as a transport fault,
-        // leaving the mirror stale). Suppressing the flow makes the re-pull a fresh top-level
-        // flow that simply queues behind the reaction's lock, like any transport delivery.
-        if (ExecutionContext.IsFlowSuppressed())
-        {
-            Start();
-            return;
-        }
-        using (ExecutionContext.SuppressFlow())
-        {
-            Start();
-        }
-
-        void Start() => _ = Task.Run(async () =>
+        // holds the context lock in UPGRADEABLE mode, and an inherited flow reaching Local.Set
+        // before the reaction unwinds would be refused as a recursive exclusive acquisition (a
+        // race the catch below would misreport as a transport fault, leaving the mirror
+        // stale). DetachedFlow gives it a fresh top-level flow that simply queues behind the
+        // reaction's lock, like any transport delivery.
+        DetachedFlow.Run(async () =>
         {
             try
             {

--- a/MemoizR.Distributed/DistributedBarrier.cs
+++ b/MemoizR.Distributed/DistributedBarrier.cs
@@ -194,16 +194,22 @@ public static class DistributedBarrier
             onRepullError?.Invoke(ex);
         }
 
+        // Content equality, not reference: a non-memoized export (a ConcurrentRace re-races on
+        // every pull) answers a re-pull with an EQUAL-content publication under a fresh
+        // sequence, and the mirror's adoption swaps the reference -- reference identity would
+        // refuse the affirmation every round and spin the heal loop forever. The publication
+        // record's value equality (value, epoch, stamp, verifiability) still counts every real
+        // change as a change.
         bool Unchanged() =>
-            ReferenceEquals(first.Publication, firstPublication)
-            && ReferenceEquals(second.Publication, secondPublication);
+            Equals(first.Publication, firstPublication)
+            && Equals(second.Publication, secondPublication);
     }
 
-    // The publication pair a full re-pull round affirmed, compared by REFERENCE: publications
-    // are immutable snapshots swapped only by adoptions, so reference identity means "no
-    // adoption happened on either mirror since the glitch was detected" -- any adoption
-    // naturally invalidates a stale affirmation. Volatile: written on the heal flow, read by
-    // the barrier reaction.
+    // The publication pair a full re-pull round affirmed, compared by CONTENT (the record's
+    // value equality): any adoption that actually changes value or evidence invalidates a
+    // stale affirmation, while an equal-content republication (a re-racing export) keeps the
+    // pair affirmed -- which is exactly what the round proved. Volatile: written on the heal
+    // flow, read by the barrier reaction.
     private sealed class AffirmationState<T1, T2>
     {
         private volatile Tuple<AdoptedPublication<T1>, AdoptedPublication<T2>>? pair;
@@ -215,8 +221,8 @@ public static class DistributedBarrier
         {
             var affirmed = pair;
             return affirmed != null
-                && ReferenceEquals(affirmed.Item1, first)
-                && ReferenceEquals(affirmed.Item2, second);
+                && Equals(affirmed.Item1, first)
+                && Equals(affirmed.Item2, second);
         }
     }
 }

--- a/MemoizR.Distributed/DistributedBarrier.cs
+++ b/MemoizR.Distributed/DistributedBarrier.cs
@@ -1,0 +1,103 @@
+using MemoizR.Reactive;
+
+namespace MemoizR.Distributed;
+
+/// <summary>
+/// The glitch barrier over mirrored inputs: renders only on a CONSISTENT, VERIFIED snapshot of
+/// the host's write history, and drives recovery itself -- when the two mirrors' evidence
+/// disagrees on a shared signal, the lagging side is re-pulled on the bridge's own flow (a
+/// reaction body must never Set its own graph's signals, so the re-pull is scheduled outside
+/// the evaluation) and the barrier re-runs when the adoption lands. v0 combines mirrors of the
+/// SAME host graph; barriers across different peers need the wire-v3 multi-peer epoch table.
+/// </summary>
+public static class DistributedBarrier
+{
+    /// <summary>
+    /// A reaction over two mirrors that calls <paramref name="render"/> exactly on consistent
+    /// verified snapshots. Keep the returned reaction (and the mirrors) strongly referenced.
+    /// Re-pull faults are reported to <paramref name="onRepullError"/> (the next advertisement
+    /// or heartbeat retries); rendering is skipped until evidence is verified again.
+    /// </summary>
+    public static Reaction CreateConsistentReaction<T1, T2>(
+        MemoFactory factory,
+        RemoteSignal<T1> first,
+        RemoteSignal<T2> second,
+        Action<T1, T2> render,
+        Action<Exception>? onRepullError = null,
+        Action<CausalityStamp, CausalityStamp>? onGlitch = null)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(render);
+
+        return factory.BuildReaction("distributed barrier").CreateReaction(
+            first.Local, second.Local, (firstValue, secondValue) =>
+            {
+                // Absent evidence (nothing synced yet) and unverifiable evidence mean the same
+                // thing to a consumer: CANNOT VERIFY -- no render, never a guess. The pull that
+                // heals an unverifiable spell is driven by advertisements/heartbeats, not here.
+                if (!first.HasEvidence || !second.HasEvidence || first.Unverifiable || second.Unverifiable)
+                {
+                    return;
+                }
+
+                var firstStamp = first.RemoteStamp;
+                var secondStamp = second.RemoteStamp;
+                if (!firstStamp.IsConsistentWith(secondStamp))
+                {
+                    // Diagnostics only -- the barrier heals itself below.
+                    onGlitch?.Invoke(firstStamp, secondStamp);
+                    RepullLagging(first, second, firstStamp, secondStamp, onRepullError);
+                    return;
+                }
+
+                render(firstValue, secondValue);
+            });
+    }
+
+    private static void RepullLagging<T1, T2>(
+        RemoteSignal<T1> first,
+        RemoteSignal<T2> second,
+        CausalityStamp firstStamp,
+        CausalityStamp secondStamp,
+        Action<Exception>? onRepullError)
+    {
+        // Dominance tells which side lags when the stamps are comparable. When NEITHER
+        // dominates -- both straddle a write, or the mirrors sit on different incarnations of a
+        // restarting host (cross-epoch stamps are incomparable by design) -- re-pull BOTH: a
+        // pull returns the host's current truth, so both sides converge on it and the barrier
+        // renders on the next consistent snapshot. Re-pulling only an arbitrary side would loop
+        // forever exactly in the restart case.
+        var firstLags = firstStamp.IsDominatedBy(secondStamp);
+        var secondLags = secondStamp.IsDominatedBy(firstStamp);
+        if (firstLags)
+        {
+            Schedule(() => first.PullAsync(), onRepullError);
+        }
+        else if (secondLags)
+        {
+            Schedule(() => second.PullAsync(), onRepullError);
+        }
+        else
+        {
+            Schedule(() => first.PullAsync(), onRepullError);
+            Schedule(() => second.PullAsync(), onRepullError);
+        }
+    }
+
+    private static void Schedule(Func<Task> repull, Action<Exception>? onRepullError)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await repull();
+            }
+            catch (Exception ex)
+            {
+                onRepullError?.Invoke(ex);
+            }
+        });
+    }
+}

--- a/MemoizR.Distributed/DistributedBarrier.cs
+++ b/MemoizR.Distributed/DistributedBarrier.cs
@@ -5,10 +5,11 @@ namespace MemoizR.Distributed;
 /// <summary>
 /// The glitch barrier over mirrored inputs: renders only on a CONSISTENT, VERIFIED snapshot of
 /// the host's write history, and drives recovery itself -- when the two mirrors' evidence
-/// disagrees on a shared signal, the lagging side is re-pulled on the bridge's own flow (a
-/// reaction body must never Set its own graph's signals, so the re-pull is scheduled outside
-/// the evaluation) and the barrier re-runs when the adoption lands. v0 combines mirrors of the
-/// SAME host graph; barriers across different peers need the wire-v3 multi-peer epoch table.
+/// disagrees on a shared signal (or the mirrors sit on different incarnations of the host),
+/// the lagging side is re-pulled on the bridge's own flow (a reaction body must never Set its
+/// own graph's signals, so the re-pull is scheduled outside the evaluation) and the barrier
+/// re-runs when the adoption lands. v0 combines mirrors of the SAME host graph; barriers
+/// across different peers need the wire-v3 multi-peer epoch table.
 /// </summary>
 public static class DistributedBarrier
 {
@@ -16,7 +17,9 @@ public static class DistributedBarrier
     /// A reaction over two mirrors that calls <paramref name="render"/> exactly on consistent
     /// verified snapshots. Keep the returned reaction (and the mirrors) strongly referenced.
     /// Re-pull faults are reported to <paramref name="onRepullError"/> (the next advertisement
-    /// or heartbeat retries); rendering is skipped until evidence is verified again.
+    /// or heartbeat retries), and so is a throwing <paramref name="onGlitch"/> callback --
+    /// diagnostics must never block the healing path; rendering is skipped until evidence is
+    /// verified again.
     /// </summary>
     public static Reaction CreateConsistentReaction<T1, T2>(
         MemoFactory factory,
@@ -32,45 +35,86 @@ public static class DistributedBarrier
         ArgumentNullException.ThrowIfNull(render);
 
         return factory.BuildReaction("distributed barrier").CreateReaction(
-            first.Local, second.Local, (firstValue, secondValue) =>
+            first.Local, second.Local, (_, _) =>
             {
+                // The graph parameters only TRIGGER the barrier. Rendering reads each mirror's
+                // atomic publication instead: the parameter values were captured when the
+                // propagation started, while an adoption landing mid-reaction swaps the side
+                // evidence -- pairing the two would render an (old value, new stamp) snapshot
+                // that never existed. Each publication binds value and evidence in one
+                // reference, so the consistency check below vouches for exactly the values it
+                // renders; a newer pair than the trigger saw is still a real published pair,
+                // and its own propagation re-runs the barrier anyway.
+                var firstPublication = first.Publication;
+                var secondPublication = second.Publication;
+
                 // Absent evidence (nothing synced yet) and unverifiable evidence mean the same
                 // thing to a consumer: CANNOT VERIFY -- no render, never a guess. The pull that
                 // heals an unverifiable spell is driven by advertisements/heartbeats, not here.
-                if (!first.HasEvidence || !second.HasEvidence || first.Unverifiable || second.Unverifiable)
+                if (firstPublication is null || secondPublication is null
+                    || firstPublication.Unverifiable || secondPublication.Unverifiable)
                 {
                     return;
                 }
 
-                var firstStamp = first.RemoteStamp;
-                var secondStamp = second.RemoteStamp;
-                if (!firstStamp.IsConsistentWith(secondStamp))
+                // Incarnation identity first: stamps from different epochs never agree, but an
+                // honestly-EMPTY stamp is epoch-agnostic and vacuously consistent with anything
+                // -- without the header-epoch check, a restarted host's first empty publication
+                // would render together with the other mirror's pre-restart state.
+                if (firstPublication.Epoch != secondPublication.Epoch
+                    || !firstPublication.Stamp.IsConsistentWith(secondPublication.Stamp))
                 {
-                    // Diagnostics only -- the barrier heals itself below.
-                    onGlitch?.Invoke(firstStamp, secondStamp);
-                    RepullLagging(first, second, firstStamp, secondStamp, onRepullError);
+                    ReportGlitch(firstPublication.Stamp, secondPublication.Stamp, onGlitch, onRepullError);
+                    RepullLagging(first, second, firstPublication, secondPublication, onRepullError);
                     return;
                 }
 
-                render(firstValue, secondValue);
+                render(firstPublication.Value, secondPublication.Value);
             });
+    }
+
+    private static void ReportGlitch(
+        CausalityStamp firstStamp,
+        CausalityStamp secondStamp,
+        Action<CausalityStamp, CausalityStamp>? onGlitch,
+        Action<Exception>? onRepullError)
+    {
+        // Diagnostics only -- the barrier heals itself either way. A throwing sink (a logger
+        // that is itself down) must not abort the reaction before the re-pull is scheduled, or
+        // the lagging mirror would stay stale with no new trigger to heal it.
+        try
+        {
+            onGlitch?.Invoke(firstStamp, secondStamp);
+        }
+        catch (Exception ex)
+        {
+            onRepullError?.Invoke(ex);
+        }
     }
 
     private static void RepullLagging<T1, T2>(
         RemoteSignal<T1> first,
         RemoteSignal<T2> second,
-        CausalityStamp firstStamp,
-        CausalityStamp secondStamp,
+        AdoptedPublication<T1> firstPublication,
+        AdoptedPublication<T2> secondPublication,
         Action<Exception>? onRepullError)
     {
-        // Dominance tells which side lags when the stamps are comparable. When NEITHER
-        // dominates -- both straddle a write, or the mirrors sit on different incarnations of a
-        // restarting host (cross-epoch stamps are incomparable by design) -- re-pull BOTH: a
-        // pull returns the host's current truth, so both sides converge on it and the barrier
-        // renders on the next consistent snapshot. Re-pulling only an arbitrary side would loop
-        // forever exactly in the restart case.
-        var firstLags = firstStamp.IsDominatedBy(secondStamp);
-        var secondLags = secondStamp.IsDominatedBy(firstStamp);
+        // Mirrors on different incarnations of a restarting host are incomparable by design
+        // (and dominance over an honestly-empty stamp would misread the empty side as lagging):
+        // re-pull BOTH -- a pull returns the host's current truth, so both sides converge on it
+        // and the barrier renders on the next consistent snapshot. Re-pulling only an arbitrary
+        // side would loop forever exactly in the restart case.
+        if (firstPublication.Epoch != secondPublication.Epoch)
+        {
+            Schedule(() => first.PullAsync(), onRepullError);
+            Schedule(() => second.PullAsync(), onRepullError);
+            return;
+        }
+
+        // Same incarnation: dominance tells which side lags when the stamps are comparable.
+        // When neither dominates (both straddle a write), re-pull both for the same reason.
+        var firstLags = firstPublication.Stamp.IsDominatedBy(secondPublication.Stamp);
+        var secondLags = secondPublication.Stamp.IsDominatedBy(firstPublication.Stamp);
         if (firstLags)
         {
             Schedule(() => first.PullAsync(), onRepullError);
@@ -88,7 +132,24 @@ public static class DistributedBarrier
 
     private static void Schedule(Func<Task> repull, Action<Exception>? onRepullError)
     {
-        _ = Task.Run(async () =>
+        // The re-pull is bridge work, not reaction work: the barrier evaluates while its flow
+        // holds the context lock in UPGRADEABLE mode, and that holdership travels with the
+        // ExecutionContext into Task.Run -- an inherited flow reaching Local.Set before the
+        // reaction unwinds would be refused as a recursive exclusive acquisition inside the
+        // upgradeable scope (a race the catch below would misreport as a transport fault,
+        // leaving the mirror stale). Suppressing the flow makes the re-pull a fresh top-level
+        // flow that simply queues behind the reaction's lock, like any transport delivery.
+        if (ExecutionContext.IsFlowSuppressed())
+        {
+            Start();
+            return;
+        }
+        using (ExecutionContext.SuppressFlow())
+        {
+            Start();
+        }
+
+        void Start() => _ = Task.Run(async () =>
         {
             try
             {

--- a/MemoizR.Distributed/DistributedBarrier.cs
+++ b/MemoizR.Distributed/DistributedBarrier.cs
@@ -55,12 +55,23 @@ public static class DistributedBarrier
                 // and its own propagation re-runs the barrier anyway.
                 var firstPublication = first.Publication;
                 var secondPublication = second.Publication;
+                if (firstPublication is null || secondPublication is null)
+                {
+                    return; // nothing synced yet: no pair observed, nothing to verify or expire
+                }
+
+                // An affirmation vouches only for the exact pair its heal round verified:
+                // observing ANY other pair expires it (single-shot). Today a pair provably
+                // cannot RETURN to an affirmed content anyway -- stamp triggers are monotone
+                // per signal within an epoch, and empty stamps never reach the inconsistent
+                // branch -- but the expiry keeps that safety local to the barrier instead of
+                // resting on a monotonicity invariant maintained elsewhere.
+                var affirmed = affirmation.MatchOrExpire(firstPublication, secondPublication);
 
                 // Absent evidence (nothing synced yet) and unverifiable evidence mean the same
                 // thing to a consumer: CANNOT VERIFY -- no render, never a guess. The pull that
                 // heals an unverifiable spell is driven by advertisements/heartbeats, not here.
-                if (firstPublication is null || secondPublication is null
-                    || firstPublication.Unverifiable || secondPublication.Unverifiable)
+                if (firstPublication.Unverifiable || secondPublication.Unverifiable)
                 {
                     return;
                 }
@@ -72,7 +83,7 @@ public static class DistributedBarrier
                 if (firstPublication.Epoch != secondPublication.Epoch
                     || !firstPublication.Stamp.IsConsistentWith(secondPublication.Stamp))
                 {
-                    if (affirmation.IsAffirmed(firstPublication, secondPublication))
+                    if (affirmed)
                     {
                         // Both hosts answered a full re-pull round with exactly these
                         // publications: the values are their affirmed current truths and the
@@ -206,10 +217,10 @@ public static class DistributedBarrier
     }
 
     // The publication pair a full re-pull round affirmed, compared by CONTENT (the record's
-    // value equality): any adoption that actually changes value or evidence invalidates a
-    // stale affirmation, while an equal-content republication (a re-racing export) keeps the
-    // pair affirmed -- which is exactly what the round proved. Volatile: written on the heal
-    // flow, read by the barrier reaction.
+    // value equality): an equal-content republication (a re-racing export) keeps the pair
+    // affirmed -- which is exactly what the round proved -- while observing any OTHER pair
+    // expires the affirmation, so its authority never outlives the heal round that earned it.
+    // Volatile: written on the heal flow, read by the barrier reaction.
     private sealed class AffirmationState<T1, T2>
     {
         private volatile Tuple<AdoptedPublication<T1>, AdoptedPublication<T2>>? pair;
@@ -217,12 +228,19 @@ public static class DistributedBarrier
         internal void Affirm(AdoptedPublication<T1> first, AdoptedPublication<T2> second) =>
             pair = Tuple.Create(first, second);
 
-        internal bool IsAffirmed(AdoptedPublication<T1> first, AdoptedPublication<T2> second)
+        internal bool MatchOrExpire(AdoptedPublication<T1> first, AdoptedPublication<T2> second)
         {
             var affirmed = pair;
-            return affirmed != null
-                && Equals(affirmed.Item1, first)
-                && Equals(affirmed.Item2, second);
+            if (affirmed == null)
+            {
+                return false;
+            }
+            if (Equals(affirmed.Item1, first) && Equals(affirmed.Item2, second))
+            {
+                return true;
+            }
+            pair = null;
+            return false;
         }
     }
 }

--- a/MemoizR.Distributed/DistributedBarrier.cs
+++ b/MemoizR.Distributed/DistributedBarrier.cs
@@ -8,18 +8,25 @@ namespace MemoizR.Distributed;
 /// disagrees on a shared signal (or the mirrors sit on different incarnations of the host),
 /// the lagging side is re-pulled on the bridge's own flow (a reaction body must never Set its
 /// own graph's signals, so the re-pull is scheduled outside the evaluation) and the barrier
-/// re-runs when the adoption lands. v0 combines mirrors of the SAME host graph; barriers
-/// across different peers need the wire-v3 multi-peer epoch table.
+/// re-runs when the adoption lands. A re-pull round that changes NOTHING -- both hosts answer
+/// with exactly the publications the glitch was detected on -- is both hosts AFFIRMING their
+/// current truth: the disagreement is then the core's documented conservative stamp
+/// under-claim (a scan-skipped recompute keeps an older stamp for a still-valid value), not a
+/// lag, and the affirmed pair renders instead of blocking forever. v0 combines mirrors of the
+/// SAME host graph; barriers across different peers need the wire-v3 multi-peer epoch table.
 /// </summary>
 public static class DistributedBarrier
 {
     /// <summary>
     /// A reaction over two mirrors that calls <paramref name="render"/> exactly on consistent
-    /// verified snapshots. Keep the returned reaction (and the mirrors) strongly referenced.
-    /// Re-pull faults are reported to <paramref name="onRepullError"/> (the next advertisement
-    /// or heartbeat retries), and so is a throwing <paramref name="onGlitch"/> callback --
-    /// diagnostics must never block the healing path; rendering is skipped until evidence is
-    /// verified again.
+    /// verified snapshots -- or on a stamp-inconsistent pair that a full re-pull round
+    /// AFFIRMED (each side was verified clean by its own pull answering with the identical
+    /// publication, so the values form a real snapshot and only the conservative stamp
+    /// under-claim disagrees). Keep the returned reaction (and the mirrors) strongly
+    /// referenced. Re-pull faults are reported to <paramref name="onRepullError"/> (the next
+    /// advertisement or heartbeat retries), and so is a throwing <paramref name="onGlitch"/>
+    /// callback -- diagnostics must never block the healing path; rendering is skipped until
+    /// evidence is verified again.
     /// </summary>
     public static Reaction CreateConsistentReaction<T1, T2>(
         MemoFactory factory,
@@ -34,6 +41,7 @@ public static class DistributedBarrier
         ArgumentNullException.ThrowIfNull(second);
         ArgumentNullException.ThrowIfNull(render);
 
+        var affirmation = new AffirmationState<T1, T2>();
         return factory.BuildReaction("distributed barrier").CreateReaction(
             first.Local, second.Local, (_, _) =>
             {
@@ -64,8 +72,18 @@ public static class DistributedBarrier
                 if (firstPublication.Epoch != secondPublication.Epoch
                     || !firstPublication.Stamp.IsConsistentWith(secondPublication.Stamp))
                 {
+                    if (affirmation.IsAffirmed(firstPublication, secondPublication))
+                    {
+                        // Both hosts answered a full re-pull round with exactly these
+                        // publications: the values are their affirmed current truths and the
+                        // stamp disagreement is the documented under-claim -- render, or the
+                        // barrier would stay blocked until an unrelated value change.
+                        render(firstPublication.Value, secondPublication.Value);
+                        return;
+                    }
+
                     ReportGlitch(firstPublication.Stamp, secondPublication.Stamp, onGlitch, onRepullError);
-                    RepullLagging(first, second, firstPublication, secondPublication, onRepullError);
+                    RepullLagging(first, second, firstPublication, secondPublication, affirmation, onRepullError);
                     return;
                 }
 
@@ -97,57 +115,108 @@ public static class DistributedBarrier
         RemoteSignal<T2> second,
         AdoptedPublication<T1> firstPublication,
         AdoptedPublication<T2> secondPublication,
+        AffirmationState<T1, T2> affirmation,
         Action<Exception>? onRepullError)
     {
         // Mirrors on different incarnations of a restarting host are incomparable by design
         // (and dominance over an honestly-empty stamp would misread the empty side as lagging):
         // re-pull BOTH -- a pull returns the host's current truth, so both sides converge on it
         // and the barrier renders on the next consistent snapshot. Re-pulling only an arbitrary
-        // side would loop forever exactly in the restart case.
-        if (firstPublication.Epoch != secondPublication.Epoch)
-        {
-            Schedule(() => first.PullAsync(), onRepullError);
-            Schedule(() => second.PullAsync(), onRepullError);
-            return;
-        }
+        // side would loop forever exactly in the restart case. Within one incarnation,
+        // dominance tells which side lags when the stamps are comparable; when neither
+        // dominates (both straddle a write), re-pull both for the same reason.
+        var crossEpoch = firstPublication.Epoch != secondPublication.Epoch;
+        var firstLags = !crossEpoch && firstPublication.Stamp.IsDominatedBy(secondPublication.Stamp);
+        var secondLags = !crossEpoch && secondPublication.Stamp.IsDominatedBy(firstPublication.Stamp);
+        var pullSecondOnly = !crossEpoch && secondLags && !firstLags;
+        var pullFirstOnly = !crossEpoch && firstLags && !secondLags;
 
-        // Same incarnation: dominance tells which side lags when the stamps are comparable.
-        // When neither dominates (both straddle a write), re-pull both for the same reason.
-        var firstLags = firstPublication.Stamp.IsDominatedBy(secondPublication.Stamp);
-        var secondLags = secondPublication.Stamp.IsDominatedBy(firstPublication.Stamp);
-        if (firstLags)
-        {
-            Schedule(() => first.PullAsync(), onRepullError);
-        }
-        else if (secondLags)
-        {
-            Schedule(() => second.PullAsync(), onRepullError);
-        }
-        else
-        {
-            Schedule(() => first.PullAsync(), onRepullError);
-            Schedule(() => second.PullAsync(), onRepullError);
-        }
-    }
-
-    private static void Schedule(Func<Task> repull, Action<Exception>? onRepullError)
-    {
         // The re-pull is bridge work, not reaction work: the barrier evaluates while its flow
         // holds the context lock in UPGRADEABLE mode, and an inherited flow reaching Local.Set
         // before the reaction unwinds would be refused as a recursive exclusive acquisition (a
-        // race the catch below would misreport as a transport fault, leaving the mirror
+        // race the heal's catch would misreport as a transport fault, leaving the mirror
         // stale). DetachedFlow gives it a fresh top-level flow that simply queues behind the
         // reaction's lock, like any transport delivery.
-        DetachedFlow.Run(async () =>
+        DetachedFlow.Run(() => HealAsync(
+            first, second, firstPublication, secondPublication,
+            pullFirst: !pullSecondOnly, pullSecond: !pullFirstOnly,
+            affirmation, onRepullError));
+    }
+
+    private static async Task HealAsync<T1, T2>(
+        RemoteSignal<T1> first,
+        RemoteSignal<T2> second,
+        AdoptedPublication<T1> firstPublication,
+        AdoptedPublication<T2> secondPublication,
+        bool pullFirst,
+        bool pullSecond,
+        AffirmationState<T1, T2> affirmation,
+        Action<Exception>? onRepullError)
+    {
+        try
         {
-            try
+            if (pullFirst)
             {
-                await repull();
+                await first.PullAsync();
             }
-            catch (Exception ex)
+            if (pullSecond)
             {
-                onRepullError?.Invoke(ex);
+                await second.PullAsync();
             }
-        });
+            if (!Unchanged())
+            {
+                return; // an adoption landed; its own propagation re-runs the barrier
+            }
+
+            // The dominance-picked side answered with the identical publication. A one-sided
+            // round only proves half the pair, so verify the other side by pull too before
+            // declaring the whole pair affirmed.
+            if (!pullFirst)
+            {
+                await first.PullAsync();
+            }
+            if (!pullSecond)
+            {
+                await second.PullAsync();
+            }
+            if (!Unchanged() || firstPublication.Epoch != secondPublication.Epoch)
+            {
+                return;
+            }
+
+            affirmation.Affirm(firstPublication, secondPublication);
+            // The affirmation is knowledge the graph does not carry: re-run the barrier
+            // through the ordinary propagation (an eager signal always re-propagates).
+            await first.RepublishLocalAsync();
+        }
+        catch (Exception ex)
+        {
+            onRepullError?.Invoke(ex);
+        }
+
+        bool Unchanged() =>
+            ReferenceEquals(first.Publication, firstPublication)
+            && ReferenceEquals(second.Publication, secondPublication);
+    }
+
+    // The publication pair a full re-pull round affirmed, compared by REFERENCE: publications
+    // are immutable snapshots swapped only by adoptions, so reference identity means "no
+    // adoption happened on either mirror since the glitch was detected" -- any adoption
+    // naturally invalidates a stale affirmation. Volatile: written on the heal flow, read by
+    // the barrier reaction.
+    private sealed class AffirmationState<T1, T2>
+    {
+        private volatile Tuple<AdoptedPublication<T1>, AdoptedPublication<T2>>? pair;
+
+        internal void Affirm(AdoptedPublication<T1> first, AdoptedPublication<T2> second) =>
+            pair = Tuple.Create(first, second);
+
+        internal bool IsAffirmed(AdoptedPublication<T1> first, AdoptedPublication<T2> second)
+        {
+            var affirmed = pair;
+            return affirmed != null
+                && ReferenceEquals(affirmed.Item1, first)
+                && ReferenceEquals(affirmed.Item2, second);
+        }
     }
 }

--- a/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
+++ b/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
@@ -50,6 +50,15 @@ public static class DistributedMemoFactoryExtensions
             throw new InvalidOperationException(
                 "This context was created with MemoFactoryOptions.DisableCausalityStamps; its nodes cannot be exported to peers.");
         }
+        if (MirrorLocals.IsMirrorLocal(handle))
+        {
+            // Re-exporting a mirror would advertise its LOCAL adoption stamps as evidence --
+            // the foreign evidence lives beside the graph in RemoteSignal.Publication, and two
+            // re-exported mirrors of one origin host carry disjoint local stamps, so a
+            // downstream barrier would render torn origin snapshots as consistent.
+            throw new InvalidOperationException(
+                "A remote mirror's local signal cannot be re-exported: its local stamps do not carry the origin's evidence. Multi-hop bridging needs the wire-v3 evidence splicing planned in issue #148.");
+        }
 
         var exported = new ExportedNode<T>(handle, publishStale);
         var reaction = wireReaction(factory.BuildReaction($"export {handle.Label}"), exported.NotifyStale);
@@ -76,7 +85,9 @@ public static class DistributedMemoFactoryExtensions
     {
         ArgumentNullException.ThrowIfNull(factory);
         ArgumentNullException.ThrowIfNull(pull);
-        return new RemoteSignal<T>(factory.CreateEagerRelativeSignal(label, initialValue), pull, nodeId)
+        var local = factory.CreateEagerRelativeSignal(label, initialValue);
+        MirrorLocals.Register(local); // re-exporting a mirror is refused (see ExportCore)
+        return new RemoteSignal<T>(local, pull, nodeId)
         {
             OnPeerReset = onPeerReset,
         };

--- a/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
+++ b/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
@@ -50,14 +50,15 @@ public static class DistributedMemoFactoryExtensions
             throw new InvalidOperationException(
                 "This context was created with MemoFactoryOptions.DisableCausalityStamps; its nodes cannot be exported to peers.");
         }
-        if (MirrorLocals.IsMirrorLocal(handle))
+        if (MirrorLocals.TouchesMirrorLocal(handle))
         {
-            // Re-exporting a mirror would advertise its LOCAL adoption stamps as evidence --
-            // the foreign evidence lives beside the graph in RemoteSignal.Publication, and two
-            // re-exported mirrors of one origin host carry disjoint local stamps, so a
-            // downstream barrier would render torn origin snapshots as consistent.
-            throw new InvalidOperationException(
-                "A remote mirror's local signal cannot be re-exported: its local stamps do not carry the origin's evidence. Multi-hop bridging needs the wire-v3 evidence splicing planned in issue #148.");
+            // Re-exporting a mirror -- or any node derived from one -- would advertise LOCAL
+            // adoption stamps as evidence; the origin's evidence lives beside the graph in
+            // RemoteSignal.Publication, so a downstream barrier would render torn origin
+            // snapshots as consistent. This is the fail-fast half: a lazy memo has no wired
+            // sources until its first evaluation, so ExportedNode.PullAsync re-checks at the
+            // wire egress.
+            throw new InvalidOperationException(MirrorLocals.ReExportMessage);
         }
 
         var exported = new ExportedNode<T>(handle, publishStale);

--- a/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
+++ b/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
@@ -1,0 +1,80 @@
+using MemoizR.Reactive;
+
+namespace MemoizR.Distributed;
+
+public static class DistributedMemoFactoryExtensions
+{
+    /// <summary>
+    /// Export a stamped node: whenever its value advances, <paramref name="publishStale"/>
+    /// receives the advertisement (write it to your transport); pulls are answered by
+    /// <see cref="ExportedNode{T}.PullAsync"/>. Keep the returned export (and dispose it to
+    /// stop exporting).
+    /// </summary>
+    public static ExportedNode<T> Export<T>(this MemoFactory factory, IStampedGetR<T> node, Func<StaleNotification, Task> publishStale)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        if (node is not MemoHandlR<T> handle)
+        {
+            throw new ArgumentException("Only MemoizR value nodes (signals, memos, concurrent nodes) can be exported.", nameof(node));
+        }
+        return ExportCore(factory, handle, publishStale, (builder, notify) => builder.CreateReaction(node, _ => notify()));
+    }
+
+    /// <summary>
+    /// Export a plain signal. (A separate overload because <see cref="Signal{T}"/> surfaces its
+    /// stamped interface as <c>IStampedGetR&lt;T?&gt;</c>; this keeps the export typed to the
+    /// signal's <typeparamref name="T"/>.)
+    /// </summary>
+    public static ExportedNode<T> Export<T>(this MemoFactory factory, Signal<T> signal, Func<StaleNotification, Task> publishStale)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        return ExportCore(factory, signal, publishStale, (builder, notify) => builder.CreateReaction(signal, _ => notify()));
+    }
+
+    private static ExportedNode<T> ExportCore<T>(
+        MemoFactory factory,
+        MemoHandlR<T> handle,
+        Func<StaleNotification, Task> publishStale,
+        Func<ReactionBuilder, Action, Reaction> wireReaction)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(publishStale);
+        if (!ReferenceEquals(handle.Context, factory.Context))
+        {
+            throw new ArgumentException("The exported node must belong to this factory's context.", nameof(handle));
+        }
+        if (!factory.Context.StampsEnabled)
+        {
+            // The one hard boundary of MemoFactoryOptions.DisableCausalityStamps: an export
+            // from a stamps-disabled context would advertise no ordering evidence at all.
+            throw new InvalidOperationException(
+                "This context was created with MemoFactoryOptions.DisableCausalityStamps; its nodes cannot be exported to peers.");
+        }
+
+        var exported = new ExportedNode<T>(handle, publishStale);
+        var reaction = wireReaction(factory.BuildReaction($"export {handle.Label}"), exported.NotifyStale);
+        exported.AttachReaction(reaction);
+        return exported;
+    }
+
+    /// <summary>
+    /// Create the consumer-side mirror of a remote exported node: a local eager signal fed by
+    /// the adoption protocol (see <see cref="RemoteSignal{T}"/>), pulling the host's truth via
+    /// <paramref name="pull"/> (your transport's request path). Feed transport deliveries to
+    /// <see cref="RemoteSignal{T}.OnStaleAsync"/> / <see cref="RemoteSignal{T}.OnValueAsync"/>.
+    /// </summary>
+    public static RemoteSignal<T> CreateRemoteSignal<T>(
+        this MemoFactory factory,
+        string label,
+        T initialValue,
+        Func<Task<ValuePayload<T>>> pull,
+        Func<Task>? onPeerReset = null)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(pull);
+        return new RemoteSignal<T>(factory.CreateEagerRelativeSignal(label, initialValue), pull)
+        {
+            OnPeerReset = onPeerReset,
+        };
+    }
+}

--- a/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
+++ b/MemoizR.Distributed/DistributedMemoFactoryExtensions.cs
@@ -62,17 +62,21 @@ public static class DistributedMemoFactoryExtensions
     /// the adoption protocol (see <see cref="RemoteSignal{T}"/>), pulling the host's truth via
     /// <paramref name="pull"/> (your transport's request path). Feed transport deliveries to
     /// <see cref="RemoteSignal{T}.OnStaleAsync"/> / <see cref="RemoteSignal{T}.OnValueAsync"/>.
+    /// Pass <paramref name="nodeId"/> (the exported node's id) on multiplexed bridges so a
+    /// misrouted payload is rejected up front; without it, the first delivered payload pins
+    /// the binding.
     /// </summary>
     public static RemoteSignal<T> CreateRemoteSignal<T>(
         this MemoFactory factory,
         string label,
         T initialValue,
         Func<Task<ValuePayload<T>>> pull,
-        Func<Task>? onPeerReset = null)
+        Func<Task>? onPeerReset = null,
+        int? nodeId = null)
     {
         ArgumentNullException.ThrowIfNull(factory);
         ArgumentNullException.ThrowIfNull(pull);
-        return new RemoteSignal<T>(factory.CreateEagerRelativeSignal(label, initialValue), pull)
+        return new RemoteSignal<T>(factory.CreateEagerRelativeSignal(label, initialValue), pull, nodeId)
         {
             OnPeerReset = onPeerReset,
         };

--- a/MemoizR.Distributed/ExportedNode.cs
+++ b/MemoizR.Distributed/ExportedNode.cs
@@ -48,7 +48,38 @@ public sealed class ExportedNode<T> : IDisposable
     {
         await node.ReadWithEvidence();
         var (value, evidence, sequence) = node.ValueEvidenceAndSequence;
+        if (evidence.Unverifiable)
+        {
+            // An unverifiable publication can be STICKY while the node is lazily clean:
+            // contagion from a since-healed source survives an equal-value parent scan (the
+            // scan proves the inputs did not change, not that the cached value was ever
+            // vouched for), so the node would answer every heartbeat-driven pull with the same
+            // no-claim publication and sequence -- which the consumer's mirror drops as a
+            // duplicate, leaving it unverifiable forever. A pull is the express request for
+            // the host's current best claim: force ONE fresh evaluation of the unverifiable
+            // chain through the ordinary invalidation entry (exactly what an upstream write
+            // would do) and answer with its outcome -- verified now, or honestly still
+            // unverifiable (a live torn spell; no retry loop, the next heartbeat tries again).
+            await RefreshUnverifiableChainAsync(node);
+            await node.ReadWithEvidence();
+            (value, evidence, sequence) = node.ValueEvidenceAndSequence;
+        }
         return new ValuePayload<T>(node.Id, node.Context.Epoch, sequence, value, evidence.Stamp.Serialize(), evidence.Unverifiable);
+    }
+
+    // Dirty every source whose current evidence is unverifiable (recursively, sources before
+    // consumers) so one Get re-evaluates the whole poisoned chain bottom-up: refreshing only
+    // this node would just re-consume the sticky no-claim evidence and republish it.
+    private static async Task RefreshUnverifiableChainAsync(SignalHandlR handle)
+    {
+        foreach (var source in handle.Sources)
+        {
+            if (source is SignalHandlR sourceHandle && sourceHandle.Evidence.Unverifiable)
+            {
+                await RefreshUnverifiableChainAsync(sourceHandle);
+            }
+        }
+        await handle.InvalidateAndPropagateAsync(CacheState.CacheDirty);
     }
 
     /// <summary>

--- a/MemoizR.Distributed/ExportedNode.cs
+++ b/MemoizR.Distributed/ExportedNode.cs
@@ -69,14 +69,33 @@ public sealed class ExportedNode<T> : IDisposable
 
     // Dirty every source whose current evidence is unverifiable (recursively, sources before
     // consumers) so one Get re-evaluates the whole poisoned chain bottom-up: refreshing only
-    // this node would just re-consume the sticky no-claim evidence and republish it.
+    // this node would just re-consume the sticky no-claim evidence and republish it. The whole
+    // chain is invalidated under one exclusive ContextLock acquisition -- the same discipline
+    // as MemoBase.Invalidate() and a parent-driven Stale, so no evaluation's commit window
+    // interleaves with a half-invalidated chain.
     private static async Task RefreshUnverifiableChainAsync(SignalHandlR handle)
+    {
+        var scope = handle.Context.ReactionScope;
+        try
+        {
+            using (await scope.ContextLock.ExclusiveLockAsync())
+            {
+                await InvalidateUnverifiableChainAsync(handle);
+            }
+        }
+        finally
+        {
+            GC.KeepAlive(scope);
+        }
+    }
+
+    private static async Task InvalidateUnverifiableChainAsync(SignalHandlR handle)
     {
         foreach (var source in handle.Sources)
         {
             if (source is SignalHandlR sourceHandle && sourceHandle.Evidence.Unverifiable)
             {
-                await RefreshUnverifiableChainAsync(sourceHandle);
+                await InvalidateUnverifiableChainAsync(sourceHandle);
             }
         }
         await handle.InvalidateAndPropagateAsync(CacheState.CacheDirty);

--- a/MemoizR.Distributed/ExportedNode.cs
+++ b/MemoizR.Distributed/ExportedNode.cs
@@ -60,7 +60,14 @@ public sealed class ExportedNode<T> : IDisposable
     {
         var (_, evidence, sequence) = node.ValueEvidenceAndSequence;
         var notification = new StaleNotification(node.Id, node.Context.Epoch, sequence, evidence.Stamp.Serialize());
-        _ = PublishSafelyAsync(notification);
+        // The notification is snapshotted above on the caller's flow (the same publication the
+        // export reaction observed); only the SEND is detached. Publishing is bridge work, not
+        // reaction work: the export reaction calls this while its flow holds the context lock
+        // in upgradeable mode, and an in-process bridge that synchronously feeds a same-context
+        // signal (an outbox, a local mirror) would inherit that scope and be refused as a
+        // recursive exclusive acquisition -- the advertisement silently lost to
+        // LastPublishError until the next value change or heartbeat.
+        DetachedFlow.Run(() => PublishSafelyAsync(notification));
     }
 
     private async Task PublishSafelyAsync(StaleNotification notification)

--- a/MemoizR.Distributed/ExportedNode.cs
+++ b/MemoizR.Distributed/ExportedNode.cs
@@ -93,7 +93,17 @@ public sealed class ExportedNode<T> : IDisposable
     {
         foreach (var source in handle.Sources)
         {
-            if (source is SignalHandlR sourceHandle && sourceHandle.Evidence.Unverifiable)
+            // Recurse into unverifiable sources AND non-clean ones: a dependency whose
+            // evaluation FAULTED keeps its previous verified evidence and parks at CacheCheck
+            // (the core's serve-last-good contract), so filtering on unverifiability alone
+            // would let the refreshed consumer clean-commit that stale cached value as
+            // VERIFIED -- and lose the unverifiability marker that makes pulls refresh at all.
+            // Forcing the parked part of the chain to genuinely re-evaluate answers honestly:
+            // still unverifiable while the fault persists, freshly verified once it healed.
+            // Signals never leave CacheClean and are never recursed; re-evaluating a merely
+            // scan-pending node is an equal-value commit that dirties nobody.
+            if (source is SignalHandlR sourceHandle
+                && (sourceHandle.Evidence.Unverifiable || sourceHandle.stateCell.State != CacheState.CacheClean))
             {
                 await InvalidateUnverifiableChainAsync(sourceHandle);
             }

--- a/MemoizR.Distributed/ExportedNode.cs
+++ b/MemoizR.Distributed/ExportedNode.cs
@@ -1,0 +1,102 @@
+using MemoizR.Reactive;
+
+namespace MemoizR.Distributed;
+
+/// <summary>
+/// The host side of one exported node: pushes a <see cref="StaleNotification"/> whenever the
+/// node's value advances (an export is just a reaction), answers pulls with the untorn
+/// (value, evidence, sequence) triple of one publication, and optionally re-advertises on a
+/// heartbeat -- the local invalidation cascade propagates only value CHANGES, so evidence-only
+/// transitions (a stamp refresh, an unverifiable spell healing) are discovered by consumers
+/// pulling after a heartbeat, by design. Dispose stops the export reaction and the heartbeat.
+/// </summary>
+public sealed class ExportedNode<T> : IDisposable
+{
+    private readonly MemoHandlR<T> node;
+    private readonly Func<StaleNotification, Task> publishStale;
+    private Reaction? exportReaction;
+    private ITimer? heartbeat;
+    private volatile Exception? lastPublishError;
+
+    /// <summary>The exported node's stable per-context id (what consumers key mirrors by).</summary>
+    public int NodeId => node.Id;
+
+    /// <summary>
+    /// The last error the stale-publishing callback threw, if any. Publishing is
+    /// fire-and-forget from the export reaction (a transport hiccup must not fault the graph),
+    /// so failures land here instead of being thrown; the next value change or heartbeat
+    /// re-advertises, which makes lost notifications self-healing on a live graph.
+    /// </summary>
+    public Exception? LastPublishError => lastPublishError;
+
+    internal ExportedNode(MemoHandlR<T> node, Func<StaleNotification, Task> publishStale)
+    {
+        this.node = node;
+        this.publishStale = publishStale;
+    }
+
+    internal void AttachReaction(Reaction reaction) => exportReaction = reaction;
+
+    /// <summary>
+    /// Answer a pull with the node's CURRENT truth: recompute if stale, then return the
+    /// (value, evidence, sequence) triple of one publication -- never torn. A concurrent
+    /// publication between the read and the box snapshot only makes the answer newer, which a
+    /// pull is always allowed to be. Faults propagate to the caller (the transport decides
+    /// retry policy); the consumer's mirror is left unchanged by a failed pull.
+    /// </summary>
+    public async Task<ValuePayload<T>> PullAsync()
+    {
+        await node.ReadWithEvidence();
+        var (value, evidence, sequence) = node.ValueEvidenceAndSequence;
+        return new ValuePayload<T>(node.Id, node.Context.Epoch, sequence, value, evidence.Stamp.Serialize(), evidence.Unverifiable);
+    }
+
+    /// <summary>
+    /// Advertise the node's current publication (id + ordering header + stamp, no value).
+    /// Called by the export reaction on every value change and by the heartbeat; also callable
+    /// directly, e.g. when a consumer (re)subscribes.
+    /// </summary>
+    public void NotifyStale()
+    {
+        var (_, evidence, sequence) = node.ValueEvidenceAndSequence;
+        var notification = new StaleNotification(node.Id, node.Context.Epoch, sequence, evidence.Stamp.Serialize());
+        _ = PublishSafelyAsync(notification);
+    }
+
+    private async Task PublishSafelyAsync(StaleNotification notification)
+    {
+        try
+        {
+            await publishStale(notification);
+        }
+        catch (Exception ex)
+        {
+            lastPublishError = ex;
+        }
+    }
+
+    /// <summary>
+    /// Re-advertise the current publication every <paramref name="period"/>: the liveness
+    /// mechanism for everything the value-change cascade deliberately does not push --
+    /// evidence-only transitions, and notifications lost by an unreliable transport.
+    /// </summary>
+    public void StartHeartbeat(TimeSpan period, TimeProvider? timeProvider = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(period, TimeSpan.Zero);
+        if (heartbeat != null)
+        {
+            throw new InvalidOperationException("The heartbeat is already running.");
+        }
+
+        var provider = timeProvider ?? TimeProvider.System;
+        heartbeat = provider.CreateTimer(_ => NotifyStale(), null, period, period);
+    }
+
+    public void Dispose()
+    {
+        heartbeat?.Dispose();
+        heartbeat = null;
+        exportReaction?.Dispose();
+        exportReaction = null;
+    }
+}

--- a/MemoizR.Distributed/ExportedNode.cs
+++ b/MemoizR.Distributed/ExportedNode.cs
@@ -47,6 +47,16 @@ public sealed class ExportedNode<T> : IDisposable
     public async Task<ValuePayload<T>> PullAsync()
     {
         await node.ReadWithEvidence();
+
+        // The export-time chain check can miss a LAZY memo whose sources only wire on first
+        // evaluation (and dynamic rewiring can splice a mirror in later): the pull is the
+        // wire egress, so it re-checks against the now-wired chain -- the read above just
+        // evaluated the node, so the wiring is current.
+        if (MirrorLocals.TouchesMirrorLocal(node))
+        {
+            throw new InvalidOperationException(MirrorLocals.ReExportMessage);
+        }
+
         var (value, evidence, sequence) = node.ValueEvidenceAndSequence;
         if (evidence.Unverifiable || node.stateCell.State != CacheState.CacheClean)
         {

--- a/MemoizR.Distributed/ExportedNode.cs
+++ b/MemoizR.Distributed/ExportedNode.cs
@@ -48,18 +48,31 @@ public sealed class ExportedNode<T> : IDisposable
     {
         await node.ReadWithEvidence();
         var (value, evidence, sequence) = node.ValueEvidenceAndSequence;
-        if (evidence.Unverifiable)
+        if (evidence.Unverifiable || node.stateCell.State != CacheState.CacheClean)
         {
-            // An unverifiable publication can be STICKY while the node is lazily clean:
-            // contagion from a since-healed source survives an equal-value parent scan (the
-            // scan proves the inputs did not change, not that the cached value was ever
-            // vouched for), so the node would answer every heartbeat-driven pull with the same
-            // no-claim publication and sequence -- which the consumer's mirror drops as a
-            // duplicate, leaving it unverifiable forever. A pull is the express request for
-            // the host's current best claim: force ONE fresh evaluation of the unverifiable
-            // chain through the ordinary invalidation entry (exactly what an upstream write
-            // would do) and answer with its outcome -- verified now, or honestly still
-            // unverifiable (a live torn spell; no retry loop, the next heartbeat tries again).
+            // Two shapes the plain read cannot answer honestly, both cured by ONE fresh
+            // evaluation of the suspect chain (through the ordinary invalidation entry --
+            // exactly what an upstream write would do):
+            //
+            //  - An UNVERIFIABLE publication can be sticky while the node is lazily clean:
+            //    contagion from a since-healed source survives an equal-value parent scan, so
+            //    every heartbeat-driven pull would answer the same no-claim publication and
+            //    sequence, which the mirror drops as a duplicate -- unverifiable forever.
+            //  - A FAULT-PARKED read: a dependency faulted during the parent scan, so the
+            //    read served the last good VERIFIED box and left the node non-clean. Shipping
+            //    that as the current truth would let a new mirror adopt stale state as
+            //    trusted while the host cannot actually compute a current value.
+            //
+            // The refreshed read answers with the chain's real current state: fresh and
+            // verified when it healed, honestly unverifiable for a live torn spell, or -- when
+            // the fault persists uncaught -- a FAULTED pull, which the wire contract already
+            // defines (the transport decides retry policy; the mirror is left unchanged).
+            //
+            // A chain an earlier read already resolved to clean-serving-last-good is not
+            // detectable here (the park launders on the second scan) -- but it degrades
+            // SAFELY: the payload's stamp claims the old triggers it genuinely reflects, so
+            // mirrors and the barrier converge on that honest older snapshot, and freshness
+            // returns with the next value-changing publication.
             await RefreshUnverifiableChainAsync(node);
             await node.ReadWithEvidence();
             (value, evidence, sequence) = node.ValueEvidenceAndSequence;

--- a/MemoizR.Distributed/MemoizR.Distributed.csproj
+++ b/MemoizR.Distributed/MemoizR.Distributed.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\MemoizR\MemoizR.csproj" />
+    <ProjectReference Include="..\MemoizR.Reactive\MemoizR.Reactive.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <PackageId>MemoizR.Distributed</PackageId>
+    <Version>0.0.1</Version>
+    <Authors>Timon Krebs</Authors>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageReadmeFile>NUGET_DISTRIBUTED_README.md</PackageReadmeFile>
+    <PackageIcon>MemoizR-Small.png</PackageIcon>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageTags>Signal, Signals, Reactive, Reactivity, Memoization, Graph, Dependency, Dependencies, Distributed, Distributed Systems, Replication, Synchronization, Causality, Causal Consistency, Interval Tree Clocks, Glitch Free, State, State Synchronization</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+        <None Include="..\docs\NUGET_DISTRIBUTED_README.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\MemoizR-Small.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/MemoizR.Distributed/Messages.cs
+++ b/MemoizR.Distributed/Messages.cs
@@ -1,0 +1,33 @@
+namespace MemoizR.Distributed;
+
+// The wire protocol is three messages: a host ADVERTISES that an exported node published
+// something new (stale), a consumer PULLS, the host answers with a VALUE payload. Values move
+// only on pull, so MemoizR's laziness survives the network. Both messages carry the same
+// ordering header:
+//
+//  - Epoch: the host context's incarnation (never 0 on the wire). Epochs are random
+//    identifiers, NOT ordered -- a mismatch means "a different incarnation", never "newer".
+//    Carried beside the stamp because an honestly-empty stamp is epoch-agnostic, and ordering
+//    must survive empty publications.
+//  - Sequence: the node's publication counter, strictly increasing per epoch. This is the
+//    total order over one node's publications -- including the shapes causality stamps
+//    deliberately cannot order (a dependency set oscillating through empty re-publishes an
+//    earlier stamp on a NEWER value).
+//  - Stamp: the publication's causality stamp in the frozen v2 wire format. Not used for
+//    ordering (the sequence does that); it is the CONSISTENCY evidence the glitch barrier
+//    checks across nodes.
+
+/// <summary>
+/// A host's advertisement that the exported node published: "I have (epoch, sequence); pull if
+/// you don't." Carries no value -- the consumer decides whether to move it.
+/// </summary>
+public sealed record StaleNotification(int NodeId, long Epoch, long Sequence, byte[] Stamp);
+
+/// <summary>
+/// A pull answer: one publication's value, ordering header, causality stamp and verifiability,
+/// all describing the SAME atomic publication of the exported node.
+/// <see cref="Unverifiable"/> means the host cannot vouch for which signal versions the value
+/// reflects (a mixed or faulted evaluation) -- a consumer must stop trusting held evidence but
+/// must not render this as a verified snapshot.
+/// </summary>
+public sealed record ValuePayload<T>(int NodeId, long Epoch, long Sequence, T Value, byte[] Stamp, bool Unverifiable);

--- a/MemoizR.Distributed/MirrorLocals.cs
+++ b/MemoizR.Distributed/MirrorLocals.cs
@@ -24,15 +24,16 @@ internal static class MirrorLocals
 
     // Whether the node is a mirror local or (transitively) depends on one: a memo built over a
     // mirror carries stamps captured from the consumer-local trigger, so re-exporting it is
-    // the same unsoundness one hop removed. Walks the CURRENT source wiring -- a lazy memo has
-    // none until its first evaluation, which is why the pull re-checks at the wire egress.
+    // the same unsoundness one hop removed. Walks the CURRENT wiring from BOTH ends -- a lazy
+    // memo has none until its first evaluation, which is why the pull re-checks at the wire
+    // egress.
     internal static bool TouchesMirrorLocal(SignalHandlR node)
     {
-        if (IsMirrorLocal(node))
-        {
-            return true;
-        }
+        return IsMirrorLocal(node) || SourcesTouchMirrorLocal(node) || ObservedByMirrorLocal(node);
+    }
 
+    private static bool SourcesTouchMirrorLocal(SignalHandlR node)
+    {
         var visited = new HashSet<SignalHandlR>();
         var pending = new Stack<SignalHandlR>();
         pending.Push(node);
@@ -43,6 +44,38 @@ internal static class MirrorLocals
                 if (source is SignalHandlR handle && visited.Add(handle))
                 {
                     if (IsMirrorLocal(handle))
+                    {
+                        return true;
+                    }
+                    pending.Push(handle);
+                }
+            }
+        }
+        return false;
+    }
+
+    // The observer-side half of the same walk: a ConcurrentRace consumes its inputs without
+    // ever populating its own Sources (its update publishes without rewiring source links; it
+    // registers on the input as an OBSERVER only), so the source walk cannot see through it.
+    // The observer down-links carry the missing direction -- walk DOWN from every live mirror
+    // local and refuse when the exported node is reachable. The registry stays small (one
+    // entry per live mirror) and observer fans are the consumer's own graph, so the sweep is
+    // cheap at export/pull frequency.
+    private static bool ObservedByMirrorLocal(SignalHandlR node)
+    {
+        var visited = new HashSet<SignalHandlR>();
+        var pending = new Stack<SignalHandlR>();
+        foreach (var (local, _) in Registry)
+        {
+            pending.Push(local);
+        }
+        while (pending.Count > 0)
+        {
+            foreach (var weak in pending.Pop().Observers)
+            {
+                if (weak.TryGetTarget(out var observer) && observer is SignalHandlR handle && visited.Add(handle))
+                {
+                    if (ReferenceEquals(handle, node))
                     {
                         return true;
                     }

--- a/MemoizR.Distributed/MirrorLocals.cs
+++ b/MemoizR.Distributed/MirrorLocals.cs
@@ -12,10 +12,44 @@ namespace MemoizR.Distributed;
 // distinction, because the mirror's local is deliberately an ordinary eager signal.
 internal static class MirrorLocals
 {
+    internal const string ReExportMessage =
+        "A remote mirror's local signal cannot be re-exported (nor can a node derived from one): its local stamps do not carry the origin's evidence. Multi-hop bridging needs the wire-v3 evidence splicing planned in issue #148.";
+
     private static readonly ConditionalWeakTable<SignalHandlR, object> Registry = new();
     private static readonly object Present = new();
 
     internal static void Register(SignalHandlR local) => Registry.AddOrUpdate(local, Present);
 
     internal static bool IsMirrorLocal(SignalHandlR node) => Registry.TryGetValue(node, out _);
+
+    // Whether the node is a mirror local or (transitively) depends on one: a memo built over a
+    // mirror carries stamps captured from the consumer-local trigger, so re-exporting it is
+    // the same unsoundness one hop removed. Walks the CURRENT source wiring -- a lazy memo has
+    // none until its first evaluation, which is why the pull re-checks at the wire egress.
+    internal static bool TouchesMirrorLocal(SignalHandlR node)
+    {
+        if (IsMirrorLocal(node))
+        {
+            return true;
+        }
+
+        var visited = new HashSet<SignalHandlR>();
+        var pending = new Stack<SignalHandlR>();
+        pending.Push(node);
+        while (pending.Count > 0)
+        {
+            foreach (var source in pending.Pop().Sources)
+            {
+                if (source is SignalHandlR handle && visited.Add(handle))
+                {
+                    if (IsMirrorLocal(handle))
+                    {
+                        return true;
+                    }
+                    pending.Push(handle);
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/MemoizR.Distributed/MirrorLocals.cs
+++ b/MemoizR.Distributed/MirrorLocals.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace MemoizR.Distributed;
+
+// The identity set of local signals that back remote mirrors. A mirror's local stamps are
+// PEER-LOCAL (its own context's ids and triggers); the foreign evidence travels beside the
+// graph in RemoteSignal.Publication until wire-format v3 splices it. Re-exporting such a
+// signal would advertise the local stamps as if they were evidence: two re-exported mirrors
+// of the same origin host carry disjoint local stamps, so a downstream barrier would find any
+// pair of them vacuously consistent and render torn origin snapshots. Export refuses them by
+// identity (a weak table, so mirrors stay collectible) -- the type system cannot express the
+// distinction, because the mirror's local is deliberately an ordinary eager signal.
+internal static class MirrorLocals
+{
+    private static readonly ConditionalWeakTable<SignalHandlR, object> Registry = new();
+    private static readonly object Present = new();
+
+    internal static void Register(SignalHandlR local) => Registry.AddOrUpdate(local, Present);
+
+    internal static bool IsMirrorLocal(SignalHandlR node) => Registry.TryGetValue(node, out _);
+}

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -83,6 +83,19 @@ public sealed class RemoteSignal<T>
     // again mid-resubscription). Closing the window answers it with one verification pull --
     // the refused delivery may have been that incarnation's only advertisement.
     private bool pendingEpochVerification;
+
+    private volatile Exception? lastBackgroundError;
+
+    /// <summary>
+    /// The last error a background recovery step threw -- the queued verification pull after
+    /// a resubscription window closed, including an <see cref="OnPeerReset"/> failure for a
+    /// reset that background pull committed. Background steps have no delivering caller to
+    /// surface to, so failures land here (like <c>ExportedNode.LastPublishError</c>); a bridge
+    /// that must react promptly to resubscription failures should observe its own hook.
+    /// Transport faults recorded here are self-healing -- the next advertisement or heartbeat
+    /// retries.
+    /// </summary>
+    public Exception? LastBackgroundError => lastBackgroundError;
     private volatile AdoptedPublication<T>? publication;
 
     private enum AdoptionVerdict { Drop, Adopt, AdoptReset, VerifyByPull }
@@ -286,11 +299,14 @@ public sealed class RemoteSignal<T>
                 {
                     await PullAsync();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Best-effort recovery of a refused single-shot advertisement; a faulted
-                    // transport here is retried by the next advertisement or heartbeat like
-                    // any other lost delivery.
+                    // Best-effort recovery of a refused single-shot advertisement, with no
+                    // delivering caller to surface to: record instead of swallowing -- this
+                    // can be an OnPeerReset failure for the reset this pull just committed,
+                    // which the bridge must be able to learn about. A plain transport fault
+                    // is retried by the next advertisement or heartbeat.
+                    lastBackgroundError = ex;
                 }
             });
         }

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -1,0 +1,153 @@
+namespace MemoizR.Distributed;
+
+/// <summary>
+/// The consumer side of one exported node: a local <see cref="EagerRelativeSignal{T}"/> (so the
+/// consumer's graph reacts through the ordinary machinery -- eager on purpose, because an
+/// adoption can change the EVIDENCE while the numeric value stays identical, and the barrier
+/// must re-run to observe it) plus the foreign evidence the current value arrived with, plus
+/// the adoption protocol that makes reordered, at-least-once transports harmless:
+///
+///  - late traffic from an incarnation this mirror already left is dropped (epochs are random
+///    identifiers, not ordered -- the mirror remembers what it abandoned instead of trusting a
+///    mismatch to mean "newer");
+///  - a different, non-abandoned epoch is a peer RESET: held evidence is discarded, never
+///    merged, and <see cref="OnPeerReset"/> runs so the bridge can resubscribe;
+///  - within an epoch, the publication SEQUENCE totally orders deliveries: anything at or
+///    below the last adopted sequence is a late or duplicated delivery and is dropped --
+///    including the dependency-oscillation shapes causality stamps cannot order, and equally
+///    while the mirror is unverifiable (a recovery is a NEW publication with a higher
+///    sequence, so it is never mistaken for old news);
+///  - an UNVERIFIABLE payload is adopted like any other (the consumer must stop trusting held
+///    evidence now), but the held stamp of the last verified adoption is kept for the barrier
+///    until a verified payload replaces it.
+///
+/// A future wire-format v3 (multi-peer epoch table) will let this evidence splice into LOCAL
+/// stamps; until then it travels beside the graph and the barrier checks it explicitly.
+/// </summary>
+public sealed class RemoteSignal<T>
+{
+    private readonly SemaphoreSlim adoptionGate = new(1, 1);
+    private readonly Func<Task<ValuePayload<T>>> pull;
+    private readonly HashSet<long> abandonedEpochs = [];
+    private long currentEpoch;
+    private long lastSequence;
+    private volatile CausalityStamp remoteStamp = CausalityStamp.Empty;
+    private volatile bool unverifiable;
+    private volatile bool hasEvidence;
+
+    /// <summary>
+    /// The local signal carrying the mirrored value: wire reactions and memos to this. Its own
+    /// causality stamp is LOCAL (peer B's incarnation); the foreign evidence lives in
+    /// <see cref="RemoteStamp"/> until wire-format v3 lets it splice.
+    /// </summary>
+    public EagerRelativeSignal<T> Local { get; }
+
+    /// <summary>The stamp of the last VERIFIED adopted publication (empty until one arrives).</summary>
+    public CausalityStamp RemoteStamp => remoteStamp;
+
+    /// <summary>Whether the host's current publication is one nobody can vouch for.</summary>
+    public bool Unverifiable => unverifiable;
+
+    /// <summary>Whether any payload was adopted at all (an honestly-empty stamp is real evidence).</summary>
+    public bool HasEvidence => hasEvidence;
+
+    /// <summary>
+    /// Runs (awaited, inside the adoption) when a payload reveals a peer RESET -- the hook for
+    /// resubscribing on a real transport. The abandoned-epoch set stays bounded by the number
+    /// of restarts this mirror lived through; a resubscribing bridge can recreate the mirror
+    /// instead if it wants a clean slate.
+    /// </summary>
+    public Func<Task>? OnPeerReset { get; init; }
+
+    internal RemoteSignal(EagerRelativeSignal<T> local, Func<Task<ValuePayload<T>>> pull)
+    {
+        Local = local;
+        this.pull = pull;
+    }
+
+    /// <summary>Pull the host's current truth and adopt it (subject to the ordering rules).</summary>
+    public async Task PullAsync() => await OnValueAsync(await pull());
+
+    /// <summary>
+    /// Handle a stale advertisement: pull when it is not provably old news -- an unknown or
+    /// different epoch (a reset is discovered on the payload), a sequence above the last
+    /// adopted one, or any advertisement at all while the mirror is unverifiable.
+    /// </summary>
+    public async Task OnStaleAsync(StaleNotification notification)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        bool shouldPull;
+        await adoptionGate.WaitAsync();
+        try
+        {
+            shouldPull = unverifiable
+                || (!abandonedEpochs.Contains(notification.Epoch)
+                    && (notification.Epoch != currentEpoch || notification.Sequence > lastSequence));
+        }
+        finally
+        {
+            adoptionGate.Release();
+        }
+
+        if (shouldPull)
+        {
+            await PullAsync();
+        }
+    }
+
+    /// <summary>Adopt one delivered publication (or drop it, per the ordering rules above).</summary>
+    public async Task OnValueAsync(ValuePayload<T> payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        // Validate the hostile parts up front, outside the gate: the stamp deserializer rejects
+        // malformed input, and a zero epoch on a VALUE payload is a protocol violation (hosts
+        // always have a nonzero incarnation; only stamps can be honestly epoch-agnostic).
+        var incoming = CausalityStamp.Deserialize(payload.Stamp);
+        if (payload.Epoch == 0)
+        {
+            throw new ArgumentException("A value payload must carry the host's nonzero incarnation epoch.", nameof(payload));
+        }
+
+        await adoptionGate.WaitAsync();
+        try
+        {
+            if (abandonedEpochs.Contains(payload.Epoch))
+            {
+                return; // late traffic from a dead incarnation
+            }
+
+            var isReset = currentEpoch != 0 && payload.Epoch != currentEpoch;
+            if (isReset)
+            {
+                abandonedEpochs.Add(currentEpoch);
+                currentEpoch = 0;
+                lastSequence = 0;
+                remoteStamp = CausalityStamp.Empty; // never merged across incarnations
+            }
+            else if (currentEpoch != 0 && payload.Sequence <= lastSequence)
+            {
+                return; // late or duplicated delivery: the sequence totally orders publications within an epoch
+            }
+
+            currentEpoch = payload.Epoch;
+            lastSequence = payload.Sequence;
+            hasEvidence = true;
+            unverifiable = payload.Unverifiable;
+            if (!payload.Unverifiable)
+            {
+                remoteStamp = incoming;
+            }
+
+            if (isReset && OnPeerReset != null)
+            {
+                await OnPeerReset();
+            }
+
+            await Local.Set(_ => payload.Value);
+        }
+        finally
+        {
+            adoptionGate.Release();
+        }
+    }
+}

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -107,6 +107,13 @@ public sealed class RemoteSignal<T>
         {
             throw new ArgumentException("A value payload must carry the host's nonzero incarnation epoch.", nameof(payload));
         }
+        // A non-empty stamp carries its own epoch; it must be the incarnation the header claims,
+        // or the ordering (header epoch) and the evidence the barrier compares (stamp epoch)
+        // would describe different incarnations. Empty stamps are epoch-agnostic by design.
+        if (incoming.Epoch != 0 && incoming.Epoch != payload.Epoch)
+        {
+            throw new ArgumentException("The payload's stamp belongs to a different incarnation epoch than the payload header claims.", nameof(payload));
+        }
 
         await adoptionGate.WaitAsync();
         try

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -115,7 +115,9 @@ public sealed class RemoteSignal<T>
     /// deliberately the READ-ONLY surface -- only the adoption protocol writes the mirror; a
     /// consumer-side Set would desynchronize the graph value from the publication evidence and
     /// the sequence order. Its own causality stamp is LOCAL (peer B's incarnation); the
-    /// foreign evidence lives in <see cref="Publication"/> until wire-format v3 lets it splice.
+    /// foreign evidence lives in <see cref="Publication"/> until wire-format v3 lets it
+    /// splice -- which is also why re-exporting this signal is refused: its local stamps
+    /// carry none of the origin's evidence.
     /// </summary>
     public IStampedGetR<T> Local => local;
 

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -233,13 +233,15 @@ public sealed class RemoteSignal<T>
         // local signal never published.
         if (verdict == AdoptionVerdict.AdoptReset && OnPeerReset != null)
         {
+            var resubscribed = false;
             try
             {
                 await OnPeerReset();
+                resubscribed = true;
             }
             finally
             {
-                await CloseResettlingWindowAsync();
+                await CloseResettlingWindowAsync(resubscribed);
             }
         }
     }
@@ -252,15 +254,18 @@ public sealed class RemoteSignal<T>
     // that opened the window (no per-reset window identity needed). If an epoch change was
     // refused while the window was open, verify it now on a detached best-effort pull: that
     // refusal may have been the dead-epoch delivery's ONLY advertisement (no heartbeat), and
-    // dropping it silently would pin the mirror to a dead incarnation.
-    private async Task CloseResettlingWindowAsync()
+    // dropping it silently would pin the mirror to a dead incarnation. Only after a SUCCESSFUL
+    // resubscription, though: a failed hook just reported the channel broken, and actively
+    // pulling it would solicit exactly the stale answers the window exists to refuse --
+    // recovery is then the bridge's own retry plus the next advertisement or heartbeat.
+    private async Task CloseResettlingWindowAsync(bool resubscribed)
     {
         bool verify;
         await adoptionGate.WaitAsync();
         try
         {
             resettling = false;
-            verify = pendingEpochVerification;
+            verify = pendingEpochVerification && resubscribed;
             pendingEpochVerification = false;
             Interlocked.Increment(ref epochGeneration);
         }
@@ -338,9 +343,13 @@ public sealed class RemoteSignal<T>
         // remembered and answered with a verification pull when the window closes: the peer
         // may have restarted AGAIN mid-resubscription, and this delivery may have been the new
         // incarnation's only advertisement. Otherwise an unsolicited payload gets a
-        // verification pull directly; a superseded pull answer (an epoch change committed
-        // since it was issued) is just dropped -- whatever committed is newer knowledge, and
-        // the live incarnation keeps advertising.
+        // verification pull directly -- and so does a SUPERSEDED pull answer (an epoch change
+        // committed since it was issued) that still claims a different epoch than the one
+        // committed: with racing verification pulls under one generation, the older restart's
+        // answer can commit first, and silently dropping the newer restart's answer would pin
+        // the mirror to a dead epoch when its delivery was a one-shot. Each such re-verify
+        // costs one pull and requires a real interleaved commit, so the chain terminates; late
+        // answers from epochs this mirror ABANDONED never reach this branch.
         if (resettling)
         {
             pendingEpochVerification = true;
@@ -350,7 +359,7 @@ public sealed class RemoteSignal<T>
         {
             return AdoptionVerdict.AdoptReset;
         }
-        return pulledAtGeneration is null ? AdoptionVerdict.VerifyByPull : AdoptionVerdict.Drop;
+        return AdoptionVerdict.VerifyByPull;
     }
 
     // Must be called under the adoption gate. Commits the ordering state and builds the new

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -33,7 +33,10 @@ public sealed record AdoptedPublication<T>(T Value, long Epoch, CausalityStamp S
 ///    answered with a verification pull (the response reflects the incarnation that is
 ///    actually alive), and committing an epoch change invalidates the answers of all pulls
 ///    still in flight. On a committed reset, held evidence is discarded, never merged, and
-///    <see cref="OnPeerReset"/> runs so the bridge can resubscribe;
+///    <see cref="OnPeerReset"/> runs so the bridge can resubscribe -- and while that
+///    resubscription is in flight, epoch-changing answers are refused entirely (they may have
+///    travelled the dead incarnation's channel), with pulls issued inside the window
+///    invalidated when it closes;
 ///  - within an epoch, the publication SEQUENCE totally orders deliveries: anything at or
 ///    below the last adopted sequence is a late or duplicated delivery and is dropped --
 ///    including the dependency-oscillation shapes causality stamps cannot order, and equally
@@ -56,14 +59,23 @@ public sealed class RemoteSignal<T>
     private bool nodeIdPinned;
     private long currentEpoch;
     private long lastSequence;
-    // Incremented when any epoch change commits (a reset or the first-contact pin). A pull
-    // captures the generation at issue, and its answer may commit an epoch change only if the
-    // generation is unchanged -- i.e. no epoch change committed since the pull was issued, so
-    // a delayed response from a pull issued before the mirror learned the current incarnation
-    // can never abandon it. Deliberately NOT bumped at pull issue: overlapping verification
-    // pulls must not invalidate each other optimistically, or a failed newer pull would strand
-    // an older pull's perfectly live answer until a heartbeat retries.
+    // Incremented when any epoch change commits (a reset or the first-contact pin), and again
+    // when a reset's resubscription window closes. A pull captures the generation at issue,
+    // and its answer may commit an epoch change only if the generation is unchanged -- i.e. no
+    // epoch change committed since the pull was issued, so a delayed response from a pull
+    // issued before the mirror learned the current incarnation can never abandon it.
+    // Deliberately NOT bumped at pull issue: overlapping verification pulls must not
+    // invalidate each other optimistically, or a failed newer pull would strand an older
+    // pull's perfectly live answer until a heartbeat retries.
     private long epochGeneration;
+
+    // Gate-guarded: true from a reset's commit until its OnPeerReset attempt finished. While a
+    // resubscription is in flight the pull channel may still point at the dead incarnation, so
+    // epoch-changing answers are refused outright; closing the window bumps the generation so
+    // pulls ISSUED inside it can never commit later either. Mirrors without a hook never open
+    // the window: declaring no resubscription means the channel is address-stable, and a fresh
+    // pull's answer always reflects whoever is actually alive.
+    private bool resettling;
     private volatile AdoptedPublication<T>? publication;
 
     private enum AdoptionVerdict { Drop, Adopt, AdoptReset, VerifyByPull }
@@ -213,7 +225,31 @@ public sealed class RemoteSignal<T>
         // local signal never published.
         if (verdict == AdoptionVerdict.AdoptReset && OnPeerReset != null)
         {
-            await OnPeerReset();
+            try
+            {
+                await OnPeerReset();
+            }
+            finally
+            {
+                await CloseResettlingWindowAsync();
+            }
+        }
+    }
+
+    // The resubscription attempt is over (success or failure -- either way the delivering
+    // caller knows): close the window and invalidate every pull issued inside it, whose
+    // answers may have travelled the dead incarnation's channel.
+    private async Task CloseResettlingWindowAsync()
+    {
+        await adoptionGate.WaitAsync();
+        try
+        {
+            resettling = false;
+            Interlocked.Increment(ref epochGeneration);
+        }
+        finally
+        {
+            adoptionGate.Release();
         }
     }
 
@@ -263,10 +299,12 @@ public sealed class RemoteSignal<T>
         }
 
         // An epoch change: only a pull issued after the last committed epoch change may commit
-        // it. An unsolicited payload gets a verification pull instead; a superseded pull answer
-        // (an epoch change committed since it was issued) is just dropped -- whatever committed
-        // is newer knowledge, and the live incarnation keeps advertising.
-        if (pulledAtGeneration == Volatile.Read(ref epochGeneration))
+        // it -- and never while a reset's resubscription is still in flight (the answer may
+        // have travelled the dead incarnation's channel). An unsolicited payload gets a
+        // verification pull instead; a superseded pull answer (an epoch change committed since
+        // it was issued) is just dropped -- whatever committed is newer knowledge, and the
+        // live incarnation keeps advertising.
+        if (!resettling && pulledAtGeneration == Volatile.Read(ref epochGeneration))
         {
             return AdoptionVerdict.AdoptReset;
         }
@@ -282,6 +320,7 @@ public sealed class RemoteSignal<T>
         {
             abandonedEpochs.Add(currentEpoch);
             heldVerifiedStamp = CausalityStamp.Empty; // never merged across incarnations
+            resettling = OnPeerReset != null;
         }
         else
         {

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -107,6 +107,14 @@ public sealed class RemoteSignal<T>
     /// </summary>
     public Func<Task>? OnPeerReset { get; init; }
 
+    // Re-run downstream reactions on the CURRENT value and publication: the barrier's
+    // affirmation path needs a graph trigger after a re-pull round that adopted nothing (an
+    // eager relative signal always propagates, even for an identical value). Harmless against
+    // concurrent adoptions -- the publication swap rides inside the adopting Set's own
+    // exclusive-locked callback, so this republication observes either the old or the new
+    // snapshot whole, never a torn one.
+    internal Task RepublishLocalAsync() => local.Set(value => value);
+
     internal RemoteSignal(EagerRelativeSignal<T> local, Func<Task<ValuePayload<T>>> pull, int? nodeId)
     {
         this.local = local;

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -175,8 +175,17 @@ public sealed class RemoteSignal<T>
             verdict = Classify(payload, pulledAtGeneration);
             if (verdict is AdoptionVerdict.Adopt or AdoptionVerdict.AdoptReset)
             {
-                CommitOrdering(payload, incoming, verdict == AdoptionVerdict.AdoptReset);
-                await local.Set(_ => payload.Value);
+                var adopted = CommitOrdering(payload, incoming, verdict == AdoptionVerdict.AdoptReset);
+                await local.Set(_ =>
+                {
+                    // The snapshot becomes visible as part of the graph write, under the same
+                    // exclusive context lock: a barrier evaluation (upgradeable, excluded by
+                    // the exclusive) can never observe the new evidence while the local graph
+                    // value still lags behind the queued Set -- publication and graph value
+                    // advance together, and the Set's own propagation re-runs the barrier.
+                    publication = adopted;
+                    return payload.Value;
+                });
             }
         }
         finally
@@ -256,8 +265,9 @@ public sealed class RemoteSignal<T>
         return pulledAtGeneration is null ? AdoptionVerdict.VerifyByPull : AdoptionVerdict.Drop;
     }
 
-    // Must be called under the adoption gate.
-    private void CommitOrdering(ValuePayload<T> payload, CausalityStamp incoming, bool isReset)
+    // Must be called under the adoption gate. Commits the ordering state and builds the new
+    // publication snapshot; the caller makes it visible inside the local graph write.
+    private AdoptedPublication<T> CommitOrdering(ValuePayload<T> payload, CausalityStamp incoming, bool isReset)
     {
         CausalityStamp heldVerifiedStamp;
         if (isReset)
@@ -280,7 +290,7 @@ public sealed class RemoteSignal<T>
 
         currentEpoch = payload.Epoch;
         lastSequence = payload.Sequence;
-        publication = new AdoptedPublication<T>(
+        return new AdoptedPublication<T>(
             payload.Value,
             payload.Epoch,
             payload.Unverifiable ? heldVerifiedStamp : incoming,

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -203,15 +203,19 @@ public sealed class RemoteSignal<T>
             verdict = Classify(payload, pulledAtGeneration);
             if (verdict is AdoptionVerdict.Adopt or AdoptionVerdict.AdoptReset)
             {
-                var adopted = CommitOrdering(payload, incoming, verdict == AdoptionVerdict.AdoptReset);
+                var isReset = verdict == AdoptionVerdict.AdoptReset;
                 await local.Set(_ =>
                 {
-                    // The snapshot becomes visible as part of the graph write, under the same
-                    // exclusive context lock: a barrier evaluation (upgradeable, excluded by
-                    // the exclusive) can never observe the new evidence while the local graph
-                    // value still lags behind the queued Set -- publication and graph value
-                    // advance together, and the Set's own propagation re-runs the barrier.
-                    publication = adopted;
+                    // Ordering state and snapshot commit atomically WITH the graph write, under
+                    // the same exclusive context lock: a barrier evaluation (upgradeable,
+                    // excluded by the exclusive) can never observe the new evidence while the
+                    // local graph value still lags behind the queued Set, and a Set that fails
+                    // to acquire at all (a bridge delivering from a same-context reaction flow
+                    // is refused as a recursive acquisition) leaves the ordering untouched --
+                    // the redelivery must adopt, not be duplicate-dropped against a sequence
+                    // the graph never published. The callback still runs inside the adoption
+                    // gate, so the ordering fields stay gate-consistent for Classify/OnStale.
+                    publication = CommitOrdering(payload, incoming, isReset);
                     return payload.Value;
                 });
             }

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -79,9 +79,10 @@ public sealed class RemoteSignal<T>
     // pull's answer always reflects whoever is actually alive.
     private bool resettling;
 
-    // Gate-guarded: an epoch change was refused while the window was open (the peer restarted
-    // again mid-resubscription). Closing the window answers it with one verification pull --
-    // the refused delivery may have been that incarnation's only advertisement.
+    // Gate-guarded: an epoch change was refused -- or a foreign-epoch restart was ADVERTISED
+    // -- while the window was open (the peer restarted again mid-resubscription). Closing the
+    // window answers it with one verification pull; the refused delivery or advertisement may
+    // have been that incarnation's only announcement.
     private bool pendingEpochVerification;
 
     // Gate-guarded: the last resubscription window closed on a FAILED hook, so the pull
@@ -181,6 +182,10 @@ public sealed class RemoteSignal<T>
     /// last adopted one, or any advertisement at all while the mirror is unverifiable. An
     /// advertisement for a different node than this mirror is bound to is ignored (a fan-out
     /// bus may broadcast advertisements; only value adoption treats misrouting as an error).
+    /// A restart advertised while a resubscription window is open is remembered instead of
+    /// chased: a mid-window pull may still travel the not-yet-resubscribed channel and answer
+    /// with the old epoch (or fault), silently discarding a single-shot advertisement -- the
+    /// window's closing verification pull follows it up on the repaired channel.
     /// </summary>
     public async Task OnStaleAsync(StaleNotification notification)
     {
@@ -189,10 +194,24 @@ public sealed class RemoteSignal<T>
         await adoptionGate.WaitAsync();
         try
         {
-            shouldPull = (!nodeIdPinned || notification.NodeId == expectedNodeId)
-                && ((publication?.Unverifiable ?? false)
+            if (nodeIdPinned && notification.NodeId != expectedNodeId)
+            {
+                shouldPull = false;
+            }
+            else if (resettling
+                && !abandonedEpochs.Contains(notification.Epoch)
+                && notification.Epoch != currentEpoch)
+            {
+                // The advertisement itself is the restart evidence; keep it for the close.
+                pendingEpochVerification = true;
+                shouldPull = false;
+            }
+            else
+            {
+                shouldPull = (publication?.Unverifiable ?? false)
                     || (!abandonedEpochs.Contains(notification.Epoch)
-                        && (notification.Epoch != currentEpoch || notification.Sequence > lastSequence)));
+                        && (notification.Epoch != currentEpoch || notification.Sequence > lastSequence));
+            }
         }
         finally
         {

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -12,17 +12,28 @@ namespace MemoizR.Distributed;
 public sealed record AdoptedPublication<T>(T Value, long Epoch, CausalityStamp Stamp, bool Unverifiable);
 
 /// <summary>
-/// The consumer side of one exported node: a local <see cref="EagerRelativeSignal{T}"/> (so the
-/// consumer's graph reacts through the ordinary machinery -- eager on purpose, because an
-/// adoption can change the EVIDENCE while the numeric value stays identical, and the barrier
-/// must re-run to observe it) plus the foreign evidence the current value arrived with, plus
-/// the adoption protocol that makes reordered, at-least-once transports harmless:
+/// The consumer side of one exported node: a local eager signal (readable through
+/// <see cref="Local"/> -- eager on purpose, because an adoption can change the EVIDENCE while
+/// the numeric value stays identical, and the barrier must re-run to observe it) plus the
+/// foreign evidence the current value arrived with, plus the adoption protocol that makes
+/// reordered, at-least-once transports harmless:
 ///
+///  - a payload for a different node than this mirror is bound to is a routing violation and
+///    is rejected (the binding comes from the creation-time node id, or is pinned by the
+///    first delivered payload) -- adopting it would replace the value with a sibling export's
+///    and advance the sequence order with a foreign counter;
 ///  - late traffic from an incarnation this mirror already left is dropped (epochs are random
 ///    identifiers, not ordered -- the mirror remembers what it abandoned instead of trusting a
 ///    mismatch to mean "newer");
-///  - a different, non-abandoned epoch is a peer RESET: held evidence is discarded, never
-///    merged, and <see cref="OnPeerReset"/> runs so the bridge can resubscribe;
+///  - a different, non-abandoned epoch signals a peer RESET, but it is committed only by a
+///    payload answering this mirror's own LATEST pull: with unordered epochs, a delayed
+///    payload from a skipped dead incarnation is indistinguishable by inspection from a live
+///    restart, and adopting it would abandon the LIVE epoch and wedge the mirror. An
+///    unsolicited epoch-mismatch payload is therefore discarded and answered with a
+///    verification pull (the response reflects the incarnation that is actually alive), and
+///    committing any epoch change invalidates all in-flight pulls. On a committed reset, held
+///    evidence is discarded, never merged, and <see cref="OnPeerReset"/> runs so the bridge
+///    can resubscribe;
 ///  - within an epoch, the publication SEQUENCE totally orders deliveries: anything at or
 ///    below the last adopted sequence is a late or duplicated delivery and is dropped --
 ///    including the dependency-oscillation shapes causality stamps cannot order, and equally
@@ -40,16 +51,27 @@ public sealed class RemoteSignal<T>
     private readonly SemaphoreSlim adoptionGate = new(1, 1);
     private readonly Func<Task<ValuePayload<T>>> pull;
     private readonly HashSet<long> abandonedEpochs = [];
+    private readonly EagerRelativeSignal<T> local;
+    private int expectedNodeId;
+    private bool nodeIdPinned;
     private long currentEpoch;
     private long lastSequence;
+    // Incremented when a pull is issued AND when any epoch change commits: an epoch-changing
+    // payload may only commit if it answers the latest generation, so a delayed response from
+    // a pull issued before the mirror learned the current incarnation can never abandon it.
+    private long pullGeneration;
     private volatile AdoptedPublication<T>? publication;
 
+    private enum AdoptionVerdict { Drop, Adopt, AdoptReset, VerifyByPull }
+
     /// <summary>
-    /// The local signal carrying the mirrored value: wire reactions and memos to this. Its own
-    /// causality stamp is LOCAL (peer B's incarnation); the foreign evidence lives in
-    /// <see cref="Publication"/> until wire-format v3 lets it splice.
+    /// The local signal carrying the mirrored value: wire reactions and memos to this. It is
+    /// deliberately the READ-ONLY surface -- only the adoption protocol writes the mirror; a
+    /// consumer-side Set would desynchronize the graph value from the publication evidence and
+    /// the sequence order. Its own causality stamp is LOCAL (peer B's incarnation); the
+    /// foreign evidence lives in <see cref="Publication"/> until wire-format v3 lets it splice.
     /// </summary>
-    public EagerRelativeSignal<T> Local { get; }
+    public IStampedGetR<T> Local => local;
 
     /// <summary>
     /// The last adopted publication -- value and evidence as ONE atomic snapshot (null until a
@@ -69,7 +91,7 @@ public sealed class RemoteSignal<T>
     public bool HasEvidence => publication != null;
 
     /// <summary>
-    /// Runs (awaited by the delivering call) when a payload reveals a peer RESET -- the hook
+    /// Runs (awaited by the delivering call) when a payload commits a peer RESET -- the hook
     /// for resubscribing on a real transport. It is invoked AFTER the reset adoption committed
     /// and the adoption gate is released: the hook may freely pull or feed this same mirror
     /// (re-entering the adoption path), and if it throws, the failure surfaces to the
@@ -81,19 +103,30 @@ public sealed class RemoteSignal<T>
     /// </summary>
     public Func<Task>? OnPeerReset { get; init; }
 
-    internal RemoteSignal(EagerRelativeSignal<T> local, Func<Task<ValuePayload<T>>> pull)
+    internal RemoteSignal(EagerRelativeSignal<T> local, Func<Task<ValuePayload<T>>> pull, int? nodeId)
     {
-        Local = local;
+        this.local = local;
         this.pull = pull;
+        if (nodeId is { } id)
+        {
+            expectedNodeId = id;
+            nodeIdPinned = true;
+        }
     }
 
     /// <summary>Pull the host's current truth and adopt it (subject to the ordering rules).</summary>
-    public async Task PullAsync() => await OnValueAsync(await pull());
+    public async Task PullAsync()
+    {
+        var generation = Interlocked.Increment(ref pullGeneration);
+        await AdoptAsync(await pull(), generation);
+    }
 
     /// <summary>
     /// Handle a stale advertisement: pull when it is not provably old news -- an unknown or
-    /// different epoch (a reset is discovered on the payload), a sequence above the last
-    /// adopted one, or any advertisement at all while the mirror is unverifiable.
+    /// different epoch (a reset is discovered on the pulled payload), a sequence above the
+    /// last adopted one, or any advertisement at all while the mirror is unverifiable. An
+    /// advertisement for a different node than this mirror is bound to is ignored (a fan-out
+    /// bus may broadcast advertisements; only value adoption treats misrouting as an error).
     /// </summary>
     public async Task OnStaleAsync(StaleNotification notification)
     {
@@ -102,9 +135,10 @@ public sealed class RemoteSignal<T>
         await adoptionGate.WaitAsync();
         try
         {
-            shouldPull = (publication?.Unverifiable ?? false)
-                || (!abandonedEpochs.Contains(notification.Epoch)
-                    && (notification.Epoch != currentEpoch || notification.Sequence > lastSequence));
+            shouldPull = (!nodeIdPinned || notification.NodeId == expectedNodeId)
+                && ((publication?.Unverifiable ?? false)
+                    || (!abandonedEpochs.Contains(notification.Epoch)
+                        && (notification.Epoch != currentEpoch || notification.Sequence > lastSequence)));
         }
         finally
         {
@@ -117,13 +151,56 @@ public sealed class RemoteSignal<T>
         }
     }
 
-    /// <summary>Adopt one delivered publication (or drop it, per the ordering rules above).</summary>
-    public async Task OnValueAsync(ValuePayload<T> payload)
+    /// <summary>
+    /// Adopt one delivered publication (or drop it, per the ordering rules above). A payload
+    /// revealing an epoch change is not adopted directly: it is discarded and the mirror
+    /// issues a verification pull, whose answer commits whatever incarnation is actually
+    /// alive.
+    /// </summary>
+    public Task OnValueAsync(ValuePayload<T> payload) => AdoptAsync(payload, pulledAtGeneration: null);
+
+    private async Task AdoptAsync(ValuePayload<T> payload, long? pulledAtGeneration)
     {
         ArgumentNullException.ThrowIfNull(payload);
-        // Validate the hostile parts up front, outside the gate: the stamp deserializer rejects
-        // malformed input, and a zero epoch on a VALUE payload is a protocol violation (hosts
-        // always have a nonzero incarnation; only stamps can be honestly epoch-agnostic).
+        var incoming = ValidateProtocol(payload);
+
+        AdoptionVerdict verdict;
+        await adoptionGate.WaitAsync();
+        try
+        {
+            verdict = Classify(payload, pulledAtGeneration);
+            if (verdict is AdoptionVerdict.Adopt or AdoptionVerdict.AdoptReset)
+            {
+                CommitOrdering(payload, incoming, verdict == AdoptionVerdict.AdoptReset);
+                await local.Set(_ => payload.Value);
+            }
+        }
+        finally
+        {
+            adoptionGate.Release();
+        }
+
+        if (verdict == AdoptionVerdict.VerifyByPull)
+        {
+            await PullAsync();
+            return;
+        }
+
+        // The resubscription hook runs with the adoption fully committed and the gate free: a
+        // hook that pulls or feeds this same mirror re-enters cleanly instead of deadlocking on
+        // the gate, and a hook that throws cannot leave the ordering state claiming a value the
+        // local signal never published.
+        if (verdict == AdoptionVerdict.AdoptReset && OnPeerReset != null)
+        {
+            await OnPeerReset();
+        }
+    }
+
+    // Rejects the hostile parts up front, outside the gate: the stamp deserializer rejects
+    // malformed input, and a zero epoch on a VALUE payload is a protocol violation (hosts
+    // always have a nonzero incarnation; only stamps can be honestly epoch-agnostic).
+    private static CausalityStamp ValidateProtocol(ValuePayload<T> payload)
+    {
         var incoming = CausalityStamp.Deserialize(payload.Stamp);
         if (payload.Epoch == 0)
         {
@@ -136,54 +213,73 @@ public sealed class RemoteSignal<T>
         {
             throw new ArgumentException("The payload's stamp belongs to a different incarnation epoch than the payload header claims.", nameof(payload));
         }
+        return incoming;
+    }
 
-        var isReset = false;
-        await adoptionGate.WaitAsync();
-        try
+    // Must be called under the adoption gate.
+    private AdoptionVerdict Classify(ValuePayload<T> payload, long? pulledAtGeneration)
+    {
+        if (nodeIdPinned && payload.NodeId != expectedNodeId)
         {
-            if (abandonedEpochs.Contains(payload.Epoch))
-            {
-                return; // late traffic from a dead incarnation
-            }
-
-            CausalityStamp heldVerifiedStamp;
-            isReset = currentEpoch != 0 && payload.Epoch != currentEpoch;
-            if (isReset)
-            {
-                abandonedEpochs.Add(currentEpoch);
-                heldVerifiedStamp = CausalityStamp.Empty; // never merged across incarnations
-            }
-            else
-            {
-                if (currentEpoch != 0 && payload.Sequence <= lastSequence)
-                {
-                    return; // late or duplicated delivery: the sequence totally orders publications within an epoch
-                }
-                heldVerifiedStamp = publication?.Stamp ?? CausalityStamp.Empty;
-            }
-
-            currentEpoch = payload.Epoch;
-            lastSequence = payload.Sequence;
-            publication = new AdoptedPublication<T>(
-                payload.Value,
-                payload.Epoch,
-                payload.Unverifiable ? heldVerifiedStamp : incoming,
-                payload.Unverifiable);
-
-            await Local.Set(_ => payload.Value);
+            throw new ArgumentException($"The value payload describes node {payload.NodeId}, but this mirror is bound to node {expectedNodeId}.", nameof(payload));
         }
-        finally
+        nodeIdPinned = true;
+        expectedNodeId = payload.NodeId;
+
+        if (abandonedEpochs.Contains(payload.Epoch))
         {
-            adoptionGate.Release();
+            return AdoptionVerdict.Drop; // late traffic from a dead incarnation
+        }
+        if (currentEpoch == 0)
+        {
+            return AdoptionVerdict.Adopt; // first contact pins the incarnation
+        }
+        if (payload.Epoch == currentEpoch)
+        {
+            // The sequence totally orders publications within an epoch; at or below the last
+            // adopted one is a late or duplicated delivery.
+            return payload.Sequence > lastSequence ? AdoptionVerdict.Adopt : AdoptionVerdict.Drop;
         }
 
-        // The resubscription hook runs with the adoption fully committed and the gate free: a
-        // hook that pulls or feeds this same mirror re-enters cleanly instead of deadlocking on
-        // the gate, and a hook that throws cannot leave the ordering state claiming a value the
-        // local signal never published.
-        if (isReset && OnPeerReset != null)
+        // An epoch change: only the answer to the LATEST pull may commit it. An unsolicited
+        // payload gets a verification pull instead; a stale pull answer (a newer pull or an
+        // epoch change happened since it was issued) is just dropped -- the newer pull brings
+        // the live incarnation's truth.
+        if (pulledAtGeneration == Volatile.Read(ref pullGeneration))
         {
-            await OnPeerReset();
+            return AdoptionVerdict.AdoptReset;
         }
+        return pulledAtGeneration is null ? AdoptionVerdict.VerifyByPull : AdoptionVerdict.Drop;
+    }
+
+    // Must be called under the adoption gate.
+    private void CommitOrdering(ValuePayload<T> payload, CausalityStamp incoming, bool isReset)
+    {
+        CausalityStamp heldVerifiedStamp;
+        if (isReset)
+        {
+            abandonedEpochs.Add(currentEpoch);
+            heldVerifiedStamp = CausalityStamp.Empty; // never merged across incarnations
+        }
+        else
+        {
+            heldVerifiedStamp = publication?.Stamp ?? CausalityStamp.Empty;
+        }
+
+        if (payload.Epoch != currentEpoch)
+        {
+            // Any committed epoch change (a reset or the first-contact pin) invalidates every
+            // in-flight pull: their answers describe a world from before the mirror learned
+            // this incarnation, and must not be able to commit another epoch change.
+            Interlocked.Increment(ref pullGeneration);
+        }
+
+        currentEpoch = payload.Epoch;
+        lastSequence = payload.Sequence;
+        publication = new AdoptedPublication<T>(
+            payload.Value,
+            payload.Epoch,
+            payload.Unverifiable ? heldVerifiedStamp : incoming,
+            payload.Unverifiable);
     }
 }

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -84,6 +84,15 @@ public sealed class RemoteSignal<T>
     // the refused delivery may have been that incarnation's only advertisement.
     private bool pendingEpochVerification;
 
+    // Gate-guarded: the last resubscription window closed on a FAILED hook, so the pull
+    // channel may still be routed to a dead incarnation. While suspect, the mirror never
+    // initiates verification pulls from superseded stale answers (zero fresh evidence) -- a
+    // broken channel answering a self-solicited pull with a dead epoch could commit it and
+    // abandon the live one. Cleared by the next successful resubscription or by any pull
+    // answer that gets adopted (the channel demonstrably served accepted truth); fresh pulls
+    // triggered by real deliveries stay allowed, so a repaired bridge heals normally.
+    private bool pullChannelSuspect;
+
     private volatile Exception? lastBackgroundError;
 
     /// <summary>
@@ -231,6 +240,13 @@ public sealed class RemoteSignal<T>
                     publication = CommitOrdering(payload, incoming, isReset);
                     return payload.Value;
                 });
+
+                if (pulledAtGeneration is not null)
+                {
+                    // The pull channel served an answer this mirror adopted: demonstrably
+                    // healthy again, so mirror-initiated re-verification is re-enabled.
+                    pullChannelSuspect = false;
+                }
             }
         }
         finally
@@ -284,6 +300,7 @@ public sealed class RemoteSignal<T>
             resettling = false;
             verify = pendingEpochVerification && resubscribed;
             pendingEpochVerification = false;
+            pullChannelSuspect = !resubscribed;
             Interlocked.Increment(ref epochGeneration);
         }
         finally
@@ -378,6 +395,14 @@ public sealed class RemoteSignal<T>
         if (pulledAtGeneration == Volatile.Read(ref epochGeneration))
         {
             return AdoptionVerdict.AdoptReset;
+        }
+        // A superseded stale answer carries zero fresh evidence: while the channel is suspect
+        // (the last resubscription FAILED), re-verifying from it would actively solicit the
+        // possibly-still-broken channel -- drop instead; deliveries and advertisements keep
+        // their verification pulls, so a repaired bridge heals normally.
+        if (pulledAtGeneration is not null && pullChannelSuspect)
+        {
+            return AdoptionVerdict.Drop;
         }
         return AdoptionVerdict.VerifyByPull;
     }

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -36,7 +36,9 @@ public sealed record AdoptedPublication<T>(T Value, long Epoch, CausalityStamp S
 ///    <see cref="OnPeerReset"/> runs so the bridge can resubscribe -- and while that
 ///    resubscription is in flight, epoch-changing answers are refused entirely (they may have
 ///    travelled the dead incarnation's channel), with pulls issued inside the window
-///    invalidated when it closes;
+///    invalidated when it closes and any refusal re-verified by one fresh pull then (the peer
+///    may have restarted again mid-resubscription, and that delivery may have been the new
+///    incarnation's only advertisement);
 ///  - within an epoch, the publication SEQUENCE totally orders deliveries: anything at or
 ///    below the last adopted sequence is a late or duplicated delivery and is dropped --
 ///    including the dependency-oscillation shapes causality stamps cannot order, and equally
@@ -76,6 +78,11 @@ public sealed class RemoteSignal<T>
     // the window: declaring no resubscription means the channel is address-stable, and a fresh
     // pull's answer always reflects whoever is actually alive.
     private bool resettling;
+
+    // Gate-guarded: an epoch change was refused while the window was open (the peer restarted
+    // again mid-resubscription). Closing the window answers it with one verification pull --
+    // the refused delivery may have been that incarnation's only advertisement.
+    private bool pendingEpochVerification;
     private volatile AdoptedPublication<T>? publication;
 
     private enum AdoptionVerdict { Drop, Adopt, AdoptReset, VerifyByPull }
@@ -112,10 +119,11 @@ public sealed class RemoteSignal<T>
     /// and the adoption gate is released: the hook may freely pull or feed this same mirror
     /// (re-entering the adoption path), and if it throws, the failure surfaces to the
     /// delivering caller while the value stays adopted -- redeliveries drop as duplicates and
-    /// only the resubscription itself needs retrying. Back-to-back resets can overlap hook
-    /// runs; a resubscribing bridge must tolerate that (or recreate the mirror for a clean
-    /// slate). The abandoned-epoch set stays bounded by the number of restarts this mirror
-    /// lived through.
+    /// only the resubscription itself needs retrying. Hook runs are SINGLE-FLIGHT: while one
+    /// is in flight, no further epoch change can commit (refused deliveries are re-verified by
+    /// pull once the resubscription attempt finishes), so back-to-back restarts run their
+    /// hooks strictly in sequence. The abandoned-epoch set stays bounded by the number of
+    /// restarts this mirror lived through.
     /// </summary>
     public Func<Task>? OnPeerReset { get; init; }
 
@@ -238,18 +246,44 @@ public sealed class RemoteSignal<T>
 
     // The resubscription attempt is over (success or failure -- either way the delivering
     // caller knows): close the window and invalidate every pull issued inside it, whose
-    // answers may have travelled the dead incarnation's channel.
+    // answers may have travelled the dead incarnation's channel. Windows are SINGLE-FLIGHT by
+    // construction -- while one is open, no epoch change can commit, so no second hook can
+    // start -- which is what makes this unconditional close pair 1:1 with the hook invocation
+    // that opened the window (no per-reset window identity needed). If an epoch change was
+    // refused while the window was open, verify it now on a detached best-effort pull: that
+    // refusal may have been the dead-epoch delivery's ONLY advertisement (no heartbeat), and
+    // dropping it silently would pin the mirror to a dead incarnation.
     private async Task CloseResettlingWindowAsync()
     {
+        bool verify;
         await adoptionGate.WaitAsync();
         try
         {
             resettling = false;
+            verify = pendingEpochVerification;
+            pendingEpochVerification = false;
             Interlocked.Increment(ref epochGeneration);
         }
         finally
         {
             adoptionGate.Release();
+        }
+
+        if (verify)
+        {
+            DetachedFlow.Run(async () =>
+            {
+                try
+                {
+                    await PullAsync();
+                }
+                catch
+                {
+                    // Best-effort recovery of a refused single-shot advertisement; a faulted
+                    // transport here is retried by the next advertisement or heartbeat like
+                    // any other lost delivery.
+                }
+            });
         }
     }
 
@@ -300,11 +334,19 @@ public sealed class RemoteSignal<T>
 
         // An epoch change: only a pull issued after the last committed epoch change may commit
         // it -- and never while a reset's resubscription is still in flight (the answer may
-        // have travelled the dead incarnation's channel). An unsolicited payload gets a
-        // verification pull instead; a superseded pull answer (an epoch change committed since
-        // it was issued) is just dropped -- whatever committed is newer knowledge, and the
-        // live incarnation keeps advertising.
-        if (!resettling && pulledAtGeneration == Volatile.Read(ref epochGeneration))
+        // have travelled the dead incarnation's channel). A refusal during the window is
+        // remembered and answered with a verification pull when the window closes: the peer
+        // may have restarted AGAIN mid-resubscription, and this delivery may have been the new
+        // incarnation's only advertisement. Otherwise an unsolicited payload gets a
+        // verification pull directly; a superseded pull answer (an epoch change committed
+        // since it was issued) is just dropped -- whatever committed is newer knowledge, and
+        // the live incarnation keeps advertising.
+        if (resettling)
+        {
+            pendingEpochVerification = true;
+            return AdoptionVerdict.Drop;
+        }
+        if (pulledAtGeneration == Volatile.Read(ref epochGeneration))
         {
             return AdoptionVerdict.AdoptReset;
         }

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -1,6 +1,17 @@
 namespace MemoizR.Distributed;
 
 /// <summary>
+/// One adopted publication as the barrier must observe it: the mirrored value and the evidence
+/// it arrived with, bound in a single immutable snapshot (swapped atomically, so a reader can
+/// never pair one publication's value with another's evidence). <see cref="Epoch"/> is the
+/// header epoch of the adopted payload -- carried beside the stamp because an honestly-empty
+/// stamp is epoch-agnostic, and incarnation identity must survive empty publications.
+/// <see cref="Stamp"/> is the stamp of the last VERIFIED adoption (an unverifiable adoption
+/// carries the held verified stamp forward, with <see cref="Unverifiable"/> set).
+/// </summary>
+public sealed record AdoptedPublication<T>(T Value, long Epoch, CausalityStamp Stamp, bool Unverifiable);
+
+/// <summary>
 /// The consumer side of one exported node: a local <see cref="EagerRelativeSignal{T}"/> (so the
 /// consumer's graph reacts through the ordinary machinery -- eager on purpose, because an
 /// adoption can change the EVIDENCE while the numeric value stays identical, and the barrier
@@ -31,31 +42,42 @@ public sealed class RemoteSignal<T>
     private readonly HashSet<long> abandonedEpochs = [];
     private long currentEpoch;
     private long lastSequence;
-    private volatile CausalityStamp remoteStamp = CausalityStamp.Empty;
-    private volatile bool unverifiable;
-    private volatile bool hasEvidence;
+    private volatile AdoptedPublication<T>? publication;
 
     /// <summary>
     /// The local signal carrying the mirrored value: wire reactions and memos to this. Its own
     /// causality stamp is LOCAL (peer B's incarnation); the foreign evidence lives in
-    /// <see cref="RemoteStamp"/> until wire-format v3 lets it splice.
+    /// <see cref="Publication"/> until wire-format v3 lets it splice.
     /// </summary>
     public EagerRelativeSignal<T> Local { get; }
 
+    /// <summary>
+    /// The last adopted publication -- value and evidence as ONE atomic snapshot (null until a
+    /// payload is adopted). The barrier renders from this, never from the graph value plus a
+    /// separately-read stamp: those two reads could straddle an adoption and pair a value with
+    /// evidence it never published under.
+    /// </summary>
+    public AdoptedPublication<T>? Publication => publication;
+
     /// <summary>The stamp of the last VERIFIED adopted publication (empty until one arrives).</summary>
-    public CausalityStamp RemoteStamp => remoteStamp;
+    public CausalityStamp RemoteStamp => publication?.Stamp ?? CausalityStamp.Empty;
 
     /// <summary>Whether the host's current publication is one nobody can vouch for.</summary>
-    public bool Unverifiable => unverifiable;
+    public bool Unverifiable => publication?.Unverifiable ?? false;
 
     /// <summary>Whether any payload was adopted at all (an honestly-empty stamp is real evidence).</summary>
-    public bool HasEvidence => hasEvidence;
+    public bool HasEvidence => publication != null;
 
     /// <summary>
-    /// Runs (awaited, inside the adoption) when a payload reveals a peer RESET -- the hook for
-    /// resubscribing on a real transport. The abandoned-epoch set stays bounded by the number
-    /// of restarts this mirror lived through; a resubscribing bridge can recreate the mirror
-    /// instead if it wants a clean slate.
+    /// Runs (awaited by the delivering call) when a payload reveals a peer RESET -- the hook
+    /// for resubscribing on a real transport. It is invoked AFTER the reset adoption committed
+    /// and the adoption gate is released: the hook may freely pull or feed this same mirror
+    /// (re-entering the adoption path), and if it throws, the failure surfaces to the
+    /// delivering caller while the value stays adopted -- redeliveries drop as duplicates and
+    /// only the resubscription itself needs retrying. Back-to-back resets can overlap hook
+    /// runs; a resubscribing bridge must tolerate that (or recreate the mirror for a clean
+    /// slate). The abandoned-epoch set stays bounded by the number of restarts this mirror
+    /// lived through.
     /// </summary>
     public Func<Task>? OnPeerReset { get; init; }
 
@@ -80,7 +102,7 @@ public sealed class RemoteSignal<T>
         await adoptionGate.WaitAsync();
         try
         {
-            shouldPull = unverifiable
+            shouldPull = (publication?.Unverifiable ?? false)
                 || (!abandonedEpochs.Contains(notification.Epoch)
                     && (notification.Epoch != currentEpoch || notification.Sequence > lastSequence));
         }
@@ -115,6 +137,7 @@ public sealed class RemoteSignal<T>
             throw new ArgumentException("The payload's stamp belongs to a different incarnation epoch than the payload header claims.", nameof(payload));
         }
 
+        var isReset = false;
         await adoptionGate.WaitAsync();
         try
         {
@@ -123,38 +146,44 @@ public sealed class RemoteSignal<T>
                 return; // late traffic from a dead incarnation
             }
 
-            var isReset = currentEpoch != 0 && payload.Epoch != currentEpoch;
+            CausalityStamp heldVerifiedStamp;
+            isReset = currentEpoch != 0 && payload.Epoch != currentEpoch;
             if (isReset)
             {
                 abandonedEpochs.Add(currentEpoch);
-                currentEpoch = 0;
-                lastSequence = 0;
-                remoteStamp = CausalityStamp.Empty; // never merged across incarnations
+                heldVerifiedStamp = CausalityStamp.Empty; // never merged across incarnations
             }
-            else if (currentEpoch != 0 && payload.Sequence <= lastSequence)
+            else
             {
-                return; // late or duplicated delivery: the sequence totally orders publications within an epoch
+                if (currentEpoch != 0 && payload.Sequence <= lastSequence)
+                {
+                    return; // late or duplicated delivery: the sequence totally orders publications within an epoch
+                }
+                heldVerifiedStamp = publication?.Stamp ?? CausalityStamp.Empty;
             }
 
             currentEpoch = payload.Epoch;
             lastSequence = payload.Sequence;
-            hasEvidence = true;
-            unverifiable = payload.Unverifiable;
-            if (!payload.Unverifiable)
-            {
-                remoteStamp = incoming;
-            }
-
-            if (isReset && OnPeerReset != null)
-            {
-                await OnPeerReset();
-            }
+            publication = new AdoptedPublication<T>(
+                payload.Value,
+                payload.Epoch,
+                payload.Unverifiable ? heldVerifiedStamp : incoming,
+                payload.Unverifiable);
 
             await Local.Set(_ => payload.Value);
         }
         finally
         {
             adoptionGate.Release();
+        }
+
+        // The resubscription hook runs with the adoption fully committed and the gate free: a
+        // hook that pulls or feeds this same mirror re-enters cleanly instead of deadlocking on
+        // the gate, and a hook that throws cannot leave the ordering state claiming a value the
+        // local signal never published.
+        if (isReset && OnPeerReset != null)
+        {
+            await OnPeerReset();
         }
     }
 }

--- a/MemoizR.Distributed/RemoteSignal.cs
+++ b/MemoizR.Distributed/RemoteSignal.cs
@@ -26,14 +26,14 @@ public sealed record AdoptedPublication<T>(T Value, long Epoch, CausalityStamp S
 ///    identifiers, not ordered -- the mirror remembers what it abandoned instead of trusting a
 ///    mismatch to mean "newer");
 ///  - a different, non-abandoned epoch signals a peer RESET, but it is committed only by a
-///    payload answering this mirror's own LATEST pull: with unordered epochs, a delayed
-///    payload from a skipped dead incarnation is indistinguishable by inspection from a live
-///    restart, and adopting it would abandon the LIVE epoch and wedge the mirror. An
-///    unsolicited epoch-mismatch payload is therefore discarded and answered with a
-///    verification pull (the response reflects the incarnation that is actually alive), and
-///    committing any epoch change invalidates all in-flight pulls. On a committed reset, held
-///    evidence is discarded, never merged, and <see cref="OnPeerReset"/> runs so the bridge
-///    can resubscribe;
+///    payload answering a pull this mirror issued after its last committed epoch change: with
+///    unordered epochs, a delayed payload from a skipped dead incarnation is indistinguishable
+///    by inspection from a live restart, and adopting it would abandon the LIVE epoch and
+///    wedge the mirror. An unsolicited epoch-mismatch payload is therefore discarded and
+///    answered with a verification pull (the response reflects the incarnation that is
+///    actually alive), and committing an epoch change invalidates the answers of all pulls
+///    still in flight. On a committed reset, held evidence is discarded, never merged, and
+///    <see cref="OnPeerReset"/> runs so the bridge can resubscribe;
 ///  - within an epoch, the publication SEQUENCE totally orders deliveries: anything at or
 ///    below the last adopted sequence is a late or duplicated delivery and is dropped --
 ///    including the dependency-oscillation shapes causality stamps cannot order, and equally
@@ -56,10 +56,14 @@ public sealed class RemoteSignal<T>
     private bool nodeIdPinned;
     private long currentEpoch;
     private long lastSequence;
-    // Incremented when a pull is issued AND when any epoch change commits: an epoch-changing
-    // payload may only commit if it answers the latest generation, so a delayed response from
-    // a pull issued before the mirror learned the current incarnation can never abandon it.
-    private long pullGeneration;
+    // Incremented when any epoch change commits (a reset or the first-contact pin). A pull
+    // captures the generation at issue, and its answer may commit an epoch change only if the
+    // generation is unchanged -- i.e. no epoch change committed since the pull was issued, so
+    // a delayed response from a pull issued before the mirror learned the current incarnation
+    // can never abandon it. Deliberately NOT bumped at pull issue: overlapping verification
+    // pulls must not invalidate each other optimistically, or a failed newer pull would strand
+    // an older pull's perfectly live answer until a heartbeat retries.
+    private long epochGeneration;
     private volatile AdoptedPublication<T>? publication;
 
     private enum AdoptionVerdict { Drop, Adopt, AdoptReset, VerifyByPull }
@@ -117,7 +121,7 @@ public sealed class RemoteSignal<T>
     /// <summary>Pull the host's current truth and adopt it (subject to the ordering rules).</summary>
     public async Task PullAsync()
     {
-        var generation = Interlocked.Increment(ref pullGeneration);
+        var generation = Volatile.Read(ref epochGeneration);
         await AdoptAsync(await pull(), generation);
     }
 
@@ -241,11 +245,11 @@ public sealed class RemoteSignal<T>
             return payload.Sequence > lastSequence ? AdoptionVerdict.Adopt : AdoptionVerdict.Drop;
         }
 
-        // An epoch change: only the answer to the LATEST pull may commit it. An unsolicited
-        // payload gets a verification pull instead; a stale pull answer (a newer pull or an
-        // epoch change happened since it was issued) is just dropped -- the newer pull brings
-        // the live incarnation's truth.
-        if (pulledAtGeneration == Volatile.Read(ref pullGeneration))
+        // An epoch change: only a pull issued after the last committed epoch change may commit
+        // it. An unsolicited payload gets a verification pull instead; a superseded pull answer
+        // (an epoch change committed since it was issued) is just dropped -- whatever committed
+        // is newer knowledge, and the live incarnation keeps advertising.
+        if (pulledAtGeneration == Volatile.Read(ref epochGeneration))
         {
             return AdoptionVerdict.AdoptReset;
         }
@@ -271,7 +275,7 @@ public sealed class RemoteSignal<T>
             // Any committed epoch change (a reset or the first-contact pin) invalidates every
             // in-flight pull: their answers describe a world from before the mirror learned
             // this incarnation, and must not be able to commit another epoch change.
-            Interlocked.Increment(ref pullGeneration);
+            Interlocked.Increment(ref epochGeneration);
         }
 
         currentEpoch = payload.Epoch;

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -84,12 +84,37 @@ public class DistributedPackageTests
         await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref count) > 0); // initial eager advertisement
         var baseline = Volatile.Read(ref count);
 
+        // The publish is detached from the timer callback's flow, so each tick's advertisement
+        // lands asynchronously.
         var clock = new FakeTimeProvider();
         export.StartHeartbeat(TimeSpan.FromSeconds(30), clock);
         clock.Advance(TimeSpan.FromSeconds(30));
-        Assert.Equal(baseline + 1, Volatile.Read(ref count));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref count) == baseline + 1);
         clock.Advance(TimeSpan.FromSeconds(60));
-        Assert.Equal(baseline + 3, Volatile.Read(ref count));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref count) == baseline + 3);
+    }
+
+    [Fact]
+    public async Task Export_PublishStale_MayFeedASameContextSignal()
+    {
+        // An in-process bridge that writes advertisements into a same-context outbox signal:
+        // the publish must run on a detached flow, or the export reaction's lock scope would
+        // flow into the callback and the outbox Set would be refused as a recursive exclusive
+        // acquisition -- silently recorded as LastPublishError, losing the advertisement.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        var outbox = host.CreateEagerRelativeSignal("outbox", 0L);
+        var published = 0;
+        using var export = host.Export(s, async n =>
+        {
+            await outbox.Set(_ => n.Sequence);
+            Interlocked.Increment(ref published);
+        });
+
+        await s.Set(2);
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref published) > 0);
+        Assert.Null(export.LastPublishError);
+        Assert.True(await outbox.Get() >= 1);
     }
 
     // ── consumer side: adoption ordering ─────────────────────────────────────────────────

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -254,6 +254,12 @@ public class DistributedPackageTests
             () => mirror.OnValueAsync(new ValuePayload<int>(1, 1, 1, 1, [0xFF, 0xFF], false)));
         await Assert.ThrowsAsync<ArgumentException>(
             () => mirror.OnValueAsync(new ValuePayload<int>(1, 0, 1, 1, CausalityStamp.Empty.Serialize(), false)));
+
+        // A non-empty stamp whose epoch differs from the header's is a protocol violation: the
+        // ordering and the evidence would describe different incarnations.
+        var mismatched = CausalityStamp.ForSignal(1, 1, epoch: 7).Serialize();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => mirror.OnValueAsync(new ValuePayload<int>(1, 5, 1, 1, mismatched, false)));
     }
 
     // ── the glitch barrier ───────────────────────────────────────────────────────────────

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -843,6 +843,60 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_RestartAdvertisedDuringResubscription_IsVerifiedWhenTheWindowCloses()
+    {
+        // A restart ADVERTISEMENT arrives mid-window. Chasing it immediately would pull the
+        // not-yet-resubscribed channel, whose answer (the old epoch -- a harmless duplicate)
+        // sets no pending verification: the single-shot advert would be lost and the mirror
+        // pinned to the dead incarnation. The advert must be remembered and followed up by
+        // the close's verification pull on the repaired channel.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var epoch3 = 33L;
+        var releaseHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var channelRepaired = false;
+        var hookRuns = 0;
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0,
+            () =>
+            {
+                Interlocked.Increment(ref pulls);
+                // The un-resubscribed channel answers the CURRENT epoch; the repaired channel
+                // answers the live restarted incarnation.
+                return Task.FromResult(Volatile.Read(ref channelRepaired)
+                    ? new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false)
+                    : new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+            },
+            onPeerReset: async () =>
+            {
+                if (Interlocked.Increment(ref hookRuns) == 1)
+                {
+                    await releaseHook.Task;
+                    Volatile.Write(ref channelRepaired, true); // resubscription repairs the channel
+                }
+            });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        // First restart: the verification pull commits epoch2, hook 1 blocks (window open).
+        var delivery = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref hookRuns) == 1);
+        var pullsBeforeAdvert = Volatile.Read(ref pulls);
+
+        // The second restart's single-shot advertisement mid-window: remembered, NOT chased.
+        await mirror.OnStaleAsync(new StaleNotification(1000, epoch3, 1, CausalityStamp.Empty.Serialize()));
+        Assert.Equal(pullsBeforeAdvert, Volatile.Read(ref pulls));
+
+        releaseHook.SetResult();
+        await delivery.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The close's verification pull runs on the repaired channel and adopts the live epoch.
+        await TestHelpers.WaitForConvergenceAsync(() => mirror.Publication?.Epoch == epoch3);
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
     public async Task RemoteSignal_QueuedVerificationHookFailure_IsRecorded()
     {
         // The queued verification pull after a window close can commit ANOTHER reset; if

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -160,6 +160,63 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task Export_Pull_ReattemptsFaultParkedDependencies()
+    {
+        // A dependency that FAULTED keeps its previous verified evidence and parks at
+        // CacheCheck, serving its last good value. The unverifiable-chain refresh must force
+        // it to genuinely re-evaluate: while the fault persists the pull answers honestly
+        // unverifiable, and once healed it answers with the dependency's FRESH value -- never
+        // a verified payload built on the stale parked one.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        var trigger = host.CreateSignal(0);
+        var failing = false;
+        var m1 = host.CreateMemoizR("m1", async () =>
+        {
+            var v = await s.Get();
+            if (Volatile.Read(ref failing))
+            {
+                throw new InvalidOperationException("m1 source down");
+            }
+            return v + 10; // s-dependent: the parked value goes stale when s moves
+        });
+        var m2 = host.CreateMemoizR("m2", async () =>
+        {
+            var t = await trigger.Get();
+            try
+            {
+                return t + await m1.Get() + 100;
+            }
+            catch (InvalidOperationException)
+            {
+                return 999;
+            }
+        });
+
+        Assert.Equal(111, await m2.Get()); // s=1: m1=11, trigger=0
+
+        Volatile.Write(ref failing, true);
+        await s.Set(2);       // m1's honest value is now 12 -- but its evaluation faults
+        await trigger.Set(1); // m2's own computation runs and catches
+        Assert.Equal(999, await m2.Get());
+        Assert.True(m2.Evidence.Unverifiable);
+
+        using var export = host.Export(m2, _ => Task.CompletedTask);
+
+        // While the fault persists, the refresh re-attempts the chain and answers honestly.
+        var stillBroken = await export.PullAsync();
+        Assert.True(stillBroken.Unverifiable);
+        Assert.Equal(999, stillBroken.Value);
+
+        // Once healed, the refresh recomputes the dependency itself: trigger(1) + fresh
+        // m1(12) + 100 -- never a verified payload built on the stale parked 11.
+        Volatile.Write(ref failing, false);
+        var healed = await export.PullAsync();
+        Assert.False(healed.Unverifiable);
+        Assert.Equal(113, healed.Value);
+    }
+
+    [Fact]
     public async Task Export_PublishStale_MayFeedASameContextSignal()
     {
         // An in-process bridge that writes advertisements into a same-context outbox signal:
@@ -672,6 +729,55 @@ public class DistributedPackageTests
         // ... superseding the newer restart's answer, which must be re-verified, not dropped.
         secondAnswer.SetResult(new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
         await delivery3.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(epoch3, mirror.Publication!.Epoch);
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_QueuedVerificationHookFailure_IsRecorded()
+    {
+        // The queued verification pull after a window close can commit ANOTHER reset; if
+        // that reset's OnPeerReset fails there is no delivering caller to surface to -- the
+        // failure must land in LastBackgroundError instead of vanishing (the value is still
+        // adopted, like every hook failure).
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var epoch3 = 33L;
+        var releaseFirstHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hookRuns = 0;
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0,
+            () =>
+            {
+                var n = Interlocked.Increment(ref pulls);
+                return Task.FromResult(n == 1
+                    ? new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false)
+                    : new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+            },
+            onPeerReset: async () =>
+            {
+                if (Interlocked.Increment(ref hookRuns) == 1)
+                {
+                    await releaseFirstHook.Task;
+                    return;
+                }
+                throw new InvalidOperationException("resubscribe to the newest incarnation failed");
+            });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        var delivery = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref hookRuns) == 1);
+
+        // A third incarnation's one-shot delivery is refused mid-window and remembered.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+
+        releaseFirstHook.SetResult(); // hook 1 succeeds; the close queues the verification
+        await delivery.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The queued verification adopts epoch3; its hook throws; the failure is recorded.
+        await TestHelpers.WaitForConvergenceAsync(() => mirror.LastBackgroundError is InvalidOperationException);
         Assert.Equal(epoch3, mirror.Publication!.Epoch);
         Assert.Equal(333, await mirror.Local.Get());
     }

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -734,6 +734,68 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_AfterFailedResubscription_StaleAnswersDoNotSelfSolicit()
+    {
+        // A pull issued during the resubscription window is still in flight when the hook
+        // FAILS. Its delayed answer arrives superseded (the close bumped the generation) --
+        // re-verifying it would actively pull the channel just reported broken, and a dead
+        // epoch answered by that fresh-generation pull could commit. While the channel is
+        // suspect, superseded stale answers are dropped without self-solicitation; a real
+        // delivery (the repaired bridge's advertisement) still verifies and heals normally.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var epoch3 = 33L;
+        var deadEpoch = 99L;
+        var failHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var windowAnswer = new TaskCompletionSource<ValuePayload<int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hookRuns = 0;
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0,
+            () =>
+            {
+                var n = Interlocked.Increment(ref pulls);
+                return n switch
+                {
+                    1 => Task.FromResult(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false)),
+                    2 => windowAnswer.Task,
+                    _ => Task.FromResult(new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false)),
+                };
+            },
+            onPeerReset: async () =>
+            {
+                if (Interlocked.Increment(ref hookRuns) == 1)
+                {
+                    await failHook.Task;
+                    throw new InvalidOperationException("resubscribe transport down");
+                }
+            });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        var delivery = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref hookRuns) == 1);
+
+        // A pull issued inside the window, still awaiting its answer when the hook fails.
+        var windowPull = mirror.PullAsync();
+        failHook.SetResult();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => delivery.WaitAsync(TimeSpan.FromSeconds(10)));
+
+        // The delayed in-window answer (a dead incarnation) arrives superseded: dropped, and
+        // NOT re-verified -- no self-initiated pull touches the broken channel.
+        windowAnswer.SetResult(new ValuePayload<int>(1000, deadEpoch, 7, 999, CausalityStamp.ForSignal(1000, 7, deadEpoch).Serialize(), false));
+        await windowPull.WaitAsync(TimeSpan.FromSeconds(10));
+        await Task.Delay(100);
+        Assert.Equal(2, Volatile.Read(ref pulls));
+        Assert.Equal(epoch2, mirror.Publication!.Epoch);
+
+        // The repaired bridge's advertisement heals normally (and re-trusts the channel).
+        await mirror.OnStaleAsync(new StaleNotification(1000, epoch3, 1, CausalityStamp.Empty.Serialize()));
+        Assert.Equal(epoch3, mirror.Publication!.Epoch);
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
     public async Task RemoteSignal_QueuedVerificationHookFailure_IsRecorded()
     {
         // The queued verification pull after a window close can commit ANOTHER reset; if

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -349,6 +349,29 @@ public class DistributedPackageTests
         Assert.True(await outbox.Get() >= 1);
     }
 
+    [Fact]
+    public async Task Export_RaceOverAMirrorLocal_IsRefused()
+    {
+        // A ConcurrentRace consumes its inputs without populating its own Sources (it wires
+        // observer links only), so the source-chain walk cannot see through it -- the
+        // observer-side walk must refuse the re-export all the same.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        using var export = host.Export(s, _ => Task.CompletedTask);
+
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("m", 0, export.PullAsync);
+        var race = consumer.CreateConcurrentRace(() => mirror.Local.Get(), async (_, r) => r);
+        await race.Get(); // wire the observer links
+        Assert.Throws<InvalidOperationException>(() => consumer.Export(race, _ => Task.CompletedTask));
+
+        // The lazily-wired variant: exported before any evaluation, so creation cannot see the
+        // dependency -- the pull's wire-egress recheck must refuse instead.
+        var lazyRace = consumer.CreateConcurrentRace(() => mirror.Local.Get(), async (_, r) => r);
+        using var lazyExport = consumer.Export(lazyRace, _ => Task.CompletedTask);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => lazyExport.PullAsync());
+    }
+
     // ── consumer side: adoption ordering ─────────────────────────────────────────────────
 
     [Fact]

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -84,6 +84,50 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task Export_ValueTypeSignalThroughItsStampedInterface_Exports()
+    {
+        // A value-type Signal<T>'s stamped interface is IStampedGetR<T> at runtime (the T? in
+        // its declaration is a nullable ANNOTATION on the unconstrained parameter, not
+        // Nullable<T>), so generic bridge code holding the interface exports through the
+        // ordinary generic overload -- pinned here so the interface path stays supported.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(5);
+        IStampedGetR<int> node = s;
+        using var export = host.Export(node, _ => Task.CompletedTask);
+        Assert.Equal(s.Id, export.NodeId);
+
+        var payload = await export.PullAsync();
+        Assert.Equal(5, payload.Value);
+        Assert.False(payload.Unverifiable);
+
+        await s.Set(6);
+        var newer = await export.PullAsync();
+        Assert.Equal(6, newer.Value);
+        Assert.True(newer.Sequence > payload.Sequence);
+    }
+
+    [Fact]
+    public async Task Export_OfANodeDerivedFromAMirror_Throws()
+    {
+        // A memo over a mirror carries stamps captured from the consumer-local trigger, not
+        // the origin's evidence: re-exporting it is the mirror re-export unsoundness one hop
+        // removed.
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"));
+
+        var derived = consumer.CreateMemoizR("derived", async () => await mirror.Local.Get() + 1);
+        await derived.Get(); // wire the sources
+        Assert.Throws<InvalidOperationException>(() => consumer.Export(derived, _ => Task.CompletedTask));
+
+        // A LAZY memo has no wired sources at export time and passes the fail-fast check --
+        // the wire egress catches it: the pull's own read wires the chain before the check.
+        var lazyDerived = consumer.CreateMemoizR("lazy", async () => await mirror.Local.Get() + 2);
+        using var export = consumer.Export(lazyDerived, _ => Task.CompletedTask);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => export.PullAsync());
+    }
+
+    [Fact]
     public void Export_NodeOfAnotherContext_Throws()
     {
         var f1 = new MemoFactory();

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -1,0 +1,330 @@
+using MemoizR.Distributed;
+using Microsoft.Extensions.Time.Testing;
+
+namespace MemoizR.Tests;
+
+// MemoizR.Distributed v0: exports, remote-signal adoption (sequence ordering, epochs,
+// unverifiability) and the self-healing glitch barrier, wired over in-proc delegates.
+public class DistributedPackageTests
+{
+    // ── export side ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_AdvertisesOnValueChange_AndPullAnswersTheSamePublication()
+    {
+        var host = new MemoFactory();
+        var temperature = host.CreateSignal(20.0);
+        var comfort = host.CreateMemoizR("comfort", async () => await temperature.Get() + 1);
+
+        var advertisements = new List<StaleNotification>();
+        using var export = host.Export(comfort, n =>
+        {
+            lock (advertisements) { advertisements.Add(n); }
+            return Task.CompletedTask;
+        });
+
+        await temperature.Set(25.0);
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (advertisements) { return advertisements.Count > 0; } });
+
+        var payload = await export.PullAsync();
+        Assert.Equal(comfort.Id, payload.NodeId);
+        Assert.Equal(26.0, payload.Value);
+        Assert.NotEqual(0, payload.Epoch);
+        Assert.True(payload.Sequence >= 1);
+        Assert.False(payload.Unverifiable);
+
+        // The advertised stamp is a valid v2 payload describing the publication.
+        var stamp = CausalityStamp.Deserialize(payload.Stamp);
+        Assert.True(stamp.TryGetTrigger(temperature.Id, out var trigger));
+        Assert.Equal(1, trigger);
+    }
+
+    [Fact]
+    public async Task Export_SequencesStrictlyIncreasePerPublication()
+    {
+        var host = new MemoFactory();
+        var s = host.CreateSignal(0);
+        using var export = host.Export(s, _ => Task.CompletedTask);
+
+        var first = await export.PullAsync();
+        await s.Set(1);
+        var second = await export.PullAsync();
+        await s.Set(2);
+        var third = await export.PullAsync();
+
+        Assert.True(first.Sequence < second.Sequence);
+        Assert.True(second.Sequence < third.Sequence);
+    }
+
+    [Fact]
+    public void Export_FromStampsDisabledContext_Throws()
+    {
+        var f = new MemoFactory(options: MemoFactoryOptions.DisableCausalityStamps);
+        var s = f.CreateSignal(1);
+        Assert.Throws<InvalidOperationException>(() => f.Export(s, _ => Task.CompletedTask));
+    }
+
+    [Fact]
+    public void Export_NodeOfAnotherContext_Throws()
+    {
+        var f1 = new MemoFactory();
+        var f2 = new MemoFactory();
+        var s = f1.CreateSignal(1);
+        Assert.Throws<ArgumentException>(() => f2.Export(s, _ => Task.CompletedTask));
+    }
+
+    [Fact]
+    public async Task Export_Heartbeat_ReadvertisesOnTheClock()
+    {
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        var count = 0;
+        using var export = host.Export(s, _ => { Interlocked.Increment(ref count); return Task.CompletedTask; });
+
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref count) > 0); // initial eager advertisement
+        var baseline = Volatile.Read(ref count);
+
+        var clock = new FakeTimeProvider();
+        export.StartHeartbeat(TimeSpan.FromSeconds(30), clock);
+        clock.Advance(TimeSpan.FromSeconds(30));
+        Assert.Equal(baseline + 1, Volatile.Read(ref count));
+        clock.Advance(TimeSpan.FromSeconds(60));
+        Assert.Equal(baseline + 3, Volatile.Read(ref count));
+    }
+
+    // ── consumer side: adoption ordering ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoteSignal_AdoptsInOrder_AndDropsLateAndDuplicateDeliveries()
+    {
+        var host = new MemoFactory();
+        var s = host.CreateSignal(10);
+        using var export = host.Export(s, _ => Task.CompletedTask);
+        var oldPayload = await export.PullAsync();
+        await s.Set(20);
+        var newPayload = await export.PullAsync();
+
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0, export.PullAsync);
+
+        await mirror.OnValueAsync(newPayload);
+        Assert.Equal(20, await mirror.Local.Get());
+
+        // A late delivery of the older publication and a duplicate of the current one are both
+        // dropped by the sequence order -- no stamp comparison needed.
+        await mirror.OnValueAsync(oldPayload);
+        Assert.Equal(20, await mirror.Local.Get());
+        await mirror.OnValueAsync(newPayload);
+        Assert.Equal(20, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_SequenceOrdersWhatStampsCannot()
+    {
+        // A dependency set oscillating through empty re-publishes an EARLIER stamp on a NEWER
+        // value; the per-node sequence still orders the publications totally.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        var epoch = 7L;
+        var stamp = CausalityStamp.ForSignal(s.Id, 1, epoch).Serialize();
+        var emptyStamp = CausalityStamp.Empty.Serialize();
+
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0, () => throw new InvalidOperationException("no pull in this test"));
+
+        await mirror.OnValueAsync(new ValuePayload<int>(s.Id, epoch, 1, 100, stamp, false));
+        await mirror.OnValueAsync(new ValuePayload<int>(s.Id, epoch, 2, 200, emptyStamp, false)); // honest empty publication
+        await mirror.OnValueAsync(new ValuePayload<int>(s.Id, epoch, 3, 300, stamp, false));      // same stamp as seq 1, NEWER value
+
+        Assert.Equal(300, await mirror.Local.Get());
+
+        // The late redelivery of seq 1 must not roll the mirror back, even though its stamp
+        // equals the currently held one.
+        await mirror.OnValueAsync(new ValuePayload<int>(s.Id, epoch, 1, 100, stamp, false));
+        Assert.Equal(300, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_StaleHandler_PullsOnlyWhenNotProvablyOld()
+    {
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        using var export = host.Export(s, _ => Task.CompletedTask);
+        var payload = await export.PullAsync();
+
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0, async () =>
+        {
+            Interlocked.Increment(ref pulls);
+            return await export.PullAsync();
+        });
+
+        // Advertisement of an unknown epoch: pull (first contact).
+        await mirror.OnStaleAsync(new StaleNotification(payload.NodeId, payload.Epoch, payload.Sequence, payload.Stamp));
+        Assert.Equal(1, Volatile.Read(ref pulls));
+        Assert.Equal(1, await mirror.Local.Get());
+
+        // The same advertisement again: provably old news (same epoch, sequence not above the
+        // adopted one) -- no pull.
+        await mirror.OnStaleAsync(new StaleNotification(payload.NodeId, payload.Epoch, payload.Sequence, payload.Stamp));
+        Assert.Equal(1, Volatile.Read(ref pulls));
+
+        // A higher sequence: pull.
+        await s.Set(2);
+        var newer = await export.PullAsync();
+        Volatile.Write(ref pulls, 0);
+        await mirror.OnStaleAsync(new StaleNotification(newer.NodeId, newer.Epoch, newer.Sequence, newer.Stamp));
+        Assert.Equal(1, Volatile.Read(ref pulls));
+        Assert.Equal(2, await mirror.Local.Get());
+    }
+
+    // ── consumer side: resets and unverifiability ────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoteSignal_PeerReset_DiscardsEvidence_RunsHook_AndDropsDeadEpochTraffic()
+    {
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var stamp1 = CausalityStamp.ForSignal(1000, 5, epoch1).Serialize();
+        var stamp2 = CausalityStamp.ForSignal(1000, 1, epoch2).Serialize();
+
+        var resets = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"),
+            onPeerReset: () => { Interlocked.Increment(ref resets); return Task.CompletedTask; });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 9, 111, stamp1, false));
+        Assert.Equal(111, await mirror.Local.Get());
+
+        // The restarted peer's sequence starts over BELOW the old one: the epoch change, not
+        // the sequence, is what admits it.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, stamp2, false));
+        Assert.Equal(222, await mirror.Local.Get());
+        Assert.Equal(1, Volatile.Read(ref resets));
+        Assert.Equal(epoch2, mirror.RemoteStamp.Epoch);
+
+        // Late traffic from the dead incarnation -- even with a huge sequence -- is dropped.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 999, 333, stamp1, false));
+        Assert.Equal(222, await mirror.Local.Get());
+        Assert.Equal(1, Volatile.Read(ref resets));
+    }
+
+    [Fact]
+    public async Task RemoteSignal_UnverifiablePayload_BlocksTrust_AndAHigherSequenceHeals()
+    {
+        var epoch = 5L;
+        var verified = CausalityStamp.ForSignal(1000, 1, epoch).Serialize();
+        var empty = CausalityStamp.Empty.Serialize();
+
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"));
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch, 1, 10, verified, false));
+        Assert.False(mirror.Unverifiable);
+        var heldStamp = mirror.RemoteStamp;
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch, 2, 11, empty, true));
+        Assert.True(mirror.Unverifiable);
+        Assert.True(mirror.HasEvidence);
+        Assert.Equal(11, await mirror.Local.Get());
+        // The held stamp of the last VERIFIED adoption is kept for the barrier.
+        Assert.Equal(heldStamp, mirror.RemoteStamp);
+
+        // A late verified delivery from BEFORE the unverifiable spell must not fake a heal.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch, 1, 10, verified, false));
+        Assert.True(mirror.Unverifiable);
+
+        // The recovery is a NEW publication: higher sequence, verified.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch, 3, 12, verified, false));
+        Assert.False(mirror.Unverifiable);
+        Assert.Equal(12, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_RejectsMalformedAndEpochlessPayloads()
+    {
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"));
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => mirror.OnValueAsync(new ValuePayload<int>(1, 1, 1, 1, [0xFF, 0xFF], false)));
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => mirror.OnValueAsync(new ValuePayload<int>(1, 0, 1, 1, CausalityStamp.Empty.Serialize(), false)));
+    }
+
+    // ── the glitch barrier ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Barrier_DetectsGlitch_RepullsLagging_AndRendersConsistentSnapshot()
+    {
+        // Host: two derived nodes over the same signal; consumer mirrors both. Deliver only one
+        // mirror's update after a write: the barrier must not render the torn pair, re-pull the
+        // lagging mirror itself, and render the consistent snapshot.
+        var host = new MemoFactory();
+        var temperature = host.CreateSignal(20.0);
+        var dew = host.CreateMemoizR("dew", async () => await temperature.Get() - 5);
+        var heat = host.CreateMemoizR("heat", async () => await temperature.Get() + 5);
+
+        using var dewExport = host.Export(dew, _ => Task.CompletedTask);
+        using var heatExport = host.Export(heat, _ => Task.CompletedTask);
+
+        var consumer = new MemoFactory();
+        var dewMirror = consumer.CreateRemoteSignal("dew", 0.0, dewExport.PullAsync);
+        var heatMirror = consumer.CreateRemoteSignal("heat", 0.0, heatExport.PullAsync);
+
+        var renders = new List<(double Dew, double Heat)>();
+        var reaction = DistributedBarrier.CreateConsistentReaction(
+            consumer, dewMirror, heatMirror,
+            (d, h) => { lock (renders) { renders.Add((d, h)); } });
+
+        // Initial sync on the pre-write snapshot.
+        await dewMirror.PullAsync();
+        await heatMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((15.0, 25.0)); } });
+
+        // The write; only dew's fresh publication is delivered -- heat is now lagging.
+        await temperature.Set(30.0);
+        await dewMirror.OnValueAsync(await dewExport.PullAsync());
+
+        // The barrier re-pulls heat itself and renders the healed snapshot.
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((25.0, 35.0)); } });
+
+        // The torn pairs (fresh dew with stale heat, or the reverse) must never have rendered.
+        lock (renders)
+        {
+            Assert.DoesNotContain((25.0, 25.0), renders);
+            Assert.DoesNotContain((15.0, 35.0), renders);
+        }
+        GC.KeepAlive(reaction);
+    }
+
+    [Fact]
+    public async Task Barrier_SkipsRendering_WhileAMirrorIsUnverifiable()
+    {
+        var epoch = 5L;
+        var stamp = CausalityStamp.ForSignal(1000, 1, epoch);
+        var consumer = new MemoFactory();
+        var a = consumer.CreateRemoteSignal<int>("a", 0, () => throw new InvalidOperationException("no pull"));
+        var b = consumer.CreateRemoteSignal<int>("b", 0, () => throw new InvalidOperationException("no pull"));
+
+        var renders = 0;
+        var reaction = DistributedBarrier.CreateConsistentReaction(
+            consumer, a, b, (_, _) => Interlocked.Increment(ref renders));
+
+        await a.OnValueAsync(new ValuePayload<int>(1000, epoch, 1, 1, stamp.Serialize(), false));
+        await b.OnValueAsync(new ValuePayload<int>(1001, epoch, 1, 2, CausalityStamp.Empty.Serialize(), true));
+
+        // Give the debounced reaction time to run: it must skip, not render a half-trusted pair.
+        await Task.Delay(100);
+        Assert.Equal(0, Volatile.Read(ref renders));
+
+        // The heal: b's host publishes verified again.
+        await b.OnValueAsync(new ValuePayload<int>(1001, epoch, 2, 3, CausalityStamp.ForSignal(1001, 1, epoch).Serialize(), false));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref renders) > 0);
+        GC.KeepAlive(reaction);
+    }
+}

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -1127,6 +1127,18 @@ public class DistributedPackageTests
         await s.Set(5);
         await qMirror.PullAsync();
         await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((5, 20)); } });
+
+        // The pair moves on with a REAL change (both sides advance consistently), which
+        // expires the affirmation ...
+        await s.Set(6); // half: 2 -> 3, so c recomputes too
+        await qMirror.PullAsync();
+        await cMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((6, 30)); } });
+
+        // ... and a NEW under-claim glitch earns its own heal round and still converges.
+        await s.Set(7); // half stays 3: c scan-skips again
+        await qMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((7, 30)); } });
         GC.KeepAlive(reaction);
     }
 

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -602,6 +602,40 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_FailedLocalWrite_DoesNotAdvanceTheOrdering()
+    {
+        // A bridge that (wrongly) delivers from inside a same-context reaction flow: the
+        // local write is refused as a recursive acquisition and the delivery faults. The
+        // ordering state must not have advanced -- the redelivery from a proper transport
+        // flow must adopt, instead of being duplicate-dropped against a sequence the graph
+        // never published.
+        var epoch = 11L;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"));
+        var payload = new ValuePayload<int>(1000, epoch, 1, 111, CausalityStamp.ForSignal(1000, 1, epoch).Serialize(), false);
+
+        var poke = consumer.CreateSignal(0);
+        Task? adoptInsideReaction = null;
+        var reactionRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reaction = consumer.BuildReaction().CreateReaction(poke, _ =>
+        {
+            adoptInsideReaction ??= mirror.OnValueAsync(payload);
+            reactionRan.TrySetResult();
+        });
+
+        await reactionRan.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => adoptInsideReaction!);
+        Assert.False(mirror.HasEvidence);
+
+        // The redelivery from a clean flow adopts.
+        await mirror.OnValueAsync(payload);
+        Assert.Equal(111, await mirror.Local.Get());
+        Assert.Equal(epoch, mirror.Publication!.Epoch);
+        GC.KeepAlive(reaction);
+    }
+
+    [Fact]
     public async Task RemoteSignal_SupersededNewerRestartAnswer_IsReverified_NotDropped()
     {
         // Two racing verification pulls under one generation: the OLDER restart's answer

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -65,6 +65,25 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public void Export_OfAMirrorsLocalSignal_Throws()
+    {
+        // Re-exporting a mirror would advertise its LOCAL adoption stamps as evidence (the
+        // origin's evidence lives beside the graph in Publication): two re-exported mirrors
+        // of one origin host carry disjoint local stamps, so a downstream barrier would
+        // render torn origin snapshots as consistent. Multi-hop bridging is wire-v3 work.
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"));
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => consumer.Export(mirror.Local, _ => Task.CompletedTask));
+        Assert.Contains("re-exported", ex.Message);
+
+        // An ordinary eager signal of the same runtime type still exports.
+        var plain = consumer.CreateEagerRelativeSignal("plain", 0);
+        using var export = consumer.Export(plain, _ => Task.CompletedTask);
+    }
+
+    [Fact]
     public void Export_NodeOfAnotherContext_Throws()
     {
         var f1 = new MemoFactory();

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -160,6 +160,53 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task Export_Pull_NeverServesFaultParkedStateAsCurrentTruth()
+    {
+        // An already-published export goes CacheCheck and a dependency faults during the
+        // parent scan: the read serves the last good VERIFIED box and parks non-clean.
+        // Shipping that as current truth would let a new mirror adopt stale state as trusted
+        // while the host cannot actually compute a current value -- the pull must force a
+        // real re-evaluation instead: a FAULTED pull while broken (the wire contract's
+        // honest answer), the fresh verified truth once healed.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        var failing = false;
+        var m1 = host.CreateMemoizR("m1", async () =>
+        {
+            var v = await s.Get();
+            if (Volatile.Read(ref failing))
+            {
+                throw new InvalidOperationException("m1 source down");
+            }
+            return v + 10;
+        });
+        var m2 = host.CreateMemoizR("m2", async () => await m1.Get() + 100); // no catch: faults propagate
+
+        Assert.Equal(111, await m2.Get()); // published verified, seq 1
+        var export = host.Export(m2, _ => Task.CompletedTask);
+
+        // Stop the export's own staleness chase: the pull below models a transport request
+        // racing AHEAD of any local read after the write -- the only window in which the
+        // fault-park is still observable (a second read's scan launders it to clean-serving-
+        // last-good, which the payload then honestly stamps as old).
+        export.Dispose();
+        Volatile.Write(ref failing, true);
+        await s.Set(2); // the chain is dirty; every re-evaluation now faults
+
+        // The pull's own scan suppresses m1's fault and would serve the stale verified 111 as
+        // current truth; the refresh detects the non-clean park and forces a REAL
+        // re-evaluation, whose fault propagates -- the wire contract's honest answer.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => export.PullAsync());
+
+        // Healed and re-published: the pull answers the fresh current truth.
+        Volatile.Write(ref failing, false);
+        await s.Set(3);
+        var healed = await export.PullAsync();
+        Assert.False(healed.Unverifiable);
+        Assert.Equal(113, healed.Value); // m1 = 3 + 10, m2 = 13 + 100
+    }
+
+    [Fact]
     public async Task Export_Pull_ReattemptsFaultParkedDependencies()
     {
         // A dependency that FAULTED keeps its previous verified evidence and parks at

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -189,18 +189,23 @@ public class DistributedPackageTests
         var stamp1 = CausalityStamp.ForSignal(1000, 5, epoch1).Serialize();
         var stamp2 = CausalityStamp.ForSignal(1000, 1, epoch2).Serialize();
 
+        // The host's current truth, as the mirror's verification pull will see it.
+        var hostPayload = new ValuePayload<int>(1000, epoch1, 9, 111, stamp1, false);
+
         var resets = 0;
         var consumer = new MemoFactory();
         var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
-            () => throw new InvalidOperationException("no pull in this test"),
+            () => Task.FromResult(hostPayload),
             onPeerReset: () => { Interlocked.Increment(ref resets); return Task.CompletedTask; });
 
-        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 9, 111, stamp1, false));
+        await mirror.OnValueAsync(hostPayload);
         Assert.Equal(111, await mirror.Local.Get());
 
         // The restarted peer's sequence starts over BELOW the old one: the epoch change, not
-        // the sequence, is what admits it.
-        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, stamp2, false));
+        // the sequence, is what admits it -- committed through the verification pull that
+        // answers the unsolicited epoch-mismatch delivery.
+        hostPayload = new ValuePayload<int>(1000, epoch2, 1, 222, stamp2, false);
+        await mirror.OnValueAsync(hostPayload);
         Assert.Equal(222, await mirror.Local.Get());
         Assert.Equal(1, Volatile.Read(ref resets));
         Assert.Equal(epoch2, mirror.RemoteStamp.Epoch);
@@ -349,14 +354,14 @@ public class DistributedPackageTests
         // duplicate -- wedging the mirror on the old value until an unrelated new publication.
         var epoch1 = 11L;
         var epoch2 = 22L;
+        var resetPayload = new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false);
         var consumer = new MemoFactory();
         var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
-            () => throw new InvalidOperationException("no pull in this test"),
+            () => Task.FromResult(resetPayload),
             onPeerReset: () => throw new InvalidOperationException("resubscribe transport down"));
 
         await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
 
-        var resetPayload = new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false);
         await Assert.ThrowsAsync<InvalidOperationException>(() => mirror.OnValueAsync(resetPayload));
 
         // The reset payload WAS adopted; only the resubscription failed.
@@ -393,6 +398,85 @@ public class DistributedPackageTests
             .WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.Equal(999, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_DelayedPayloadFromASkippedIncarnation_CannotAbandonTheLiveEpoch()
+    {
+        // The host restarted twice and the mirror never saw the middle incarnation, so that
+        // epoch is not in the abandoned set -- and with unordered random epochs, a delayed
+        // payload from it is indistinguishable by inspection from a live restart. Adopting it
+        // directly would abandon the LIVE epoch and drop all of its future traffic, wedging
+        // the mirror on a dead incarnation. Epoch changes therefore commit only through the
+        // mirror's own latest pull, which answers with the live incarnation's truth.
+        var deadEpoch = 22L;
+        var liveEpoch = 33L;
+        var hostSequence = 2L;
+        var hostValue = 999;
+
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0, () =>
+        {
+            Interlocked.Increment(ref pulls);
+            return Task.FromResult(new ValuePayload<int>(
+                1000, liveEpoch, hostSequence, hostValue, CausalityStamp.ForSignal(1000, hostSequence, liveEpoch).Serialize(), false));
+        });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, liveEpoch, 1, 300, CausalityStamp.ForSignal(1000, 1, liveEpoch).Serialize(), false));
+        Assert.Equal(300, await mirror.Local.Get());
+
+        // The delayed dead-incarnation payload: discarded, answered by one verification pull.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, deadEpoch, 7, 200, CausalityStamp.ForSignal(1000, 7, deadEpoch).Serialize(), false));
+        Assert.Equal(1, Volatile.Read(ref pulls));
+        Assert.Equal(999, await mirror.Local.Get()); // the pull's answer, never the dead value
+        Assert.Equal(liveEpoch, mirror.Publication!.Epoch);
+
+        // The live epoch keeps flowing -- the mirror is not wedged.
+        hostSequence = 3;
+        hostValue = 1000;
+        await mirror.OnStaleAsync(new StaleNotification(1000, liveEpoch, 3, CausalityStamp.Empty.Serialize()));
+        Assert.Equal(1000, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_RejectsPayloadsRoutedToTheWrongMirror()
+    {
+        // On a multiplexed bridge, a payload routed to the wrong mirror must not adopt: it
+        // would replace this mirror's value with a sibling export's and advance the sequence
+        // order with the sibling's counter, so the intended node's next payloads would drop as
+        // old news.
+        var epoch = 5L;
+        var consumer = new MemoFactory();
+
+        var pulls = 0;
+        var bound = consumer.CreateRemoteSignal("bound", 0,
+            () =>
+            {
+                Interlocked.Increment(ref pulls);
+                return Task.FromResult(new ValuePayload<int>(1000, epoch, 9, 9, CausalityStamp.ForSignal(1000, 9, epoch).Serialize(), false));
+            },
+            nodeId: 1000);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => bound.OnValueAsync(new ValuePayload<int>(2000, epoch, 1, 5, CausalityStamp.ForSignal(2000, 1, epoch).Serialize(), false)));
+        Assert.False(bound.HasEvidence);
+
+        await bound.OnValueAsync(new ValuePayload<int>(1000, epoch, 1, 10, CausalityStamp.ForSignal(1000, 1, epoch).Serialize(), false));
+        Assert.Equal(10, await bound.Local.Get());
+
+        // A foreign advertisement on a broadcast bus is ignored, not treated as an error --
+        // and it must not trigger a pull.
+        await bound.OnStaleAsync(new StaleNotification(2000, epoch, 50, CausalityStamp.Empty.Serialize()));
+        Assert.Equal(0, Volatile.Read(ref pulls));
+
+        // Without an explicit id, the first delivered payload pins the binding.
+        var pinned = consumer.CreateRemoteSignal<int>("pinned", 0,
+            () => throw new InvalidOperationException("no pull in this test"));
+        await pinned.OnValueAsync(new ValuePayload<int>(1000, epoch, 1, 10, CausalityStamp.ForSignal(1000, 1, epoch).Serialize(), false));
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => pinned.OnValueAsync(new ValuePayload<int>(2000, epoch, 2, 20, CausalityStamp.ForSignal(2000, 2, epoch).Serialize(), false)));
+        Assert.Equal(10, await pinned.Local.Get());
     }
 
     [Fact]

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -129,25 +129,25 @@ public class DistributedPackageTests
                 return 999; // the caught-fault fallback: published as unverifiable
             }
         });
-        using var export = host.Export(m2, _ => Task.CompletedTask);
-
         Assert.Equal(111, await m2.Get());
-        var baseline = await export.PullAsync();
-        Assert.False(baseline.Unverifiable);
 
+        // The export is created only AFTER the poisoned state is established: an export
+        // reaction chases invalidations on a detached flow, and on a loaded runner it can
+        // reach the faulting m1 first -- m1 then falls back to serve-last-good and the test's
+        // own m2 evaluation would see a healthy cached m1 instead of catching the fault.
         Volatile.Write(ref failing, true);
         await s.Set(2);       // dirties m1, whose evaluation now faults
         await trigger.Set(1); // dirties m2 directly, so its own computation runs and catches
         Assert.Equal(999, await m2.Get());
-        Volatile.Write(ref failing, false); // m1's next evaluation heals to the SAME 11
+        Assert.True(m2.Evidence.Unverifiable);
+        Volatile.Write(ref failing, false); // the dependency has healed
 
-        // The sticky shape: m2 committed its fallback CLEAN with no-claim evidence, and stays
-        // that way through quiescence -- nothing is left to re-dirty it.
-        await TestHelpers.WaitForConvergenceAsync(() => m2.Evidence.Unverifiable);
+        // The sticky shape: m2 committed its fallback CLEAN with no-claim evidence, and
+        // nothing is left to re-dirty it.
+        using var export = host.Export(m2, _ => Task.CompletedTask);
         var payload = await export.PullAsync();
         Assert.False(payload.Unverifiable);
         Assert.Equal(112, payload.Value); // trigger(1) + healed m1(11) + 100
-        Assert.True(payload.Sequence > baseline.Sequence);
         Assert.False(m2.Evidence.Unverifiable);
 
         // The consumer-side heal completes: the fresh publication has a higher sequence, so

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -95,6 +95,71 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task Export_Pull_RefreshesAStickyUnverifiablePublication()
+    {
+        // Unverifiability can outlive its cause: a memo that catches a faulted dependency
+        // publishes its fallback with no-claim evidence and commits CLEAN (a fault is not a
+        // Set; nothing bumped its generation), and nothing ever re-dirties it once the
+        // dependency heals without a value change. Served on a pull, the consumer's mirror
+        // drops the unchanged publication as a duplicate and stays unverifiable forever (the
+        // barrier never renders). A pull must instead force a fresh evaluation of the
+        // unverifiable chain and answer with the host's current best claim.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(1);
+        var trigger = host.CreateSignal(0);
+        var failing = false;
+        var m1 = host.CreateMemoizR("m1", async () =>
+        {
+            var v = await s.Get();
+            if (Volatile.Read(ref failing))
+            {
+                throw new InvalidOperationException("m1 source down");
+            }
+            return v - v + 11; // always 11, still depends on s
+        });
+        var m2 = host.CreateMemoizR("m2", async () =>
+        {
+            var t = await trigger.Get();
+            try
+            {
+                return t + await m1.Get() + 100;
+            }
+            catch (InvalidOperationException)
+            {
+                return 999; // the caught-fault fallback: published as unverifiable
+            }
+        });
+        using var export = host.Export(m2, _ => Task.CompletedTask);
+
+        Assert.Equal(111, await m2.Get());
+        var baseline = await export.PullAsync();
+        Assert.False(baseline.Unverifiable);
+
+        Volatile.Write(ref failing, true);
+        await s.Set(2);       // dirties m1, whose evaluation now faults
+        await trigger.Set(1); // dirties m2 directly, so its own computation runs and catches
+        Assert.Equal(999, await m2.Get());
+        Volatile.Write(ref failing, false); // m1's next evaluation heals to the SAME 11
+
+        // The sticky shape: m2 committed its fallback CLEAN with no-claim evidence, and stays
+        // that way through quiescence -- nothing is left to re-dirty it.
+        await TestHelpers.WaitForConvergenceAsync(() => m2.Evidence.Unverifiable);
+        var payload = await export.PullAsync();
+        Assert.False(payload.Unverifiable);
+        Assert.Equal(112, payload.Value); // trigger(1) + healed m1(11) + 100
+        Assert.True(payload.Sequence > baseline.Sequence);
+        Assert.False(m2.Evidence.Unverifiable);
+
+        // The consumer-side heal completes: the fresh publication has a higher sequence, so
+        // the mirror adopts it and stops being unverifiable.
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("m2", 0, export.PullAsync);
+        await mirror.OnValueAsync(payload);
+        Assert.False(mirror.Unverifiable);
+        Assert.Equal(112, await mirror.Local.Get());
+    }
+
+    [Fact]
     public async Task Export_PublishStale_MayFeedASameContextSignal()
     {
         // An in-process bridge that writes advertisements into a same-context outbox signal:

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -574,6 +574,45 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task Barrier_UnderclaimedEvidence_AffirmedByRepull_StillRenders()
+    {
+        // The core's documented conservative under-claim: a scan-skipped recompute (a parent
+        // recomputed to an unchanged value) keeps an OLDER stamp -- and the same publication
+        // sequence -- while its value stays valid. The resulting stamp disagreement is a
+        // spurious glitch the re-pull cannot heal (the pull answers with the identical
+        // publication, dropped as a duplicate). The barrier must not stay blocked: a re-pull
+        // round that changes nothing is both hosts AFFIRMING their current truth, and the
+        // affirmed pair renders.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(4);
+        var q = host.CreateMemoizR("q", async () => await s.Get());
+        var half = host.CreateMemoizR("half", async () => await s.Get() / 2);
+        var c = host.CreateMemoizR("c", async () => await half.Get() * 10);
+        using var qExport = host.Export(q, _ => Task.CompletedTask);
+        using var cExport = host.Export(c, _ => Task.CompletedTask);
+
+        var consumer = new MemoFactory();
+        var qMirror = consumer.CreateRemoteSignal("q", 0, qExport.PullAsync);
+        var cMirror = consumer.CreateRemoteSignal("c", 0, cExport.PullAsync);
+
+        var renders = new List<(int Q, int C)>();
+        var reaction = DistributedBarrier.CreateConsistentReaction(
+            consumer, qMirror, cMirror, (vq, vc) => { lock (renders) { renders.Add((vq, vc)); } });
+
+        await qMirror.PullAsync();
+        await cMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((4, 20)); } });
+
+        // s: 4 -> 5. q recomputes (4 -> 5, fresh stamp); half recomputes to the SAME 2, so c's
+        // scan skips the recompute and keeps its old stamp and sequence. Deliver only q's
+        // update: the barrier sees the spurious glitch, re-pulls, both hosts affirm, renders.
+        await s.Set(5);
+        await qMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((5, 20)); } });
+        GC.KeepAlive(reaction);
+    }
+
+    [Fact]
     public async Task Barrier_ThrowingGlitchCallback_StillHeals()
     {
         // onGlitch is diagnostics only: a throwing sink (a logger that is itself down) must

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -309,6 +309,172 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_Publication_BindsValueAndEvidenceAtomically()
+    {
+        // The barrier's contract: one adopted publication is ONE snapshot -- value, header
+        // epoch and stamp never observable in a torn combination.
+        var epoch = 5L;
+        var verified = CausalityStamp.ForSignal(1000, 1, epoch);
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"));
+
+        Assert.Null(mirror.Publication);
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch, 1, 10, verified.Serialize(), false));
+        var publication = mirror.Publication;
+        Assert.NotNull(publication);
+        Assert.Equal(10, publication.Value);
+        Assert.Equal(epoch, publication.Epoch);
+        Assert.Equal(verified, publication.Stamp);
+        Assert.False(publication.Unverifiable);
+
+        // An unverifiable adoption publishes the NEW value with the HELD verified stamp, still
+        // as one snapshot.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch, 2, 11, CausalityStamp.Empty.Serialize(), true));
+        publication = mirror.Publication;
+        Assert.NotNull(publication);
+        Assert.Equal(11, publication.Value);
+        Assert.Equal(epoch, publication.Epoch);
+        Assert.Equal(verified, publication.Stamp);
+        Assert.True(publication.Unverifiable);
+    }
+
+    [Fact]
+    public async Task RemoteSignal_ThrowingResetHook_LeavesTheValueAdopted_NotWedged()
+    {
+        // A resubscription hook failure surfaces to the delivering caller, but the adoption
+        // itself must have committed: otherwise the ordering state would claim the sequence
+        // while the local signal never published, and every redelivery would be dropped as a
+        // duplicate -- wedging the mirror on the old value until an unrelated new publication.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal<int>("mirror", 0,
+            () => throw new InvalidOperationException("no pull in this test"),
+            onPeerReset: () => throw new InvalidOperationException("resubscribe transport down"));
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        var resetPayload = new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => mirror.OnValueAsync(resetPayload));
+
+        // The reset payload WAS adopted; only the resubscription failed.
+        Assert.Equal(222, await mirror.Local.Get());
+        Assert.Equal(epoch2, mirror.RemoteStamp.Epoch);
+
+        // Its redelivery is an ordinary duplicate (no reset, no hook, no throw) ...
+        await mirror.OnValueAsync(resetPayload);
+        Assert.Equal(222, await mirror.Local.Get());
+
+        // ... and newer publications keep flowing.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 2, 333, CausalityStamp.ForSignal(1000, 2, epoch2).Serialize(), false));
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_ResetHook_MayPullTheSameMirror()
+    {
+        // The documented resubscribe path: a bridge answering a reset by pulling the mirror's
+        // current truth. The hook runs outside the adoption gate, so the nested pull re-enters
+        // the adoption path instead of deadlocking on the gate.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        RemoteSignal<int>? mirror = null;
+        var consumer = new MemoFactory();
+        mirror = consumer.CreateRemoteSignal("mirror", 0,
+            () => Task.FromResult(new ValuePayload<int>(1000, epoch2, 2, 999, CausalityStamp.ForSignal(1000, 2, epoch2).Serialize(), false)),
+            onPeerReset: () => mirror!.PullAsync());
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        // A deadlock here must fail the test, not hang the suite.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false))
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(999, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task Barrier_HostRestartWithEmptyStamp_NeverRendersAcrossIncarnations()
+    {
+        // A restarted host's first publication can carry an honestly-EMPTY stamp, and empty
+        // stamps are vacuously consistent with anything -- the barrier must still refuse to
+        // combine it with the other mirror's pre-restart state (the header epoch, not the
+        // stamp, carries the incarnation identity), and must re-pull BOTH sides to converge.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var consumer = new MemoFactory();
+        var a = consumer.CreateRemoteSignal("a", 0,
+            () => Task.FromResult(new ValuePayload<int>(1000, epoch2, 1, 10, CausalityStamp.Empty.Serialize(), false)));
+        var b = consumer.CreateRemoteSignal("b", 0,
+            () => Task.FromResult(new ValuePayload<int>(1001, epoch2, 1, 20, CausalityStamp.ForSignal(1001, 1, epoch2).Serialize(), false)));
+
+        var renders = new List<(int A, int B)>();
+        var reaction = DistributedBarrier.CreateConsistentReaction(
+            consumer, a, b, (va, vb) => { lock (renders) { renders.Add((va, vb)); } });
+
+        // Pre-restart snapshot: disjoint verified stamps of the same incarnation.
+        await a.OnValueAsync(new ValuePayload<int>(1000, epoch1, 1, 1, CausalityStamp.ForSignal(1000, 1, epoch1).Serialize(), false));
+        await b.OnValueAsync(new ValuePayload<int>(1001, epoch1, 1, 2, CausalityStamp.ForSignal(1001, 1, epoch1).Serialize(), false));
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((1, 2)); } });
+
+        // The restart: only mirror a receives the new incarnation's (empty-stamped) truth.
+        await a.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 10, CausalityStamp.Empty.Serialize(), false));
+
+        // The barrier re-pulls both sides itself and renders the post-restart snapshot.
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((10, 20)); } });
+
+        // Cross-incarnation mixes must never have rendered.
+        lock (renders)
+        {
+            Assert.DoesNotContain((10, 2), renders);
+            Assert.DoesNotContain((1, 20), renders);
+        }
+        GC.KeepAlive(reaction);
+    }
+
+    [Fact]
+    public async Task Barrier_ThrowingGlitchCallback_StillHeals()
+    {
+        // onGlitch is diagnostics only: a throwing sink (a logger that is itself down) must
+        // not abort the reaction before the re-pull is scheduled. The failure is reported to
+        // onRepullError and the barrier heals regardless.
+        var host = new MemoFactory();
+        var temperature = host.CreateSignal(20.0);
+        var dew = host.CreateMemoizR("dew", async () => await temperature.Get() - 5);
+        var heat = host.CreateMemoizR("heat", async () => await temperature.Get() + 5);
+        using var dewExport = host.Export(dew, _ => Task.CompletedTask);
+        using var heatExport = host.Export(heat, _ => Task.CompletedTask);
+
+        var consumer = new MemoFactory();
+        var dewMirror = consumer.CreateRemoteSignal("dew", 0.0, dewExport.PullAsync);
+        var heatMirror = consumer.CreateRemoteSignal("heat", 0.0, heatExport.PullAsync);
+
+        var renders = new List<(double Dew, double Heat)>();
+        var reported = new List<Exception>();
+        var reaction = DistributedBarrier.CreateConsistentReaction(
+            consumer, dewMirror, heatMirror,
+            (d, h) => { lock (renders) { renders.Add((d, h)); } },
+            onRepullError: ex => { lock (reported) { reported.Add(ex); } },
+            onGlitch: (_, _) => throw new InvalidOperationException("glitch sink down"));
+
+        await dewMirror.PullAsync();
+        await heatMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((15.0, 25.0)); } });
+
+        await temperature.Set(30.0);
+        await dewMirror.OnValueAsync(await dewExport.PullAsync());
+
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((25.0, 35.0)); } });
+        lock (reported)
+        {
+            Assert.Contains(reported, ex => ex is InvalidOperationException { Message: "glitch sink down" });
+        }
+        GC.KeepAlive(reaction);
+    }
+
+    [Fact]
     public async Task Barrier_SkipsRendering_WhileAMirrorIsUnverifiable()
     {
         var epoch = 5L;

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -546,6 +546,62 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_EpochChangeRefusedDuringResubscription_IsVerifiedWhenTheWindowCloses()
+    {
+        // The peer restarts AGAIN while the previous reset's resubscription hook is still
+        // running. The mid-window delivery is refused (it may have travelled the dead
+        // channel) -- but it may have been the new incarnation's ONLY advertisement, so
+        // closing the window must answer it with one fresh verification pull instead of
+        // pinning the mirror to the now-dead epoch. Hook runs stay strictly sequential.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var epoch3 = 33L;
+        var releaseFirstHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hookRuns = 0;
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0,
+            () =>
+            {
+                var n = Interlocked.Increment(ref pulls);
+                return Task.FromResult(n == 1
+                    // The verification pull that commits the first reset (epoch1 -> epoch2).
+                    ? new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false)
+                    // Every later pull answers the live truth: the second restart's incarnation.
+                    : new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+            },
+            onPeerReset: async () =>
+            {
+                if (Interlocked.Increment(ref hookRuns) == 1)
+                {
+                    await releaseFirstHook.Task;
+                }
+            });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        // First restart: the unsolicited delivery triggers the verification pull, the reset
+        // commits, and hook 1 blocks -- the resubscription window is open.
+        var delivery = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref hookRuns) == 1);
+
+        // Second restart mid-resubscription: its single-shot delivery is refused (and no
+        // second hook starts -- windows are single-flight), but remembered.
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+        Assert.Equal(epoch2, mirror.Publication!.Epoch);
+        Assert.Equal(1, Volatile.Read(ref hookRuns));
+
+        releaseFirstHook.SetResult();
+        await delivery.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Closing the window verifies the refused epoch change by pull and adopts the live
+        // incarnation, running its hook in sequence.
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref hookRuns) == 2);
+        Assert.Equal(epoch3, mirror.Publication!.Epoch);
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
     public async Task RemoteSignal_DelayedPayloadFromASkippedIncarnation_CannotAbandonTheLiveEpoch()
     {
         // The host restarted twice and the mirror never saw the middle incarnation, so that

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -440,6 +440,36 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_FailedNewerPull_DoesNotStrandAnOlderPullsLiveAnswer()
+    {
+        // Two verification pulls overlap and the newer one faults. The older pull's answer
+        // still carries the live incarnation's truth, and no epoch change committed since it
+        // was issued, so it must commit -- invalidating older pulls optimistically at issue
+        // time would defer this recovery to an unrelated heartbeat or advertisement.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var firstAnswer = new TaskCompletionSource<ValuePayload<int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0, () =>
+            Interlocked.Increment(ref pulls) == 1
+                ? firstAnswer.Task
+                : throw new InvalidOperationException("transport blip"));
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        var olderPull = mirror.PullAsync();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => mirror.PullAsync());
+
+        // The host restarted; the older pull's answer reflects the live incarnation.
+        firstAnswer.SetResult(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await olderPull.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(222, await mirror.Local.Get());
+        Assert.Equal(epoch2, mirror.Publication!.Epoch);
+    }
+
+    [Fact]
     public async Task RemoteSignal_RejectsPayloadsRoutedToTheWrongMirror()
     {
         // On a multiplexed bridge, a payload routed to the wrong mirror must not adopt: it

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -491,6 +491,61 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_StaleEpochAnswer_DuringResubscription_CannotAbandonTheJustAdoptedEpoch()
+    {
+        // While a reset's OnPeerReset resubscription is in flight, the pull channel may still
+        // point at the dead incarnation. An epoch-changing answer from a pull issued inside
+        // that window must be refused: committing it would abandon the epoch the mirror JUST
+        // adopted and wedge it on a dead incarnation.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var deadEpoch = 33L;
+        var hookStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0,
+            () =>
+            {
+                var n = Interlocked.Increment(ref pulls);
+                return Task.FromResult(n switch
+                {
+                    // The verification pull that commits the reset to epoch2.
+                    1 => new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false),
+                    // The not-yet-resubscribed channel answers a window-issued pull with a
+                    // dead incarnation's payload.
+                    2 => new ValuePayload<int>(1000, deadEpoch, 9, 999, CausalityStamp.ForSignal(1000, 9, deadEpoch).Serialize(), false),
+                    // The live truth, after the window closed.
+                    _ => new ValuePayload<int>(1000, epoch2, 3, 333, CausalityStamp.ForSignal(1000, 3, epoch2).Serialize(), false),
+                });
+            },
+            onPeerReset: async () =>
+            {
+                hookStarted.TrySetResult();
+                await releaseHook.Task;
+            });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        // Unsolicited epoch change -> verification pull commits epoch2 -> the hook starts.
+        var delivery = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await hookStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // A pull issued inside the resubscription window: its dead-incarnation answer is
+        // refused, and the just-adopted live epoch survives.
+        await mirror.PullAsync().WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(epoch2, mirror.Publication!.Epoch);
+        Assert.Equal(222, await mirror.Local.Get());
+
+        releaseHook.SetResult();
+        await delivery.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The mirror is not stuck: the live epoch keeps flowing after the window closes.
+        await mirror.OnStaleAsync(new StaleNotification(1000, epoch2, 3, CausalityStamp.Empty.Serialize()));
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
     public async Task RemoteSignal_DelayedPayloadFromASkippedIncarnation_CannotAbandonTheLiveEpoch()
     {
         // The host restarted twice and the mirror never saw the middle incarnation, so that
@@ -673,6 +728,42 @@ public class DistributedPackageTests
         // update: the barrier sees the spurious glitch, re-pulls, both hosts affirm, renders.
         await s.Set(5);
         await qMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((5, 20)); } });
+        GC.KeepAlive(reaction);
+    }
+
+    [Fact]
+    public async Task Barrier_WithAReRacingExport_StillAffirmsAndRenders()
+    {
+        // A ConcurrentRace is non-memoized: every pull re-races and publishes an equal-content
+        // payload under a FRESH sequence. The heal round's "nothing changed" check must
+        // compare publication content, not references -- reference identity would refuse the
+        // affirmation every round and spin re-pulls forever instead of rendering.
+        var host = new MemoFactory();
+        var s = host.CreateSignal(4);
+        var race = host.CreateConcurrentRace(s.Get, async (_, r) => r);
+        var half = host.CreateMemoizR("half", async () => await s.Get() / 2);
+        var c = host.CreateMemoizR("c", async () => await half.Get() * 10);
+        using var raceExport = host.Export(race, _ => Task.CompletedTask);
+        using var cExport = host.Export(c, _ => Task.CompletedTask);
+
+        var consumer = new MemoFactory();
+        var raceMirror = consumer.CreateRemoteSignal("race", 0, raceExport.PullAsync);
+        var cMirror = consumer.CreateRemoteSignal("c", 0, cExport.PullAsync);
+
+        var renders = new List<(int Race, int C)>();
+        var reaction = DistributedBarrier.CreateConsistentReaction(
+            consumer, raceMirror, cMirror, (r, v) => { lock (renders) { renders.Add((r, v)); } });
+
+        await raceMirror.PullAsync();
+        await cMirror.PullAsync();
+        await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((4, 20)); } });
+
+        // s: 4 -> 5. The race re-evaluates to 5 with a fresh stamp; c's scan-skip keeps its
+        // old stamp. Deliver only the race's update: a spurious glitch whose every re-pull of
+        // the race answers equal content under a new sequence -- it must still affirm.
+        await s.Set(5);
+        await raceMirror.PullAsync();
         await TestHelpers.WaitForConvergenceAsync(() => { lock (renders) { return renders.Contains((5, 20)); } });
         GC.KeepAlive(reaction);
     }

--- a/MemoizR.Tests/DistributedPackageTests.cs
+++ b/MemoizR.Tests/DistributedPackageTests.cs
@@ -602,6 +602,99 @@ public class DistributedPackageTests
     }
 
     [Fact]
+    public async Task RemoteSignal_SupersededNewerRestartAnswer_IsReverified_NotDropped()
+    {
+        // Two racing verification pulls under one generation: the OLDER restart's answer
+        // commits first (it was live when it answered), superseding the newer restart's
+        // answer. Dropping that answer silently would pin the mirror to the now-dead epoch
+        // when its delivery was a one-shot -- it must re-enter the verification path instead.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var epoch3 = 33L;
+        var firstAnswer = new TaskCompletionSource<ValuePayload<int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondAnswer = new TaskCompletionSource<ValuePayload<int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0, () =>
+            Interlocked.Increment(ref pulls) switch
+            {
+                1 => firstAnswer.Task,
+                2 => secondAnswer.Task,
+                // The re-verification and anything later answers the live incarnation.
+                _ => Task.FromResult(new ValuePayload<int>(1000, epoch3, 2, 333, CausalityStamp.ForSignal(1000, 2, epoch3).Serialize(), false)),
+            });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        // Two one-shot deliveries from two successive restarts, each triggering a pull.
+        var delivery2 = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        var delivery3 = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+
+        // The older restart's answer arrives first and commits (it was live at answer time)...
+        firstAnswer.SetResult(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await delivery2.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(epoch2, mirror.Publication!.Epoch);
+
+        // ... superseding the newer restart's answer, which must be re-verified, not dropped.
+        secondAnswer.SetResult(new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+        await delivery3.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(epoch3, mirror.Publication!.Epoch);
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
+    public async Task RemoteSignal_FailedResubscription_DoesNotSolicitTheBrokenChannel()
+    {
+        // The peer restarts again mid-resubscription AND the hook then fails: the channel was
+        // just reported broken, so closing the window must NOT actively pull it -- soliciting
+        // it could commit exactly the stale answers the window exists to refuse. Recovery is
+        // the bridge's own retry plus the next advertisement, which heals normally.
+        var epoch1 = 11L;
+        var epoch2 = 22L;
+        var epoch3 = 33L;
+        var failFirstHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hookRuns = 0;
+        var pulls = 0;
+        var consumer = new MemoFactory();
+        var mirror = consumer.CreateRemoteSignal("mirror", 0,
+            () =>
+            {
+                var n = Interlocked.Increment(ref pulls);
+                return Task.FromResult(n == 1
+                    ? new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false)
+                    : new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+            },
+            onPeerReset: async () =>
+            {
+                if (Interlocked.Increment(ref hookRuns) == 1)
+                {
+                    await failFirstHook.Task;
+                    throw new InvalidOperationException("resubscribe transport down");
+                }
+            });
+
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch1, 5, 111, CausalityStamp.ForSignal(1000, 5, epoch1).Serialize(), false));
+
+        var delivery = mirror.OnValueAsync(new ValuePayload<int>(1000, epoch2, 1, 222, CausalityStamp.ForSignal(1000, 1, epoch2).Serialize(), false));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref hookRuns) == 1);
+
+        // A second restart's one-shot delivery is refused during the window...
+        await mirror.OnValueAsync(new ValuePayload<int>(1000, epoch3, 1, 333, CausalityStamp.ForSignal(1000, 1, epoch3).Serialize(), false));
+
+        // ... and the hook then FAILS: the window closes without soliciting the broken channel.
+        failFirstHook.SetResult();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => delivery.WaitAsync(TimeSpan.FromSeconds(10)));
+        await Task.Delay(100); // no detached verification pull may sneak in
+        Assert.Equal(1, Volatile.Read(ref pulls));
+        Assert.Equal(epoch2, mirror.Publication!.Epoch);
+
+        // The bridge repairs its channel; the next advertisement heals the mirror normally.
+        await mirror.OnStaleAsync(new StaleNotification(1000, epoch3, 1, CausalityStamp.Empty.Serialize()));
+        Assert.Equal(epoch3, mirror.Publication!.Epoch);
+        Assert.Equal(333, await mirror.Local.Get());
+    }
+
+    [Fact]
     public async Task RemoteSignal_DelayedPayloadFromASkippedIncarnation_CannotAbandonTheLiveEpoch()
     {
         // The host restarted twice and the mirror never saw the middle incarnation, so that

--- a/MemoizR.Tests/MemoizR.Tests.csproj
+++ b/MemoizR.Tests/MemoizR.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\MemoizR\MemoizR.csproj" />
     <ProjectReference Include="..\MemoizR.Reactive\MemoizR.Reactive.csproj" />
     <ProjectReference Include="..\MemoizR.StructuredConcurrency\MemoizR.StructuredConcurrency.csproj" />
+    <ProjectReference Include="..\MemoizR.Distributed\MemoizR.Distributed.csproj" />
   </ItemGroup>
 
 </Project>

--- a/MemoizR.Tests/StructuredAsyncLockTests.cs
+++ b/MemoizR.Tests/StructuredAsyncLockTests.cs
@@ -30,6 +30,34 @@ public class AsyncAsymmetricLockTests
         }
     }
 
+    [Fact(Timeout = 5000)]
+    public async Task DetachedTaskInsideUpgradeableScope_InheritsTheFlow_UnlessSuppressed()
+    {
+        // The premise behind DistributedBarrier's re-pull scheduling: the lock scope is an
+        // AsyncLocal, so a Task.Run started inside an upgradeable scope inherits the holding
+        // flow and its exclusive acquisition is refused as recursive -- even though it runs on
+        // another thread. Suppressing ExecutionContext flow detaches the task into a fresh
+        // top-level flow that simply queues until the upgradeable is released.
+        var asyncLock = new AsyncAsymmetricLock();
+
+        using (await asyncLock.UpgradeableLockAsync())
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => Task.Run(() => asyncLock.ExclusiveLockAsync()));
+        }
+
+        Task<IDisposable> queued;
+        using (await asyncLock.UpgradeableLockAsync())
+        {
+            using (ExecutionContext.SuppressFlow())
+            {
+                queued = Task.Run(() => asyncLock.ExclusiveLockAsync());
+            }
+            Assert.False(queued.IsFaulted);
+        }
+        (await queued).Dispose();
+    }
+
     [Fact(Timeout = 500)]
     public async Task UpgradeableLock_AcquiredAndReleased()
     {

--- a/MemoizR.Tests/StructuredConcurrencyTests.cs
+++ b/MemoizR.Tests/StructuredConcurrencyTests.cs
@@ -56,7 +56,10 @@ public class StructuredConcurrencyTests
         await Assert.ThrowsAsync<AggregateException>(c1.Get);
     }
 
-    [Fact(Timeout = 1000)]
+    // Timing-sensitive: the winner branch's real 100 ms delay plus graph work must beat the
+    // timeout on a possibly-loaded runner. Retry like the other flaky timing tests (xRetry)
+    // instead of relying on a knife-edge timeout, keeping a generous hang guard.
+    [RetryFact(3, 200, Timeout = 10000)]
     public async Task TestRaceHandling()
     {
         var f = new MemoFactory();

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -1,4 +1,5 @@
 using MemoizR.Reactive;
+using xRetry.v3;
 
 namespace MemoizR.Tests;
 
@@ -383,7 +384,12 @@ public class TransitionTests
         gate2.SetResult(); // unpark the stray effect
     }
 
-    [Fact(Timeout = 5000)]
+    // Timing-sensitive on loaded runners (observed twice on windows-latest): va's and vb's
+    // cascades schedule two debounced updates, and when the va-triggered faulting scan is
+    // serialized AFTER the vb-triggered committing rerun, the fault is recorded over the
+    // commit and LastStabilizationFault survives. Retried like the other flaky reactive
+    // tests until the fault-record/commit ordering is token-guarded.
+    [RetryFact(3, 200, Timeout = 5000)]
     public async Task Transition_ParentFaultWithSuccessfulRerun_SettlesClean_WithoutAFaultRecord()
     {
         var f = new MemoFactory();

--- a/MemoizR.slnx
+++ b/MemoizR.slnx
@@ -4,6 +4,9 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/MemoizR.Benchmarks/MemoizR.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/DistributedGraphSample/DistributedGraphSample.csproj" />
   </Folder>

--- a/MemoizR.slnx
+++ b/MemoizR.slnx
@@ -14,6 +14,7 @@
   <Project Path="MemoizR.Analyzers/MemoizR.Analyzers.csproj" />
   <Project Path="MemoizR.Blazor.Tests/MemoizR.Blazor.Tests.csproj" />
   <Project Path="MemoizR.Blazor/MemoizR.Blazor.csproj" />
+  <Project Path="MemoizR.Distributed/MemoizR.Distributed.csproj" />
   <Project Path="MemoizR.Reactive/MemoizR.Reactive.csproj" />
   <Project Path="MemoizR.StructuredAsyncLock/MemoizR.StructuredAsyncLock.csproj" />
   <Project Path="MemoizR.StructuredConcurrency/MemoizR.StructuredConcurrency.csproj" />

--- a/MemoizR/Friends.cs
+++ b/MemoizR/Friends.cs
@@ -2,4 +2,5 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MemoizR.Reactive")]
 [assembly: InternalsVisibleTo("MemoizR.StructuredConcurrency")]
+[assembly: InternalsVisibleTo("MemoizR.Distributed")]
 [assembly: InternalsVisibleTo("MemoizR.Tests")]

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -448,12 +448,16 @@ public abstract class MemoHandlR<T> : SignalHandlR
         }
     }
 
-    // Every publication funnels through here: one box swap, carrying the next sequence.
-    // Interlocked because the writers hold DIFFERENT locks per node type (a signal's monitor,
-    // a recomputing node's mutex), so no single monitor orders all increments.
+    // Every publication funnels through here: one box swap, carrying the next sequence. A
+    // PLAIN increment on purpose: a node's publications are already mutually exclusive under
+    // its own write serialization -- a signal only publishes inside its monitor, a recomputing
+    // node only under its mutex, and a node is never both -- and the volatile box store
+    // releases the incremented value to readers. (An Interlocked here would also be a Coyote
+    // interception point inside the signal monitor's critical section, which the systematic
+    // tests cannot control -- see TestChainLostUpdateWithCoyote on the uncontrolled Lock.)
     private void Publish(T value, StampEvidence evidence)
     {
-        valueBox = new ValueBox(value, evidence, Interlocked.Increment(ref publicationSequence));
+        valueBox = new ValueBox(value, evidence, ++publicationSequence);
     }
 
     // The signal write path: publishes the value with its own single-entry stamp (a signal has

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -397,7 +397,15 @@ public abstract class MemoHandlR<T> : SignalHandlR
     // The causality evidence rides in the same box (issue #39): the stamp AND the per-source map
     // describing which signal versions the value reflects are published in the same atomic swap,
     // so neither can ever be paired with a neighbouring publication's value.
-    private volatile ValueBox valueBox = new(default!, StampEvidence.None);
+    private volatile ValueBox valueBox = new(default!, StampEvidence.None, 0);
+
+    // Monotonic per-node publication counter, stamped into each box: sequence n+1's box swap
+    // happened after sequence n's, full stop. Distributed payloads carry it (via the friend
+    // package) because causality stamps deliberately cannot totally order one node's
+    // publications when its dependency set oscillates -- {s:3}, then {} (empty), then {s:3}
+    // again are three DIFFERENT publications with two indistinguishable stamps; the sequence
+    // is the per-node tiebreaker that lets a consumer drop late deliveries exactly.
+    private long publicationSequence;
 
     internal T Value => valueBox.Value;
 
@@ -419,6 +427,17 @@ public abstract class MemoHandlR<T> : SignalHandlR
         }
     }
 
+    // The full (value, evidence, sequence) triple of one publication, for the distributed
+    // export path: a pull must answer with fields that all describe the SAME box.
+    internal (T Value, StampEvidence Evidence, long Sequence) ValueEvidenceAndSequence
+    {
+        get
+        {
+            var box = valueBox;
+            return (box.Value, box.Evidence, box.Sequence);
+        }
+    }
+
     // The (value, stamp) projection of one publication.
     internal (T Value, CausalityStamp Stamp) ValueAndStamp
     {
@@ -429,11 +448,19 @@ public abstract class MemoHandlR<T> : SignalHandlR
         }
     }
 
+    // Every publication funnels through here: one box swap, carrying the next sequence.
+    // Interlocked because the writers hold DIFFERENT locks per node type (a signal's monitor,
+    // a recomputing node's mutex), so no single monitor orders all increments.
+    private void Publish(T value, StampEvidence evidence)
+    {
+        valueBox = new ValueBox(value, evidence, Interlocked.Increment(ref publicationSequence));
+    }
+
     // The signal write path: publishes the value with its own single-entry stamp (a signal has
     // no sources), in one atomic box swap.
     internal void SetValueAndStamp(T value, CausalityStamp stamp)
     {
-        valueBox = new ValueBox(value, StampEvidence.ForOwnStamp(stamp));
+        Publish(value, StampEvidence.ForOwnStamp(stamp));
     }
 
     // The signal write path of a stamps-disabled context: no stamp is constructed at all, and
@@ -441,7 +468,7 @@ public abstract class MemoHandlR<T> : SignalHandlR
     // made" (None would falsely assert "depends on no tracked signals" to a consistency check).
     internal void SetValueUnstamped(T value)
     {
-        valueBox = new ValueBox(value, StampEvidence.UnverifiableEvidence);
+        Publish(value, StampEvidence.UnverifiableEvidence);
     }
 
     // Publish a computed value together with the evidence captured during the evaluation that
@@ -454,7 +481,7 @@ public abstract class MemoHandlR<T> : SignalHandlR
         // A stamps-disabled context publishes the shared Unverifiable evidence: the capture is
         // always empty there, and sealing it would produce None -- an honest-looking "depends
         // on nothing" claim no disabled context can actually make.
-        valueBox = new ValueBox(value, Context.StampsEnabled
+        Publish(value, Context.StampsEnabled
             ? StampEvidence.FromCapture(capture, winningBranch)
             : StampEvidence.UnverifiableEvidence);
     }
@@ -506,10 +533,11 @@ public abstract class MemoHandlR<T> : SignalHandlR
         return pair;
     }
 
-    private sealed class ValueBox(T value, StampEvidence evidence)
+    private sealed class ValueBox(T value, StampEvidence evidence, long sequence)
     {
         public readonly T Value = value;
         public readonly StampEvidence Evidence = evidence;
+        public readonly long Sequence = sequence;
 
         // Benign race: two concurrent creations produce interchangeable completed tasks over
         // the same immutable box, so no synchronization is needed.

--- a/MemoizR/MemoizR.csproj
+++ b/MemoizR/MemoizR.csproj
@@ -19,7 +19,10 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>MemoizR</PackageId>
-    <Version>0.0.5</Version>
+    <!-- 0.0.6: MemoizR.Distributed (friend assembly) requires this version's internals
+         (per-node publication sequences, ValueEvidenceAndSequence, the invalidation entry);
+         the packed dependency floor must exclude the published 0.0.5. -->
+    <Version>0.0.6</Version>
     <Authors>Timon Krebs</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>

--- a/README.md
+++ b/README.md
@@ -189,8 +189,16 @@ var payload = stamp.Serialize();              // compact, deterministic wire for
 Stamps are space-efficient (uniform regions collapse, ITC-style), reset-resilient (a restarted
 graph's stamps are never confused with their pre-restart incarnation), and documented in
 [docs/architecture/causality-trigger-clock.md](docs/architecture/causality-trigger-clock.md).
-A runnable two-peer bridge — stale/pull protocol, glitch barrier, late-delivery dropping and
-reset detection — lives in [samples/DistributedGraphSample](samples/DistributedGraphSample).
+
+The **MemoizR.Distributed** package builds the bridge layer on top: `Export` a node on the
+host (value changes push tiny stale advertisements; consumers pull lazily),
+`CreateRemoteSignal` on the consumer (an adoption protocol with per-publication sequences,
+incarnation epochs and abandoned-epoch tracking makes reordered, at-least-once transports
+harmless), and `DistributedBarrier` (renders only consistent, verified snapshots and re-pulls
+the lagging mirror itself). A runnable two-peer demo lives in
+[samples/DistributedGraphSample](samples/DistributedGraphSample); the roadmap (multi-peer
+epoch table, wire v3, evidence splicing) is
+[#148](https://github.com/timonkrebs/MemoizR/issues/148).
 
 Purely-local graphs that will never be synchronized can opt out of the stamp bookkeeping
 entirely with `new MemoFactory(options: MemoFactoryOptions.DisableCausalityStamps)` — same

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ graph's stamps are never confused with their pre-restart incarnation), and docum
 A runnable two-peer bridge — stale/pull protocol, glitch barrier, late-delivery dropping and
 reset detection — lives in [samples/DistributedGraphSample](samples/DistributedGraphSample).
 
+Purely-local graphs that will never be synchronized can opt out of the stamp bookkeeping
+entirely with `new MemoFactory(options: MemoFactoryOptions.DisableCausalityStamps)` — same
+semantics, honest no-claim evidence, and the recompute paths measure below the pre-stamps
+baseline (reproducible via [benchmarks/MemoizR.Benchmarks](benchmarks/MemoizR.Benchmarks)).
+
 ### Data-race safety (strict mode)
 
 MemoizR publishes value *references* tear-free across concurrent flows, but only an immutable

--- a/README.md
+++ b/README.md
@@ -200,6 +200,64 @@ the lagging mirror itself). A runnable two-peer demo lives in
 epoch table, wire v3, evidence splicing) is
 [#148](https://github.com/timonkrebs/MemoizR/issues/148).
 
+### Exporting nodes: the problem the glitch barrier solves
+
+The problem, in one story: **a consumer combining two values that never existed together.**
+A weather server holds one signal and derives two values from it:
+
+```
+temperature ──┬─► dewPoint   ──[wire]──►  dewMirror  ──┐
+              │                                        ├─► comfort (glitch barrier)
+              └─► heatIndex  ──[wire]──►  heatMirror ──┘
+```
+
+`temperature` changes 20° → 30°; both derived values recompute and both updates head across
+the wire — but networks reorder things. The dashboard receives the new `dewPoint` (25) while
+the new `heatIndex` (35) is still in flight, so for a moment it holds `(25, 25)`: each number
+is individually a value the server once published, but this *pair never existed* — nothing in
+the values themselves says which `temperature` they came from. Inside one process MemoizR's
+locks make such glitches impossible; across a network no lock can span the two machines, so
+the export layer makes glitch-freedom *checkable* instead:
+
+```cs
+// ── Server (peer A) ── disjoint id slices keep stamps unambiguous across peers
+var host = new MemoFactory("server", idRangeStart: 1_000, idRangeEnd: 2_000);
+var temperature = host.CreateSignal("temperature", 20.0);
+var dewPoint  = host.CreateMemoizR("dewPoint",  async () => await temperature.Get() - 5);
+var heatIndex = host.CreateMemoizR("heatIndex", async () => await temperature.Get() + 5);
+
+// An export is just a reaction: whenever the value advances, a tiny stale ADVERTISEMENT
+// (id + ordering header + causality stamp — NO value) goes to your transport. Values move
+// only when a consumer PULLS, so laziness survives the network.
+using var dewExport  = host.Export(dewPoint,  advert => SendToDashboard(advert));
+using var heatExport = host.Export(heatIndex, advert => SendToDashboard(advert));
+
+// ── Dashboard (peer B) ── a real bridge pumps these from gRPC/WebSockets
+var dash = new MemoFactory("dashboard", idRangeStart: 2_000, idRangeEnd: 3_000);
+var dewMirror  = dash.CreateRemoteSignal("dew",  0.0, dewExport.PullAsync);
+var heatMirror = dash.CreateRemoteSignal("heat", 0.0, heatExport.PullAsync);
+// (transport deliveries feed dewMirror.OnStaleAsync / OnValueAsync)
+
+// The barrier renders ONLY pairs that provably belong to the same write history.
+var comfort = DistributedBarrier.CreateConsistentReaction(
+    dash, dewMirror, heatMirror,
+    (dew, heat) => Render(dew, heat));
+```
+
+Every pulled value arrives with its causality stamp — a receipt listing exactly which version
+of each input the value was computed from. Replaying the race: the fresh `dewPoint` adopts
+with the receipt `{temperature: v1}` while `heatIndex` still carries `{temperature: v0}`. The
+barrier compares receipts, sees the pair straddles a write, and refuses to render — no
+cross-machine lock needed, the evidence alone detects the tear. The receipts also say which
+side is behind (v0 is dominated by v1), so the barrier re-pulls the lagging mirror itself and
+renders once the receipts agree: the dashboard skips straight from the old consistent state
+`(15, 25)` to the new one `(25, 35)`, and the phantom `(25, 25)` never renders. **Exports
+ship values with proof of what they were computed from, and the consumer refuses to combine
+values whose proofs disagree — recovering by asking again rather than by guessing.** The rest
+of the package keeps that story true on a real network: sequences drop duplicated and late
+deliveries, incarnation epochs catch host restarts (re-verified by pull, never trusted
+blindly), and heartbeats cover the transitions the value cascade deliberately does not push.
+
 Purely-local graphs that will never be synchronized can opt out of the stamp bookkeeping
 entirely with `new MemoFactory(options: MemoFactoryOptions.DisableCausalityStamps)` — same
 semantics, honest no-claim evidence, and the recompute paths measure below the pre-stamps

--- a/benchmarks/MemoizR.Benchmarks/MemoizR.Benchmarks.csproj
+++ b/benchmarks/MemoizR.Benchmarks/MemoizR.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Workstation GC on purpose: the numbers compare the library's allocation and latency,
+         not GC throughput modes. -->
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <!-- Benchmark a DIFFERENT checkout of MemoizR with the SAME harness (e.g. a baseline
+         commit in a second worktree) by overriding the path:
+           dotnet run -c Release -p:MemoizRPath=/path/to/other/checkout -->
+    <MemoizRPath Condition="'$(MemoizRPath)' == ''">$(MSBuildThisFileDirectory)../..</MemoizRPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(MemoizRPath)/MemoizR/MemoizR.csproj" />
+  </ItemGroup>
+</Project>

--- a/benchmarks/MemoizR.Benchmarks/Program.cs
+++ b/benchmarks/MemoizR.Benchmarks/Program.cs
@@ -8,7 +8,22 @@ using MemoizR;
 // allocation-free?
 class Bench
 {
+    // Main and the scenario groups are split because SonarSource cognitive complexity (S3776)
+    // attributes every measurement lambda's loop to the containing method.
     static async Task Main()
+    {
+        await MeasureCorePaths();
+
+        // The stamps-disabled variants quantify what MemoFactoryOptions.DisableCausalityStamps
+        // saves. Resolved at runtime so this harness still compiles against builds that predate
+        // the flag (they simply skip these rows).
+        if (Enum.TryParse<MemoFactoryOptions>("DisableCausalityStamps", out var noStamps))
+        {
+            await MeasureStampsDisabledPaths(noStamps);
+        }
+    }
+
+    static async Task MeasureCorePaths()
     {
         await Measure("signal.Set (distinct values)", 1_000_000, async n =>
         {
@@ -52,15 +67,10 @@ class Bench
             var c = f.CreateMemoizR(async () => await a.Get() + await b.Get());
             for (var i = 1; i <= n; i++) { await s.Set(i); await c.Get(); }
         });
+    }
 
-        // The stamps-disabled variants quantify what MemoFactoryOptions.DisableCausalityStamps
-        // saves. Resolved at runtime so this harness still compiles against builds that predate
-        // the flag (they simply skip these rows).
-        if (!Enum.TryParse<MemoFactoryOptions>("DisableCausalityStamps", out var noStamps))
-        {
-            return;
-        }
-
+    static async Task MeasureStampsDisabledPaths(MemoFactoryOptions noStamps)
+    {
         await Measure("signal.Set (distinct, stamps disabled)", 1_000_000, async n =>
         {
             var f = new MemoFactory(options: noStamps);

--- a/benchmarks/MemoizR.Benchmarks/Program.cs
+++ b/benchmarks/MemoizR.Benchmarks/Program.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using MemoizR;
+
+// Micro-harness comparing the library's hot paths across builds (see the csproj for how to
+// point it at a different checkout). Not BenchmarkDotNet-rigorous, but with warmup and
+// best-of-5 medians it is solid for the order-of-magnitude questions it exists to answer:
+// what do causality stamps cost on Set/recompute, and do the clean read fast paths stay
+// allocation-free?
+class Bench
+{
+    static async Task Main()
+    {
+        await Measure("signal.Set (distinct values)", 1_000_000, async n =>
+        {
+            var f = new MemoFactory();
+            var s = f.CreateSignal(0);
+            for (var i = 1; i <= n; i++) await s.Set(i);
+        });
+
+        await Measure("signal.Set (same value)", 1_000_000, async n =>
+        {
+            var f = new MemoFactory();
+            var s = f.CreateSignal(42);
+            for (var i = 0; i < n; i++) await s.Set(42);
+        });
+
+        await Measure("memo.Get (clean, untracked fast path)", 2_000_000, async n =>
+        {
+            var f = new MemoFactory();
+            var s = f.CreateSignal(1);
+            var m = f.CreateMemoizR(async () => await s.Get() + 1);
+            await m.Get();
+            for (var i = 0; i < n; i++) await m.Get();
+        });
+
+        await Measure("chain recompute (Set + Get through 3 memos)", 50_000, async n =>
+        {
+            var f = new MemoFactory();
+            var s = f.CreateSignal(0);
+            var m1 = f.CreateMemoizR(async () => await s.Get() + 1);
+            var m2 = f.CreateMemoizR(async () => await m1.Get() + 1);
+            var m3 = f.CreateMemoizR(async () => await m2.Get() + 1);
+            for (var i = 1; i <= n; i++) { await s.Set(i); await m3.Get(); }
+        });
+
+        await Measure("diamond recompute (Set + Get, c = a + b)", 50_000, async n =>
+        {
+            var f = new MemoFactory();
+            var s = f.CreateSignal(0);
+            var a = f.CreateMemoizR(async () => await s.Get() + 1);
+            var b = f.CreateMemoizR(async () => await s.Get() * 2);
+            var c = f.CreateMemoizR(async () => await a.Get() + await b.Get());
+            for (var i = 1; i <= n; i++) { await s.Set(i); await c.Get(); }
+        });
+
+        // The stamps-disabled variants quantify what MemoFactoryOptions.DisableCausalityStamps
+        // saves. Resolved at runtime so this harness still compiles against builds that predate
+        // the flag (they simply skip these rows).
+        if (!Enum.TryParse<MemoFactoryOptions>("DisableCausalityStamps", out var noStamps))
+        {
+            return;
+        }
+
+        await Measure("signal.Set (distinct, stamps disabled)", 1_000_000, async n =>
+        {
+            var f = new MemoFactory(options: noStamps);
+            var s = f.CreateSignal(0);
+            for (var i = 1; i <= n; i++) await s.Set(i);
+        });
+
+        await Measure("chain recompute (stamps disabled)", 50_000, async n =>
+        {
+            var f = new MemoFactory(options: noStamps);
+            var s = f.CreateSignal(0);
+            var m1 = f.CreateMemoizR(async () => await s.Get() + 1);
+            var m2 = f.CreateMemoizR(async () => await m1.Get() + 1);
+            var m3 = f.CreateMemoizR(async () => await m2.Get() + 1);
+            for (var i = 1; i <= n; i++) { await s.Set(i); await m3.Get(); }
+        });
+
+        await Measure("diamond recompute (stamps disabled)", 50_000, async n =>
+        {
+            var f = new MemoFactory(options: noStamps);
+            var s = f.CreateSignal(0);
+            var a = f.CreateMemoizR(async () => await s.Get() + 1);
+            var b = f.CreateMemoizR(async () => await s.Get() * 2);
+            var c = f.CreateMemoizR(async () => await a.Get() + await b.Get());
+            for (var i = 1; i <= n; i++) { await s.Set(i); await c.Get(); }
+        });
+    }
+
+    static async Task Measure(string name, int n, Func<int, Task> run)
+    {
+        await run(Math.Max(1000, n / 20)); // warmup + JIT
+        var bestNs = double.MaxValue; var bytesPer = 0.0;
+        for (var round = 0; round < 5; round++)
+        {
+            GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+            var a0 = GC.GetAllocatedBytesForCurrentThread();
+            var sw = Stopwatch.StartNew();
+            await run(n);
+            sw.Stop();
+            var ns = sw.Elapsed.TotalNanoseconds / n;
+            if (ns < bestNs) { bestNs = ns; bytesPer = (GC.GetAllocatedBytesForCurrentThread() - a0) / (double)n; }
+        }
+        Console.WriteLine($"{name,-46} {bestNs,8:F0} ns/op {bytesPer,8:F0} B/op");
+    }
+}

--- a/benchmarks/MemoizR.Benchmarks/Program.cs
+++ b/benchmarks/MemoizR.Benchmarks/Program.cs
@@ -106,12 +106,17 @@ class Bench
         for (var round = 0; round < 5; round++)
         {
             GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-            var a0 = GC.GetAllocatedBytesForCurrentThread();
+            // Process-wide, not per-thread: the scenarios await inside their loops, so
+            // continuations hop pool threads and per-thread counters would miss (or even
+            // negatively skew) everything allocated off the starting thread. Nothing else
+            // allocates concurrently in this single-scenario process, and best-of-5 absorbs
+            // the residual noise.
+            var a0 = GC.GetTotalAllocatedBytes(precise: true);
             var sw = Stopwatch.StartNew();
             await run(n);
             sw.Stop();
             var ns = sw.Elapsed.TotalNanoseconds / n;
-            if (ns < bestNs) { bestNs = ns; bytesPer = (GC.GetAllocatedBytesForCurrentThread() - a0) / (double)n; }
+            if (ns < bestNs) { bestNs = ns; bytesPer = (GC.GetTotalAllocatedBytes(precise: true) - a0) / (double)n; }
         }
         Console.WriteLine($"{name,-46} {bestNs,8:F0} ns/op {bytesPer,8:F0} B/op");
     }

--- a/docs/NUGET_DISTRIBUTED_README.md
+++ b/docs/NUGET_DISTRIBUTED_README.md
@@ -13,7 +13,9 @@ with every value).
   traffic from dead incarnations, and misrouted payloads for a different node are rejected.
 - **`DistributedBarrier`** combines mirrored inputs only on a consistent, verified snapshot of
   the host's write history — a transient glitch (one mirror fresh, one stale, straddling the
-  same write) is detected via the causality stamps and healed by re-pulling the lagging side.
+  same write) is detected via the causality stamps and healed by re-pulling the lagging side;
+  a re-pull round both hosts answer with their unchanged current publications AFFIRMS the pair
+  (the stamp disagreement is a documented conservative under-claim, not a lag) and it renders.
 
 The transport is yours: three messages (stale / pull / value), delegate-shaped, with an
 in-process pairing being a few lines of glue. See the repository's

--- a/docs/NUGET_DISTRIBUTED_README.md
+++ b/docs/NUGET_DISTRIBUTED_README.md
@@ -6,10 +6,11 @@ with every value).
 
 - **`Export`** a node on the host: value changes push a tiny stale advertisement; consumers
   pull lazily, so MemoizR's laziness survives the network.
-- **`CreateRemoteSignal`** on the consumer: a local signal fed by an adoption protocol that
-  makes reordered, at-least-once transports harmless — per-publication sequences totally order
-  deliveries, incarnation epochs detect host restarts (held evidence is discarded, never
-  merged), and abandoned epochs drop late traffic from dead incarnations.
+- **`CreateRemoteSignal`** on the consumer: a local read-only signal fed by an adoption
+  protocol that makes reordered, at-least-once transports harmless — per-publication sequences
+  totally order deliveries, incarnation epochs detect host restarts (committed only through
+  the mirror's own pull; held evidence is discarded, never merged), abandoned epochs drop late
+  traffic from dead incarnations, and misrouted payloads for a different node are rejected.
 - **`DistributedBarrier`** combines mirrored inputs only on a consistent, verified snapshot of
   the host's write history — a transient glitch (one mirror fresh, one stale, straddling the
   same write) is detected via the causality stamps and healed by re-pulling the lagging side.

--- a/docs/NUGET_DISTRIBUTED_README.md
+++ b/docs/NUGET_DISTRIBUTED_README.md
@@ -1,0 +1,19 @@
+# MemoizR.Distributed
+
+Glitch-free synchronization of MemoizR reactive graphs across process and machine boundaries,
+built on the Causality Trigger Clock (space-efficient ITC-style causality stamps that travel
+with every value).
+
+- **`Export`** a node on the host: value changes push a tiny stale advertisement; consumers
+  pull lazily, so MemoizR's laziness survives the network.
+- **`CreateRemoteSignal`** on the consumer: a local signal fed by an adoption protocol that
+  makes reordered, at-least-once transports harmless — per-publication sequences totally order
+  deliveries, incarnation epochs detect host restarts (held evidence is discarded, never
+  merged), and abandoned epochs drop late traffic from dead incarnations.
+- **`DistributedBarrier`** combines mirrored inputs only on a consistent, verified snapshot of
+  the host's write history — a transient glitch (one mirror fresh, one stale, straddling the
+  same write) is detected via the causality stamps and healed by re-pulling the lagging side.
+
+The transport is yours: three messages (stale / pull / value), delegate-shaped, with an
+in-process pairing being a few lines of glue. See the repository's
+`samples/DistributedGraphSample` and `docs/architecture/causality-trigger-clock.md`.

--- a/docs/architecture/causality-trigger-clock.md
+++ b/docs/architecture/causality-trigger-clock.md
@@ -223,6 +223,26 @@ reads — and the node stays dirty, so the next `Get` replaces both.
   `Epoch`, `Triggers`, `TryGetTrigger`, `Join`, `IsConsistentWith`, `IsDominatedBy`, value
   equality, `Serialize`/`Deserialize`. Stamp *creation* stays internal.
 
+## 5b. Opting out: `MemoFactoryOptions.DisableCausalityStamps`
+
+Stamps are on by default and cost nothing on the read fast paths (clean `Get` is
+allocation-free either way), a small constant on `Set`, and ~2 KB of allocation per recompute
+(the capture bucket, the seal, the joined evidence). A purely-local graph that will never be
+bridged can turn all of it off: `new MemoFactory(options:
+MemoFactoryOptions.DisableCausalityStamps)`. On a disabled context, signals stop bumping
+triggers, evaluations never open a capture, `GetWithStamp` returns the empty stamp, and
+`GetWithEvidence` returns evidence flagged unverifiable — "no claim can be made" — so a
+consistency check can never mistake the missing capture for a verified value. Values,
+invalidation, glitch freedom and every other semantic are unchanged (they come from the
+evaluation protocol, not from stamps); with the flag the recompute paths measure *below* the
+pre-CTC baseline.
+
+The flag binds to the **context**, not the factory: factories sharing a keyed context must
+agree on it (a mismatch throws at construction), because a context where only some nodes record
+evidence would publish stamps silently omitting real dependencies — over-claiming, the one
+thing §2 forbids. And a disabled context must not be exported to peers: its advertisements
+would carry no ordering evidence at all.
+
 ## 6. The encoding (phase 2): a canonical event tree
 
 `CausalityStamp` stores the id→trigger map as an ITC-style **event tree** over the id space

--- a/docs/architecture/causality-trigger-clock.md
+++ b/docs/architecture/causality-trigger-clock.md
@@ -210,7 +210,10 @@ reads — and the node stays dirty, so the next `Get` replaces both.
   single graph produces — but a consumer-side stamp joining sources replicated from several
   peers spans several incarnations. The planned evolution is an epoch *table* keyed by id-range
   (slices are contiguous, so the table stays one entry per peer), arriving as wire-format v3
-  together with the bridge layer.
+  (issue #148). Until then the bridge layer's first cut — the `MemoizR.Distributed` package —
+  keeps foreign evidence *beside* the consumer's graph and checks it explicitly at the barrier,
+  and orders one node's deliveries by a per-publication sequence (the per-node total order
+  stamps deliberately do not provide).
 - **Public surface** (frozen alongside the wire format): `IStampedGetR<T>.GetWithEvidence()` —
   the `(value, evidence)` pair of one publication, carrying verifiability so an interface-typed
   consumer can never mistake a poisoned publication for an honest no-dependency value — on

--- a/samples/DistributedGraphSample/DistributedGraphSample.csproj
+++ b/samples/DistributedGraphSample/DistributedGraphSample.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\MemoizR\MemoizR.csproj" />
     <ProjectReference Include="..\..\MemoizR.Reactive\MemoizR.Reactive.csproj" />
+    <ProjectReference Include="..\..\MemoizR.Distributed\MemoizR.Distributed.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/DistributedGraphSample/Program.cs
+++ b/samples/DistributedGraphSample/Program.cs
@@ -1,12 +1,13 @@
 using MemoizR;
-using MemoizR.Reactive;
+using MemoizR.Distributed;
 
 // ═══════════════════════════════════════════════════════════════════════════════════════════
-// Distributed reactive graph sample (issue #39, docs/architecture/causality-trigger-clock.md)
+// Distributed reactive graph sample, built on the MemoizR.Distributed package
+// (issue #148; design: docs/architecture/causality-trigger-clock.md).
 //
 // Peer A hosts the source-of-truth graph; peer B mirrors two of A's derived values and
-// combines them GLITCH-FREE -- without any lock spanning the two peers -- by checking the
-// causality stamps that travel with every value:
+// combines them GLITCH-FREE -- without any lock spanning the two peers -- via the causality
+// stamps that travel with every value:
 //
 //   peer A                                    peer B
 //   ──────                                    ──────
@@ -16,17 +17,17 @@ using MemoizR.Reactive;
 //
 // Both mirrored inputs derive from the SAME signals, so when temperature changes on A and the
 // two updates race across the wire, B can transiently hold a fresh dewPoint next to a stale
-// heatIndex. The barrier detects that (their stamps disagree on temperature's trigger), has
-// the lagging input re-pulled, and only renders on a consistent snapshot.
+// heatIndex. The barrier detects that (their stamps disagree on temperature's trigger),
+// re-pulls the lagging mirror itself, and renders only on a consistent snapshot.
 //
-// The whole protocol is three messages; values move only on Pull, so laziness survives the
-// network. This sample drives the message flow by hand to make every step visible -- a real
-// bridge would pump the same handlers from a gRPC stream or WebSocket.
+// The wire protocol is three messages (stale / pull / value); values move only on pull, so
+// laziness survives the network. This script plays the transport by hand -- delivering,
+// delaying and duplicating messages deliberately -- to make every mechanism visible; a real
+// bridge pumps the same three handlers from a gRPC stream or WebSocket.
 // ═══════════════════════════════════════════════════════════════════════════════════════════
 
 // ───────────────────────── peer A: the source-of-truth graph ─────────────────────────
-// Disjoint node-id slices per peer: stamps merged across peers can never collide on an id,
-// and each peer occupies its own subtree of the stamp's interval encoding.
+// Disjoint node-id slices per peer: stamps merged across peers can never collide on an id.
 var peerA = new MemoFactory("sample-peer-a", idRangeStart: 1_000, idRangeEnd: 2_000);
 
 var temperature = peerA.CreateSignal("temperature", 24.0);
@@ -36,289 +37,141 @@ var dewPoint = peerA.CreateMemoizR("dewPoint", async () =>
 var heatIndex = peerA.CreateMemoizR("heatIndex", async () =>
     await temperature.Get() + 0.1 * await humidity.Get() * (await temperature.Get() - 14.5));
 
-// An EXPORT is just a reaction: whenever the node's VALUE advances, push a stale notification
-// (id + stamp, no value). This sample parks them in per-node outboxes so the "network" can
-// deliver them out of order below; a real bridge would write to its transport here.
-// Deliberate design boundary: the local invalidation cascade propagates only value changes, so
-// an evaluation that keeps the value but changes the EVIDENCE (a stamp refresh, or an
-// unverifiable spell healing) emits no notification -- evidence-only transitions are
-// discovered by PULLING (the glitch barrier re-pulls lagging inputs, and an unverifiable
-// mirror chases every advertisement); a real bridge adds a heartbeat/poll for liveness.
-var outbox = new Outbox(dewPoint.Id, heatIndex.Id);
-var exportDew = peerA.BuildReaction("export dewPoint").CreateReaction(dewPoint, _ =>
-    outbox.Enqueue(new StaleMsg(dewPoint.Id, dewPoint.Stamp.Serialize())));
-var exportHeat = peerA.BuildReaction("export heatIndex").CreateReaction(heatIndex, _ =>
-    outbox.Enqueue(new StaleMsg(heatIndex.Id, heatIndex.Stamp.Serialize())));
+// EXPORTS: whenever a node's value advances, the package pushes a stale advertisement (id +
+// ordering header + stamp, no value) to this sink -- the demo's stand-in for a transport. The
+// sink keeps only the LATEST advertisement per node, exactly like a coalescing send buffer.
+var wire = new AdvertisementBuffer();
+using var dewExport = peerA.Export(dewPoint, wire.PublishAsync);
+using var heatExport = peerA.Export(heatIndex, wire.PublishAsync);
 
 // ───────────────────────── peer B: mirrors and the glitch barrier ─────────────────────────
 var peerB = new MemoFactory("sample-peer-b", idRangeStart: 2_000, idRangeEnd: 3_000);
 
-// Each mirror carries the consumer side of the wire protocol; its Pull delegate is the host's
-// endpoint for that node: recompute lazily, answer with the untorn (value, evidence) pair.
-var dewMirror = new Mirror("dewPoint", peerB.CreateEagerRelativeSignal("dewMirror", 0.0), async () =>
-{
-    var (value, evidence) = await dewPoint.GetWithEvidence();
-    return new ValueMsg(dewPoint.Id, value, evidence.Stamp.Serialize(), evidence.Unverifiable);
-});
-var heatMirror = new Mirror("heatIndex", peerB.CreateEagerRelativeSignal("heatMirror", 0.0), async () =>
-{
-    var (value, evidence) = await heatIndex.GetWithEvidence();
-    return new ValueMsg(heatIndex.Id, value, evidence.Stamp.Serialize(), evidence.Unverifiable);
-});
+// Each mirror's pull delegate is the host's answer path for that node: recompute lazily,
+// answer with the untorn (value, evidence, sequence) triple of one publication.
+var dewMirror = peerB.CreateRemoteSignal("dewMirror", 0.0, dewExport.PullAsync,
+    onPeerReset: () => { Console.WriteLine("   [B] dewMirror: peer RESET detected (epoch changed) -> discarding evidence, resubscribing"); return Task.CompletedTask; });
+var heatMirror = peerB.CreateRemoteSignal("heatMirror", 0.0, heatExport.PullAsync);
 
-// THE GLITCH BARRIER: combine the two mirrored inputs only on a consistent snapshot of peer
-// A's write history. Both stamps cover temperature and humidity; IsConsistentWith fails
-// exactly when the inputs straddle a write, and IsDominatedBy tells which side lags. The
-// barrier only REPORTS the lagging input -- the re-pull runs on the bridge's own flow (below,
-// the demo script plays that part), because a reaction body must not Set signals of its own
-// graph from inside its own evaluation.
-var rendered = new TaskCompletionSource<(double Dew, double Heat)>(TaskCreationOptions.RunContinuationsAsynchronously);
-var glitched = new TaskCompletionSource<Mirror>(TaskCreationOptions.RunContinuationsAsynchronously);
-var comfort = peerB.BuildReaction("comfort").CreateReaction(
-    dewMirror.Local, heatMirror.Local,
+// THE GLITCH BARRIER: renders only on consistent, verified snapshots of peer A's write
+// history, and re-pulls the lagging mirror itself when the evidence disagrees.
+var renders = new RenderLog();
+var comfort = DistributedBarrier.CreateConsistentReaction(
+    peerB, dewMirror, heatMirror,
     (dew, heat) =>
     {
-        // Absent evidence (nothing synced yet) and unverifiable evidence mean the same thing
-        // to a consumer: CANNOT VERIFY -- so no render, never a guess. Gated on HasEvidence,
-        // not on the stamp being non-empty: an honestly-empty stamp (a value depending on no
-        // tracked signals) is verifiable evidence and consistent with anything.
-        if (!dewMirror.HasEvidence || !heatMirror.HasEvidence
-            || dewMirror.Unverifiable || heatMirror.Unverifiable)
-        {
-            return;
-        }
-
-        if (!dewMirror.Remote.IsConsistentWith(heatMirror.Remote))
-        {
-            var lagging = dewMirror.Remote.IsDominatedBy(heatMirror.Remote) ? dewMirror : heatMirror;
-            Console.WriteLine($"   [B] GLITCH detected (inputs disagree on a shared signal) -> {lagging.Name} lags");
-            glitched.TrySetResult(lagging); // hand the re-pull to the bridge's pump
-            return;
-        }
-
         Console.WriteLine($"   [B] render comfort(dewPoint: {dew:F2}, heatIndex: {heat:F2})  <- consistent snapshot");
-        rendered.TrySetResult((dew, heat));
-    });
+        renders.Add(dew, heat);
+    },
+    onGlitch: (_, _) => Console.WriteLine("   [B] GLITCH detected (inputs disagree on a shared signal) -> re-pulling the lagging mirror"));
 
 // ───────────────────────── the demo script ─────────────────────────
 Console.WriteLine("1) initial sync: B pulls both exported nodes");
 await dewMirror.PullAsync();
 await heatMirror.PullAsync();
-await rendered.Task;
+await renders.WaitFor(21.00, 24.38);
 
-Console.WriteLine("\n2) temperature changes on A; the two stale notifications race -- deliver only dewPoint's");
-rendered = new(TaskCreationOptions.RunContinuationsAsynchronously);
-var staleDewPayload = await dewMirror.Pull(); // keep a pre-change payload for step 3
-// The export reactions each run once EAGERLY on creation; wait for those initial
-// notifications to land before discarding them. Draining first would race the initial runs:
-// one landing after the drain (but before the Set) would leave a pre-change stamp as the only
-// dewPoint message, the dominance check in OnStaleAsync would skip the pull, and the glitch
-// this step demonstrates would never materialize -- the script would hang on glitched.Task.
-await outbox.WaitForAllAsync();
-outbox.Drain(); // step 2 cares about the post-change notifications only
+Console.WriteLine("\n2) temperature changes on A; the two stale advertisements race -- deliver only dewPoint's");
+var staleDewPayload = await dewExport.PullAsync(); // keep a pre-change payload for step 3
+var dewSeqBefore = staleDewPayload.Sequence;
 await temperature.Set(30.0);
-await outbox.WaitForAllAsync(); // let A's (debounced) export reactions run
-await dewMirror.OnStaleAsync(outbox.DequeueLatest(dewPoint.Id));
-// heatIndex's stale is still "in flight": B now holds fresh dewPoint next to stale heatIndex.
-// The barrier reports the lagging input; the pump re-pulls it; the barrier renders once the
-// snapshot is consistent:
-await (await glitched.Task).PullAsync();
-var (dewRendered, heatRendered) = await rendered.Task;
-Console.WriteLine($"   healed: dew={dewRendered:F2}, heat={heatRendered:F2}");
+// The publication SEQUENCE makes "wait until the post-change advertisement exists"
+// deterministic -- no draining races: newer publication, strictly higher sequence.
+var freshDewAdvert = await wire.WaitForAdvertisementAfter(dewPoint.Id, dewSeqBefore);
+await dewMirror.OnStaleAsync(freshDewAdvert);
+// heatIndex's advertisement is still "in flight": B now holds fresh dewPoint next to stale
+// heatIndex. The barrier detects the glitch, re-pulls heatMirror itself, and renders once
+// the snapshot is consistent:
+await renders.WaitFor(27.00, 30.62);
 
-Console.WriteLine("\n3) a late duplicate of the OLD dewPoint payload arrives -- dominance drops it");
+Console.WriteLine("\n3) a late duplicate of the OLD dewPoint payload arrives -- the sequence order drops it");
 await dewMirror.OnValueAsync(staleDewPayload);
+Console.WriteLine($"   [B] dewMirror still {await dewMirror.Local.Get():F2} (late delivery dropped)");
 
 Console.WriteLine("\n4) peer A restarts: same ids and triggers, but a fresh incarnation epoch");
+// A restart invalidates EVERY mirror of that peer: a real bridge resubscribes them all
+// together (the multi-peer epoch table planned as wire-format v3 makes that first-class).
+// This demo migrates only dewMirror, so tear the barrier down first -- it would otherwise
+// correctly chase the half-migrated pair forever.
+comfort.Dispose();
 var restartedA = new MemoFactory(null, idRangeStart: 1_000, idRangeEnd: 2_000); // unkeyed: a new context
 var temperature2 = restartedA.CreateSignal("temperature", 18.0);
 var humidity2 = restartedA.CreateSignal("humidity", 0.55);
 var dewPoint2 = restartedA.CreateMemoizR("dewPoint", async () =>
     await temperature2.Get() - (1 - await humidity2.Get()) * 5);
-var (value2, evidence2) = await dewPoint2.GetWithEvidence();
-await dewMirror.OnValueAsync(new ValueMsg(dewPoint2.Id, value2, evidence2.Stamp.Serialize(), evidence2.Unverifiable));
+using var dewExport2 = restartedA.Export(dewPoint2, wire.PublishAsync);
+await dewMirror.OnValueAsync(await dewExport2.PullAsync());
+Console.WriteLine($"   [B] dewMirror adopted the new incarnation's value: {await dewMirror.Local.Get():F2}");
 
 Console.WriteLine("\n5) a late payload from the PRE-RESET incarnation arrives -- its abandoned epoch drops it");
 await dewMirror.OnValueAsync(staleDewPayload);
+Console.WriteLine($"   [B] dewMirror still {await dewMirror.Local.Get():F2} (dead-incarnation delivery dropped)");
 
 Console.WriteLine("\ndone.");
-GC.KeepAlive(exportDew);
-GC.KeepAlive(exportHeat);
 GC.KeepAlive(comfort);
 
-// ───────────────────────── the wire protocol: three tiny messages ─────────────────────────
-// Stamps travel in the frozen v2 binary format; Deserialize validates hostile input.
-record StaleMsg(int NodeId, byte[] Stamp);
-record ValueMsg(int NodeId, double Value, byte[] Stamp, bool Unverifiable);
+// ───────────────────────── demo plumbing ─────────────────────────
 
-// A mirror pairs a LOCAL signal (so B's graph reacts through the ordinary machinery) with the
-// FOREIGN evidence the current value arrived with (so cross-peer consistency stays checkable)
-// and the consumer side of the wire protocol. A future MemoizR.Distributed package folds these
-// into one stamp-adopting RemoteSignal<T>; until then the evidence travels beside the graph.
-sealed class Mirror(string name, EagerRelativeSignal<double> local, Func<Task<ValueMsg>> pull)
+// The stand-in transport: keeps the latest advertisement per exported node (a coalescing send
+// buffer), and lets the script wait for the advertisement of a publication NEWER than a known
+// sequence -- deterministic because sequences strictly increase per publication.
+sealed class AdvertisementBuffer
 {
-    public string Name { get; } = name;
-    // An EAGER relative signal on purpose: a re-pull can change the EVIDENCE while the numeric
-    // value stays identical (e.g. the lagging side of a glitch recomputes to the same number).
-    // A plain Signal.Set would suppress the notification and the barrier would never re-run to
-    // observe the fresh evidence; the eager signal always notifies.
-    public EagerRelativeSignal<double> Local { get; } = local;
-    public Func<Task<ValueMsg>> Pull { get; } = pull;
-    public CausalityStamp Remote { get; private set; } = CausalityStamp.Empty;
-    // ORDERING FLOOR: the join of every non-empty stamp adopted in the current epoch. Late and
-    // duplicate deliveries are ordered against this, not against Remote: adopting an honestly-
-    // empty publication rightly clears the CURRENT evidence (an empty stamp claims nothing),
-    // but it must not amnesty older non-empty payloads still in flight on a reordered
-    // transport.
-    private CausalityStamp floor = CausalityStamp.Empty;
-    // Epochs this mirror has moved on from. Epochs are random identifiers, not ordered: a
-    // mismatch alone cannot tell "the peer restarted" from "a payload of the incarnation we
-    // already left arrived late", so the mirror remembers what it abandoned. (A real bridge
-    // bounds this set by resubscribing on reset.)
-    private readonly HashSet<long> abandonedEpochs = [];
-    public volatile bool Unverifiable;
-    // Whether any payload was adopted at all: an honestly-empty stamp (a value that depends on
-    // no tracked signals) is real, verifiable evidence, so "synced" cannot be derived from the
-    // stamp being non-empty.
-    public volatile bool HasEvidence;
+    private readonly Dictionary<int, StaleNotification> latest = new();
 
-    public async Task PullAsync() => await OnValueAsync(await Pull());
-
-    // STALE handler: pull only when the host advertises something newer than we hold -- the
-    // value itself moves lazily. Two exceptions always pull: an EMPTY advertisement (the host
-    // published no claim, e.g. an unverifiable evaluation) carries no ordering information,
-    // and a mirror that is currently UNVERIFIABLE must chase every advertisement -- a host
-    // recovering without any trigger advancing re-advertises the very stamp we already hold,
-    // which dominance would otherwise mistake for old news.
-    public async Task OnStaleAsync(StaleMsg msg)
+    public Task PublishAsync(StaleNotification advertisement)
     {
-        var advertised = CausalityStamp.Deserialize(msg.Stamp);
-        if (Unverifiable || advertised.Epoch == 0 || !advertised.IsDominatedBy(Remote))
+        lock (latest)
         {
-            await PullAsync();
+            latest[advertisement.NodeId] = advertisement;
         }
+        return Task.CompletedTask;
     }
 
-    public async Task OnValueAsync(ValueMsg msg)
-    {
-        var incoming = CausalityStamp.Deserialize(msg.Stamp);
-
-        // An UNVERIFIABLE payload carries the empty stamp, so it must be adopted BEFORE the
-        // ordering checks below (an empty stamp is dominated by anything): the consumer has to
-        // stop trusting its held evidence now, not keep rendering stale verified state. The
-        // held stamps are kept -- they still order future verified payloads -- but the
-        // dominance drop below relaxes to strictly-older-only while unverifiable, so a recovery
-        // republishing the SAME stamp (a transient fault healing without any trigger advancing)
-        // is not mistaken for a duplicate.
-        if (msg.Unverifiable)
-        {
-            Console.WriteLine($"   [B] {Name}: host published UNVERIFIABLE evidence -> rendering blocked until verified again");
-            Unverifiable = true;
-            HasEvidence = true;
-            await Local.Set(_ => msg.Value);
-            return;
-        }
-
-        // LATE TRAFFIC FROM A DEAD INCARNATION: a payload stamped with an epoch this mirror
-        // already abandoned is stale by definition. Without this check the reset detection
-        // below would fire AGAIN on the mismatch (epochs carry no order -- "different" cannot
-        // mean "newer") and roll the mirror back to the dead incarnation's state.
-        if (incoming.Epoch != 0 && abandonedEpochs.Contains(incoming.Epoch))
-        {
-            Console.WriteLine($"   [B] {Name}: DROPPED delivery (stamp from an abandoned incarnation)");
-            return;
-        }
-
-        // RESET detection: a different incarnation epoch means the host restarted -- its ids
-        // and triggers started over, so held evidence must be discarded, never merged (Join
-        // across epochs throws by design). Keyed off the ordering floor, not Remote: the floor
-        // still carries the old epoch while Remote is honestly empty. A real bridge would
-        // resubscribe here.
-        if (floor.Epoch != 0 && incoming.Epoch != 0 && incoming.Epoch != floor.Epoch)
-        {
-            Console.WriteLine($"   [B] {Name}: peer RESET detected (epoch changed) -> discarding held evidence");
-            abandonedEpochs.Add(floor.Epoch);
-            Remote = CausalityStamp.Empty;
-            floor = CausalityStamp.Empty;
-        }
-
-        // LATE / DUPLICATE delivery, ordered against the FLOOR: ordering information only
-        // exists between two NON-EMPTY stamps -- an honestly-empty stamp (the exported node
-        // legitimately depends on no tracked signals) is a real publication, not old news.
-        // While VERIFIED, anything dominated (including equal re-deliveries) is dropped, which
-        // is what makes at-least-once transports harmless. While UNVERIFIABLE, only payloads
-        // STRICTLY below the floor are dropped: a floor-equal verified payload is exactly the
-        // recovery (a transient fault healed without any trigger advancing) and must be
-        // adopted -- but a genuinely older late delivery must still not resurrect stale
-        // verified state.
-        if (floor.Epoch != 0 && incoming.Epoch != 0 && incoming.IsDominatedBy(floor)
-            && (!Unverifiable || !floor.IsDominatedBy(incoming)))
-        {
-            Console.WriteLine($"   [B] {Name}: DROPPED delivery (stamp dominated by held evidence)");
-            return;
-        }
-
-        Remote = incoming;
-        floor = floor.Join(incoming); // empty joins as identity; same epoch is guaranteed above
-        Unverifiable = false;
-        HasEvidence = true;
-        await Local.Set(_ => msg.Value); // from here, B's ordinary local reactivity takes over
-    }
-}
-
-// The host-side outboxes standing in for a transport, one queue per exported node, so the
-// demo can deliver notifications deliberately out of order.
-sealed class Outbox(params int[] nodeIds)
-{
-    private readonly Dictionary<int, Queue<StaleMsg>> queues = nodeIds.ToDictionary(id => id, _ => new Queue<StaleMsg>());
-
-    public void Enqueue(StaleMsg msg)
-    {
-        lock (queues)
-        {
-            queues[msg.NodeId].Enqueue(msg);
-        }
-    }
-
-    public void Drain()
-    {
-        lock (queues)
-        {
-            foreach (var queue in queues.Values)
-            {
-                queue.Clear();
-            }
-        }
-    }
-
-    public StaleMsg DequeueLatest(int nodeId)
-    {
-        lock (queues)
-        {
-            var queue = queues[nodeId];
-            var last = queue.Dequeue();
-            while (queue.Count > 0)
-            {
-                last = queue.Dequeue();
-            }
-            return last;
-        }
-    }
-
-    // The export reactions are debounced; poll until every outbox carries a notification.
-    public async Task WaitForAllAsync()
+    public async Task<StaleNotification> WaitForAdvertisementAfter(int nodeId, long sequence)
     {
         for (var i = 0; i < 500; i++)
         {
-            lock (queues)
+            lock (latest)
             {
-                if (queues.Values.All(queue => queue.Count > 0))
+                if (latest.TryGetValue(nodeId, out var advertisement) && advertisement.Sequence > sequence)
+                {
+                    return advertisement;
+                }
+            }
+            await Task.Delay(10);
+        }
+        throw new TimeoutException("the export did not advertise");
+    }
+}
+
+// Collects rendered snapshots so the script can await a specific one (the debounced barrier
+// may legitimately render the same consistent snapshot more than once).
+sealed class RenderLog
+{
+    private readonly List<(double Dew, double Heat)> rendered = new();
+
+    public void Add(double dew, double heat)
+    {
+        lock (rendered)
+        {
+            rendered.Add((Math.Round(dew, 2), Math.Round(heat, 2)));
+        }
+    }
+
+    public async Task WaitFor(double dew, double heat)
+    {
+        for (var i = 0; i < 500; i++)
+        {
+            lock (rendered)
+            {
+                if (rendered.Contains((dew, heat)))
                 {
                     return;
                 }
             }
             await Task.Delay(10);
         }
-        throw new TimeoutException("exports did not fire");
+        throw new TimeoutException($"the barrier never rendered ({dew:F2}, {heat:F2})");
     }
 }

--- a/samples/DistributedGraphSample/Program.cs
+++ b/samples/DistributedGraphSample/Program.cs
@@ -48,8 +48,12 @@ using var heatExport = peerA.Export(heatIndex, wire.PublishAsync);
 var peerB = new MemoFactory("sample-peer-b", idRangeStart: 2_000, idRangeEnd: 3_000);
 
 // Each mirror's pull delegate is the host's answer path for that node: recompute lazily,
-// answer with the untorn (value, evidence, sequence) triple of one publication.
-var dewMirror = peerB.CreateRemoteSignal("dewMirror", 0.0, dewExport.PullAsync,
+// answer with the untorn (value, evidence, sequence) triple of one publication. It models the
+// node's transport ADDRESS -- whoever is live behind it answers -- which matters in step 4:
+// epoch changes commit only through the mirror's own pull, so after a host restart the same
+// address must reach the new incarnation (as it does on a real bridge).
+var dewHost = dewExport;
+var dewMirror = peerB.CreateRemoteSignal("dewMirror", 0.0, () => dewHost.PullAsync(),
     onPeerReset: () => { Console.WriteLine("   [B] dewMirror: peer RESET detected (epoch changed) -> discarding evidence, resubscribing"); return Task.CompletedTask; });
 var heatMirror = peerB.CreateRemoteSignal("heatMirror", 0.0, heatExport.PullAsync);
 
@@ -100,6 +104,11 @@ var humidity2 = restartedA.CreateSignal("humidity", 0.55);
 var dewPoint2 = restartedA.CreateMemoizR("dewPoint", async () =>
     await temperature2.Get() - (1 - await humidity2.Get()) * 5);
 using var dewExport2 = restartedA.Export(dewPoint2, wire.PublishAsync);
+dewHost = dewExport2; // the address now reaches the restarted incarnation
+// The delivered payload reveals an unknown epoch. The mirror does NOT trust it directly --
+// with unordered epochs it could equally be a delayed payload from a dead incarnation the
+// mirror skipped -- so it discards it and verifies with its own pull; the answer (from
+// whoever is actually alive) commits the reset and runs the resubscription hook.
 await dewMirror.OnValueAsync(await dewExport2.PullAsync());
 Console.WriteLine($"   [B] dewMirror adopted the new incarnation's value: {await dewMirror.Local.Get():F2}");
 

--- a/samples/DistributedGraphSample/README.md
+++ b/samples/DistributedGraphSample/README.md
@@ -1,12 +1,12 @@
 # Distributed reactive graph sample
 
-A minimal two-peer bridge over the **Causality Trigger Clock**
-([issue #39](https://github.com/timonkrebs/MemoizR/issues/39), design:
+A minimal two-peer bridge built on the **MemoizR.Distributed** package
+(tracking: [issue #148](https://github.com/timonkrebs/MemoizR/issues/148), design:
 [docs/architecture/causality-trigger-clock.md](../../docs/architecture/causality-trigger-clock.md)).
 
 Peer A hosts the source-of-truth graph; peer B mirrors two of A's derived values and combines
-them **glitch-free — with no lock spanning the peers** — by checking the causality stamps that
-travel with every value:
+them **glitch-free — with no lock spanning the peers** — via the causality stamps that travel
+with every value:
 
 ```
 peer A                                    peer B
@@ -17,18 +17,20 @@ humidity ─────┴─► heatIndex ──[wire]──►   heatMirror �
 ```
 
 The whole wire protocol is three messages (`Stale`, `Pull`, `Value`); values move only on
-pull, so MemoizR's laziness survives the network. The sample drives the message flow by hand
-so every mechanism is visible:
+pull, so MemoizR's laziness survives the network. The script plays the transport by hand —
+delivering, delaying and duplicating messages deliberately — so every mechanism is visible:
 
-1. **Initial sync** — B pulls both nodes, the barrier renders on a consistent snapshot.
-2. **A racing update** — temperature changes on A; only dewPoint's update is delivered. The
-   barrier detects that the inputs disagree on temperature's trigger (`IsConsistentWith`),
-   identifies the lagging input (`IsDominatedBy`), has it re-pulled, and renders once
-   consistent.
-3. **A late duplicate delivery** — dropped because its stamp is dominated by the held
-   evidence; reordered and at-least-once transports are harmless.
+1. **Initial sync** — B pulls both nodes (`RemoteSignal`), the barrier renders on a consistent
+   snapshot.
+2. **A racing update** — temperature changes on A; only dewPoint's advertisement is delivered.
+   The barrier detects that the mirrors' evidence disagrees on temperature's trigger,
+   re-pulls the lagging mirror **itself**, and renders once consistent.
+3. **A late duplicate delivery** — dropped by the per-publication *sequence* order (which also
+   settles the orderings causality stamps deliberately cannot: a dependency set oscillating
+   through empty re-publishes an earlier stamp on a newer value); reordered and at-least-once
+   transports are harmless.
 4. **A peer restart** — the fresh incarnation epoch is detected on the first payload; held
-   evidence is discarded, never merged.
+   evidence is discarded (never merged) and the `OnPeerReset` resubscription hook runs.
 5. **Late traffic from the pre-reset incarnation** — dropped: epochs are random identifiers,
    not ordered, so the mirror remembers the epochs it abandoned instead of trusting a
    mismatch to mean "newer".
@@ -39,9 +41,7 @@ Run it:
 dotnet run --project samples/DistributedGraphSample
 ```
 
-What this sample deliberately does **not** do: splice peer A's stamps into peer B's *local*
-stamps. The foreign evidence travels beside B's graph (in the `Mirror`), and the barrier
-checks it explicitly — a stamp-adopting `RemoteSignal<T>` that publishes a foreign
-`(value, evidence)` pair into the local evidence chain is the future `MemoizR.Distributed`
-package's job (a friend assembly, like `MemoizR.Reactive`), together with the multi-peer
-epoch table (wire format v3).
+What the package deliberately does **not** do yet: splice peer A's stamps into peer B's
+*local* stamps. The foreign evidence travels beside B's graph (in the `RemoteSignal`) and the
+barrier checks it explicitly — first-class splicing needs the multi-peer epoch table
+(wire-format v3), tracked in [#148](https://github.com/timonkrebs/MemoizR/issues/148).

--- a/samples/DistributedGraphSample/README.md
+++ b/samples/DistributedGraphSample/README.md
@@ -29,8 +29,11 @@ delivering, delaying and duplicating messages deliberately — so every mechanis
    settles the orderings causality stamps deliberately cannot: a dependency set oscillating
    through empty re-publishes an earlier stamp on a newer value); reordered and at-least-once
    transports are harmless.
-4. **A peer restart** — the fresh incarnation epoch is detected on the first payload; held
-   evidence is discarded (never merged) and the `OnPeerReset` resubscription hook runs.
+4. **A peer restart** — the fresh incarnation epoch is detected on the first payload, but not
+   trusted from an unsolicited delivery (with unordered epochs it could equally be a delayed
+   payload from a dead incarnation the mirror skipped): the mirror verifies with its own pull,
+   whose answer commits the reset — held evidence is discarded (never merged) and the
+   `OnPeerReset` resubscription hook runs.
 5. **Late traffic from the pre-reset incarnation** — dropped: epochs are random identifiers,
    not ordered, so the mirror remembers the epochs it abandoned instead of trusting a
    mismatch to mean "newer".


### PR DESCRIPTION
Follow-up to #117, delivering the first slice of #148 plus the benchmarks harness. Rebased onto post-#149 main: the `MemoFactoryOptions.DisableCausalityStamps` flag this PR originally carried landed independently in #149 with the same context-binding rule, so this PR now contributes the flag's documentation (changelog/README/architecture doc, aligned with the merged no-claim semantics) rather than its implementation.

## MemoizR.Distributed v0 (new package)

Productizes the sample&#39;s bridge protocol as a friend assembly:

- **`ExportedNode`** — an export is a reaction: value changes push a stale advertisement (id + ordering header + stamp, no value) to the caller&#39;s transport sink; pulls answer the untorn `(value, evidence, sequence)` triple of one publication; an optional heartbeat re-advertises for the evidence-only transitions the value cascade deliberately does not push. Exporting from a stamps-disabled context throws.
- **`RemoteSignal`** — a local eager signal (exposed read-only: only the adoption protocol writes the mirror) fed by an adoption protocol hardened by two Codex review rounds: per-publication **sequences** totally order deliveries within an epoch (including the dependency-oscillation shapes causality stamps provably cannot order, and equally during unverifiable spells); adoptions publish value+evidence as one atomic `AdoptedPublication` snapshot; payloads are validated against the bound node id (misrouting on multiplexed bridges rejects instead of corrupting the sequence order); epoch changes commit only through the mirror's own latest pull (with unordered epochs, a delayed payload from a skipped dead incarnation is indistinguishable from a live restart — pull verification is what keeps it from abandoning the live epoch), with `OnPeerReset` running after the adoption commits, outside the gate (hook failures can't wedge the mirror; hooks may pull the same mirror); abandoned epochs drop late traffic from dead incarnations.
- **`DistributedBarrier`** — renders only consistent, verified snapshots (from the atomic publications, compared epoch-first so an honestly-empty stamp can't vacuously pass across incarnations) and re-pulls the lagging mirror itself on a flow-suppressed task (the reaction's lock scope must not leak into the repull); when dominance cannot tell which side lags, it re-pulls both, which is what keeps the recovery loop from spinning. Diagnostics callbacks are isolated from the healing path.
- **Core**: each value box now carries a strictly increasing per-node publication sequence (one `Interlocked.Increment` per publish) — the per-node total order stamps deliberately do not provide.
- The sample migrated to the package: same five demo steps, the barrier heals the glitch itself, the advertisement waits are sequence-based, and the pull delegates model the transport address (whoever is live answers), as pull-verified resets require.

## `benchmarks/MemoizR.Benchmarks`

The measurement harness behind the overhead numbers, in-repo and runnable against any checkout via `-p:MemoizRPath=` for before/after comparisons; the stamps-disabled rows resolve the flag at runtime. On post-#149 main the flag still saves ~1.8 KB per recompute (chain 6423→4610 B/op, diamond 6231→4419 B/op).

## Verification

- Full suite green after the rebase (328 + 56 analyzer tests; 22 distributed-package tests: sequence ordering, pull-verified resets, node binding, unverifiability, publication atomicity, barrier healing end-to-end incl. cross-incarnation empty-stamp restarts)
- Coyote systematic pass green on rewritten assemblies (including `MemoizR.Distributed`)
- cognitive-complexity gate (S3776 ≤ 15) clean
- sample runs to completion repeatedly with the expected five-step output; benchmarks harness runs against the rebased core

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zkA8tQDPMggf7p4yyccv9