### PR TITLE
ADR 0007: Transitions, pending indicators, and optimistic state

### DIFF
--- a/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SendableTypeArgumentAnalyzerTests.cs
@@ -582,4 +582,56 @@ public class SendableTypeArgumentAnalyzerTests
         var diagnostic = Assert.Single(diagnostics);
         Assert.Equal("MZR001", diagnostic.Id);
     }
+
+    // ADR 0007's process layer: the action payload crosses to the detached run flow and the
+    // optimistic view publishes T across flows -- both are runtime-checked in strict mode, so
+    // the build-time mirror must cover them like every other value-bearing factory.
+    [Fact]
+    public async Task ProcessLayerFactories_MutableTypeArguments_AreFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using MemoizR;
+
+            public sealed class ListSource : IStateGetR<List<int>>
+            {
+                public Task<List<int>> Get() => Task.FromResult(new List<int>());
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateAction<List<int>>((p, ctx) => Task.CompletedTask);
+                    f.CreateOptimistic<List<int>>(new ListSource());
+                }
+            }
+            """);
+
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR001", d.Id));
+    }
+
+    [Fact]
+    public async Task ProcessLayerFactories_ImmutableTypeArguments_AreNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Threading.Tasks;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateAction<string>((p, ctx) => Task.CompletedTask);
+                    f.CreateOptimistic<int>(f.CreateSignal(1));
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -32,6 +32,35 @@ public class SetInsideComputationAnalyzerTests
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
 
+    // Invalidate (the ADR 0007 refresh) takes the same exclusive lock as Set and throws
+    // identically inside a same-flow computation; the runtime contract is pinned by
+    // StabilizationAndInvalidateTests.Invalidate_InsideComputation_IsRejectedLikeSet.
+    [Fact]
+    public async Task InvalidateInsideMemoComputation_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var m1 = f.CreateMemoizR(async () => 1);
+                    f.CreateMemoizR(async () =>
+                    {
+                        await m1.Invalidate();
+                        return 2;
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains(".Invalidate", diagnostic.GetMessage());
+    }
+
     [Fact]
     public async Task SetInsideReaction_IsFlagged()
     {

--- a/MemoizR.Analyzers/DiagnosticDescriptors.cs
+++ b/MemoizR.Analyzers/DiagnosticDescriptors.cs
@@ -42,8 +42,8 @@ internal static class DiagnosticDescriptors
 
     public static readonly DiagnosticDescriptor SetInsideComputation = new(
         id: "MZR003",
-        title: "Signal.Set inside a reactive computation throws at runtime",
-        messageFormat: "'{0}.Set' is called inside a reactive computation; the computation's flow already holds " +
+        title: "A graph write inside a reactive computation throws at runtime",
+        messageFormat: "'{0}.{1}' is called inside a reactive computation; the computation's flow already holds " +
                        "the evaluation lock in upgradeable mode, so this exclusive acquisition throws " +
                        "InvalidOperationException at runtime — return the value instead, or schedule the write " +
                        "outside the evaluation",

--- a/MemoizR.Analyzers/FactoryMethods.cs
+++ b/MemoizR.Analyzers/FactoryMethods.cs
@@ -17,7 +17,11 @@ internal static class FactoryMethods
     public static bool IsValueBearingCreation(IMethodSymbol method)
     {
         return IsMemoFactoryMethod(method, "CreateSignal", "CreateEagerRelativeSignal", "CreateMemoizR", "CreateActorSignal", "CreateActorMemoizR")
-            || IsStructuredFactoryMethod(method, "CreateConcurrentMap", "CreateConcurrentMapReduce", "CreateConcurrentRace");
+            || IsStructuredFactoryMethod(method, "CreateConcurrentMap", "CreateConcurrentMapReduce", "CreateConcurrentRace")
+            // ADR 0007's process layer: CreateAction's TPayload crosses to the detached run
+            // flow, CreateOptimistic's T is the value its composed view publishes -- both are
+            // runtime-checked in strict mode, so they get the same build-time mirror.
+            || IsReactiveMemoFactoryMethod(method, "CreateAction", "CreateOptimistic");
     }
 
     // Methods whose delegate arguments execute inside graph evaluations, possibly concurrently

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -47,7 +47,8 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.SetInsideComputation,
                         ComputationLambdas.NameLocation(inner),
-                        SendableSymbolClassifier.Display(inner.TargetMethod.ContainingType)));
+                        SendableSymbolClassifier.Display(inner.TargetMethod.ContainingType),
+                        inner.TargetMethod.Name));
                 }
             }
         }
@@ -92,16 +93,13 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
             || !Equals(hostContext.ContextKey, targetContext.ContextKey);
     }
 
-    // A Set that throws in THIS host's engine: ActorSignal.Set inside an actor computation, or
-    // lock-engine Signal/EagerRelativeSignal.Set inside a lock-engine computation. A cross-engine
-    // Set takes no same-flow lock and does not throw, so it must not be flagged.
+    // A write API that throws in THIS host's engine: ActorSignal.Set inside an actor
+    // computation, or lock-engine Signal/EagerRelativeSignal.Set and MemoBase.Invalidate (the
+    // ADR 0007 refresh, which takes the same exclusive lock as Set) inside a lock-engine
+    // computation. A cross-engine write takes no same-flow lock and does not throw, so it must
+    // not be flagged.
     private static bool IsSameEngineSet(IMethodSymbol method, bool actorHost)
     {
-        if (method.Name != "Set")
-        {
-            return false;
-        }
-
         var type = method.ContainingType?.OriginalDefinition;
         if (type is not { Arity: 1 } || type.ContainingNamespace?.ToDisplayString() != "MemoizR"
             || !FactoryMethods.IsLibraryType(type))
@@ -112,8 +110,12 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        return actorHost
-            ? type.Name == "ActorSignal"
-            : type.Name is "Signal" or "EagerRelativeSignal";
+        if (actorHost)
+        {
+            return method.Name == "Set" && type.Name == "ActorSignal";
+        }
+
+        return (method.Name == "Set" && type.Name is "Signal" or "EagerRelativeSignal")
+            || (method.Name == "Invalidate" && type.Name == "MemoBase");
     }
 }

--- a/MemoizR.Blazor.Tests/BlazorIntegrationTests.cs
+++ b/MemoizR.Blazor.Tests/BlazorIntegrationTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MemoizR.Reactive;
+
+namespace MemoizR.Blazor.Tests;
+
+// Phase 4 of ADR 0007, tested against Blazor's real renderer dispatcher
+// (Dispatcher.CreateDefault -- the same implementation Blazor Server circuits use), so the
+// thread-pool/renderer-context split is exercised without spinning up a renderer.
+public class BlazorIntegrationTests
+{
+    private static async Task WaitForConvergenceAsync(Func<bool> converged, int timeoutMs = 5000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!converged() && sw.ElapsedMilliseconds < timeoutMs)
+        {
+            await Task.Delay(10);
+        }
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task BlazorDispatcherExecutor_RunsActionsOnTheDispatcher_DependenciesOffIt()
+    {
+        var dispatcher = Dispatcher.CreateDefault();
+        var f = new MemoFactory().AddBlazorDispatcher(dispatcher);
+
+        var v = f.CreateSignal(1);
+        var computedOnDispatcher = true;
+        var m = f.CreateMemoizR(async () =>
+        {
+            // Dependency evaluation must stay off the renderer's context.
+            computedOnDispatcher &= dispatcher.CheckAccess();
+            return await v.Get() * 2;
+        });
+
+        var observed = 0;
+        var actionOnDispatcher = false;
+        var r = f.BuildReaction().CreateReaction(m, value =>
+        {
+            actionOnDispatcher = dispatcher.CheckAccess();
+            Volatile.Write(ref observed, value);
+        });
+
+        await v.Set(5);
+        await WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 10);
+
+        Assert.True(actionOnDispatcher);
+        Assert.False(computedOnDispatcher);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ReactionBinder_AppliesValuesAndNotifies_ThroughTheDispatchDelegate()
+    {
+        var dispatcher = Dispatcher.CreateDefault();
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var m = f.CreateMemoizR(async () => await v.Get() * 2);
+
+        // The component-side snapshot the render would read, plus the StateHasChanged count.
+        var snapshot = 0;
+        var renders = 0;
+        var appliedOnDispatcher = true;
+        var binder = new ReactionBinder(
+            f,
+            work => dispatcher.InvokeAsync(work),
+            () => Interlocked.Increment(ref renders));
+
+        binder.Bind(m, value =>
+        {
+            appliedOnDispatcher &= dispatcher.CheckAccess();
+            Volatile.Write(ref snapshot, value);
+        });
+
+        await WaitForConvergenceAsync(() => Volatile.Read(ref snapshot) == 2);
+        await v.Set(5);
+        await WaitForConvergenceAsync(() => Volatile.Read(ref snapshot) == 10);
+
+        Assert.True(appliedOnDispatcher);
+        Assert.True(Volatile.Read(ref renders) >= 2); // initial apply + the change
+
+        // Disposing the binder stops the bindings: no further applies or renders.
+        binder.Dispose();
+        var rendersAtDispose = Volatile.Read(ref renders);
+        await v.Set(7);
+        await Task.Delay(100);
+        Assert.Equal(10, Volatile.Read(ref snapshot));
+        Assert.Equal(rendersAtDispose, Volatile.Read(ref renders));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ReactionBinder_DrivesPendingIndicators()
+    {
+        var dispatcher = Dispatcher.CreateDefault();
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var optimistic = f.CreateOptimistic<int>(v);
+        var server = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var act = f.CreateAction<int>(async (delta, ctx) =>
+        {
+            await ctx.Apply(optimistic, x => x + delta);
+            await server.Task;
+        });
+
+        // The disabled-button binding: a component field driven by the action's pending flag.
+        var buttonDisabled = false;
+        var value = 0;
+        var binder = new ReactionBinder(f, work => dispatcher.InvokeAsync(work), () => { });
+        binder.Bind(act.IsPending, pending => Volatile.Write(ref buttonDisabled, pending));
+        binder.Bind(optimistic, x => Volatile.Write(ref value, x));
+
+        await WaitForConvergenceAsync(() => Volatile.Read(ref value) == 1);
+        var run = act.Run(5);
+        await WaitForConvergenceAsync(() => Volatile.Read(ref buttonDisabled) && Volatile.Read(ref value) == 6);
+
+        server.SetResult();
+        await run.Completion;
+        await run.Settled;
+        await WaitForConvergenceAsync(() => !Volatile.Read(ref buttonDisabled) && Volatile.Read(ref value) == 1);
+        Assert.False(Volatile.Read(ref buttonDisabled));
+        Assert.Equal(1, Volatile.Read(ref value)); // no confirm write in this action: rolled forward to source truth
+
+        binder.Dispose();
+    }
+
+    [Fact]
+    public void AddMemoizR_RegistersOneFactoryPerScope()
+    {
+        var services = new ServiceCollection().AddMemoizR().BuildServiceProvider();
+
+        using var circuit1 = services.CreateScope();
+        using var circuit2 = services.CreateScope();
+
+        var f1a = circuit1.ServiceProvider.GetRequiredService<MemoFactory>();
+        var f1b = circuit1.ServiceProvider.GetRequiredService<MemoFactory>();
+        var f2 = circuit2.ServiceProvider.GetRequiredService<MemoFactory>();
+
+        Assert.Same(f1a, f1b);   // one graph per circuit
+        Assert.NotSame(f1a, f2); // circuits are isolated
+    }
+}

--- a/MemoizR.Blazor.Tests/BlazorIntegrationTests.cs
+++ b/MemoizR.Blazor.Tests/BlazorIntegrationTests.cs
@@ -122,6 +122,39 @@ public class BlazorIntegrationTests
         binder.Dispose();
     }
 
+    [Fact(Timeout = 5000)]
+    public async Task ReactionBinder_DispatchRejection_FallsBackWithoutHanging()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var reject = false;
+        var applied = 0;
+        var binder = new ReactionBinder(
+            f,
+            work =>
+            {
+                if (Volatile.Read(ref reject))
+                {
+                    return Task.FromException(new InvalidOperationException("renderer gone"));
+                }
+                work();
+                return Task.CompletedTask;
+            },
+            () => { });
+        binder.Bind(v, x => Volatile.Write(ref applied, x));
+        await WaitForConvergenceAsync(() => Volatile.Read(ref applied) == 1);
+
+        // The dispatcher rejects the work without running it: the executor must fall back
+        // inline so the reaction's update pipeline (and any pending flag or transition hanging
+        // off it) completes instead of waiting forever on a callback that will never run.
+        Volatile.Write(ref reject, true);
+        await v.Set(5);
+        await WaitForConvergenceAsync(() => Volatile.Read(ref applied) == 5);
+        Assert.Equal(5, Volatile.Read(ref applied));
+
+        binder.Dispose();
+    }
+
     [Fact]
     public void AddMemoizR_RegistersOneFactoryPerScope()
     {

--- a/MemoizR.Blazor.Tests/MemoizR.Blazor.Tests.csproj
+++ b/MemoizR.Blazor.Tests/MemoizR.Blazor.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MemoizR.Blazor\MemoizR.Blazor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MemoizR.Blazor.Tests/Usings.cs
+++ b/MemoizR.Blazor.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/MemoizR.Blazor/BlazorMemoFactory.cs
+++ b/MemoizR.Blazor/BlazorMemoFactory.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Components;
+
+namespace MemoizR;
+
+// Blazor wiring for the thread-pool/UI split (#13, ADR 0007 phase 4), mirroring
+// MemoizR.Wpf: signals, memos and every reaction's dependency evaluation stay on the thread
+// pool; only the reaction's action is marshalled to the renderer's dispatcher -- on Blazor
+// Server that is the circuit's synchronization context, on WebAssembly the single UI thread.
+public static class BlazorMemoFactory
+{
+    /// <summary>
+    /// Routes the actions of reactions built from this factory to the given renderer
+    /// <see cref="Dispatcher"/>; dependency evaluation stays on the thread pool. Components
+    /// that own their bindings should prefer <see cref="MemoizRComponentBase"/>, which
+    /// marshals through the component's own <c>InvokeAsync</c> instead.
+    /// </summary>
+    public static MemoFactory AddBlazorDispatcher(this MemoFactory memoFactory, Dispatcher dispatcher)
+    {
+        ArgumentNullException.ThrowIfNull(dispatcher);
+        return memoFactory.AddExecutor(new BlazorDispatcherExecutor(dispatcher));
+    }
+}
+
+// A dispatcher-backed IExecutor, the exact Blazor mirror of WpfDispatcherExecutor: IsCurrent
+// asks the dispatcher directly via CheckAccess -- true exactly when the caller is on the
+// renderer's synchronization context -- so executor.AssertIsolated() works for dispatched
+// reaction actions.
+internal sealed class BlazorDispatcherExecutor(Dispatcher dispatcher) : IExecutor
+{
+    public void Enqueue(Action work) => _ = dispatcher.InvokeAsync(work);
+
+    public bool IsCurrent => dispatcher.CheckAccess();
+}

--- a/MemoizR.Blazor/BlazorMemoFactory.cs
+++ b/MemoizR.Blazor/BlazorMemoFactory.cs
@@ -27,7 +27,24 @@ public static class BlazorMemoFactory
 // reaction actions.
 internal sealed class BlazorDispatcherExecutor(Dispatcher dispatcher) : IExecutor
 {
-    public void Enqueue(Action work) => _ = dispatcher.InvokeAsync(work);
+    public void Enqueue(Action work) => _ = EnqueueCore(work);
+
+    private async Task EnqueueCore(Action work)
+    {
+        try
+        {
+            await dispatcher.InvokeAsync(work).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The dispatcher rejected the work without running it (circuit/renderer teardown):
+            // ExecutorInvoke would wait forever on a callback that never runs, wedging the
+            // reaction's update pipeline, its pending flag and any transition. Run it inline
+            // instead -- the ExecutorInvoke wrapper never throws, and Blazor's dispatcher
+            // faults its task only when the work did not run, so this cannot double-run it.
+            work();
+        }
+    }
 
     public bool IsCurrent => dispatcher.CheckAccess();
 }

--- a/MemoizR.Blazor/MemoizR.Blazor.csproj
+++ b/MemoizR.Blazor/MemoizR.Blazor.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\MemoizR.Reactive\MemoizR.Reactive.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <PackageId>MemoizR.Blazor</PackageId>
+    <Version>0.0.5</Version>
+    <Authors>Timon Krebs</Authors>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageReadmeFile>NUGET_BLAZOR_README.md</PackageReadmeFile>
+    <PackageIcon>MemoizR-Small.png</PackageIcon>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageTags>Blazor, Dispatcher, UI, UI Thread, Circuit, Signal, Signals, Signaling, Reactive, Reactivity, Memoization, Graph, Dependency, Dependencies, Dynamic Dependencies, Concurrency, Thread Pool, Sync, Synchronization, State, State Synchronization, Transitions, Optimistic</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+        <None Include="..\docs\NUGET_BLAZOR_README.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\MemoizR-Small.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/MemoizR.Blazor/MemoizRComponentBase.cs
+++ b/MemoizR.Blazor/MemoizRComponentBase.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Components;
+
+namespace MemoizR;
+
+/// <summary>
+/// Component base for MemoizR-driven Blazor UIs (ADR 0007 phase 4). Call
+/// <see cref="Bind{T}"/> from <c>OnInitialized</c> to project graph nodes into component
+/// fields: dependency evaluation runs on the thread pool, and only the field write plus
+/// <c>StateHasChanged</c> are marshalled through the component's <c>InvokeAsync</c>. Markup
+/// then reads those fields (and sync snapshots like <c>Transition.IsPending</c> /
+/// <c>ReactionBase.IsPendingSnapshot</c>) -- renders stay synchronous while the graph stays
+/// async. Bindings are disposed with the component.
+/// </summary>
+public abstract class MemoizRComponentBase : ComponentBase, IDisposable
+{
+    private ReactionBinder? binder;
+
+    /// <summary>The scoped factory registered by <c>services.AddMemoizR()</c> -- per circuit
+    /// on Blazor Server, per app on WebAssembly.</summary>
+    [Inject]
+    protected MemoFactory MemoFactory { get; set; } = default!;
+
+    /// <summary>The component's binder; created on first use. Only call after initialization
+    /// has started (<c>OnInitialized</c> or later), when <c>InvokeAsync</c> is available.</summary>
+    protected ReactionBinder Binder => binder ??= new(MemoFactory, work => InvokeAsync(work), StateHasChanged);
+
+    /// <summary>Projects <paramref name="source"/> into the component: <paramref name="apply"/>
+    /// writes the value into a field on the renderer's context, then the component re-renders.</summary>
+    protected void Bind<T>(IStateGetR<T> source, Action<T> apply) => Binder.Bind(source, apply);
+
+    public virtual void Dispose()
+    {
+        binder?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/MemoizR.Blazor/ReactionBinder.cs
+++ b/MemoizR.Blazor/ReactionBinder.cs
@@ -93,7 +93,27 @@ public sealed class ReactionBinder : IDisposable
     // an InvokeAsync issued from its own context.
     private sealed class DispatchExecutor(Func<Action, Task> dispatch) : IExecutor
     {
-        public void Enqueue(Action work) => _ = dispatch(work);
+        public void Enqueue(Action work) => _ = EnqueueCore(work);
+
+        private async Task EnqueueCore(Action work)
+        {
+            try
+            {
+                await dispatch(work).ConfigureAwait(false);
+            }
+            catch
+            {
+                // The dispatcher rejected the work (renderer teardown): `work` never ran, and
+                // ExecutorInvoke would wait forever on its completion -- wedging the reaction's
+                // update pipeline, its pending flag and any transition. Run it inline instead,
+                // like DedicatedThreadExecutor's after-shutdown fallback; the wrapper never
+                // throws, and the disposal re-check in the bound action keeps a torn-down
+                // component from being touched. (A dispatcher that rejects only AFTER running
+                // the work would double-run it; Blazor's dispatcher faults its task only when
+                // the work did not run.)
+                work();
+            }
+        }
 
         public bool IsCurrent => false;
     }

--- a/MemoizR.Blazor/ReactionBinder.cs
+++ b/MemoizR.Blazor/ReactionBinder.cs
@@ -1,0 +1,91 @@
+using MemoizR.Reactive;
+
+namespace MemoizR;
+
+/// <summary>
+/// Binds reactive nodes to a UI surface (ADR 0007 phase 4): each <see cref="Bind"/> builds a
+/// reaction whose dependency evaluation runs on the thread pool and whose apply-and-notify
+/// step is marshalled through the supplied dispatch delegate (a component's
+/// <c>InvokeAsync</c>). Renders are synchronous, MemoizR reads are async -- so the binder's
+/// applied values ARE the render snapshot: markup reads the fields the apply callbacks wrote,
+/// never the graph directly. Dispose with the component; disposing stops all bindings.
+/// Component authors normally use <see cref="MemoizRComponentBase"/> instead of this directly.
+/// </summary>
+public sealed class ReactionBinder : IDisposable
+{
+    private readonly MemoFactory factory;
+    private readonly IExecutor executor;
+    private readonly Action notifyChanged;
+    private readonly Lock gate = new();
+    private readonly List<IDisposable> reactions = new();
+    private bool disposed;
+
+    /// <param name="factory">The factory whose graph the bindings observe.</param>
+    /// <param name="dispatch">Marshals work onto the UI surface -- pass the component's
+    /// <c>InvokeAsync</c>. Faults thrown by the dispatched work surface through the reaction's
+    /// fault machinery (the binding stays dirty and re-runs on the next change).</param>
+    /// <param name="notifyChanged">Called after a binding applied a new value, on the UI
+    /// surface -- pass <c>StateHasChanged</c>.</param>
+    public ReactionBinder(MemoFactory factory, Func<Action, Task> dispatch, Action notifyChanged)
+    {
+        this.factory = factory;
+        this.notifyChanged = notifyChanged;
+        executor = new DispatchExecutor(dispatch);
+    }
+
+    /// <summary>
+    /// Observes <paramref name="source"/>: on every committed change, <paramref name="apply"/>
+    /// runs on the UI surface with the new value (write it into a component field), followed
+    /// by the change notification. The initial value is applied eagerly.
+    /// </summary>
+    public void Bind<T>(IStateGetR<T> source, Action<T> apply)
+    {
+        var reaction = factory.BuildReaction("Blazor.Bind")
+            .AddExecutor(executor)
+            .CreateReaction(source, value =>
+            {
+                apply(value);
+                notifyChanged();
+            });
+
+        lock (gate)
+        {
+            if (disposed)
+            {
+                reaction.Dispose();
+                return;
+            }
+            reactions.Add(reaction);
+        }
+    }
+
+    public void Dispose()
+    {
+        IDisposable[] toDispose;
+        lock (gate)
+        {
+            if (disposed)
+            {
+                return;
+            }
+            disposed = true;
+            toDispose = [.. reactions];
+            reactions.Clear();
+        }
+
+        foreach (var reaction in toDispose)
+        {
+            reaction.Dispose();
+        }
+    }
+
+    // InvokeAsync-backed executor. IsCurrent is conservatively false (a component exposes no
+    // CheckAccess), which only costs an extra hop: the renderer's dispatcher already inlines
+    // an InvokeAsync issued from its own context.
+    private sealed class DispatchExecutor(Func<Action, Task> dispatch) : IExecutor
+    {
+        public void Enqueue(Action work) => _ = dispatch(work);
+
+        public bool IsCurrent => false;
+    }
+}

--- a/MemoizR.Blazor/ReactionBinder.cs
+++ b/MemoizR.Blazor/ReactionBinder.cs
@@ -18,7 +18,8 @@ public sealed class ReactionBinder : IDisposable
     private readonly Action notifyChanged;
     private readonly Lock gate = new();
     private readonly List<IDisposable> reactions = new();
-    private bool disposed;
+    // Volatile: also read inside dispatched callbacks, which can be in flight when Dispose runs.
+    private volatile bool disposed;
 
     /// <param name="factory">The factory whose graph the bindings observe.</param>
     /// <param name="dispatch">Marshals work onto the UI surface -- pass the component's
@@ -44,6 +45,14 @@ public sealed class ReactionBinder : IDisposable
             .AddExecutor(executor)
             .CreateReaction(source, value =>
             {
+                // Disposing the underlying reaction cannot recall a callback that is already
+                // dispatched to the UI surface; re-checking here keeps the disposal contract
+                // (no apply/StateHasChanged after teardown). Both this callback and Dispose
+                // normally run on the renderer's context, so the check is race-free there.
+                if (disposed)
+                {
+                    return;
+                }
                 apply(value);
                 notifyChanged();
             });

--- a/MemoizR.Blazor/ServiceCollectionExtensions.cs
+++ b/MemoizR.Blazor/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MemoizR;
+
+public static class MemoizRServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a scoped <see cref="MemoFactory"/>: one reactive graph per circuit on Blazor
+    /// Server (circuits are genuinely multi-threaded -- exactly what MemoizR's cross-flow
+    /// guarantees are for), one per app on WebAssembly. Inject it into components (built in
+    /// for <see cref="MemoizRComponentBase"/>) or services.
+    /// </summary>
+    public static IServiceCollection AddMemoizR(this IServiceCollection services, MemoFactoryOptions options = MemoFactoryOptions.None)
+    {
+        return services.AddScoped(_ => new MemoFactory(null, options));
+    }
+}

--- a/MemoizR.Reactive/Friends.cs
+++ b/MemoizR.Reactive/Friends.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MemoizR.Tests")]

--- a/MemoizR.Reactive/OptimisticState.cs
+++ b/MemoizR.Reactive/OptimisticState.cs
@@ -2,6 +2,16 @@ using System.Collections.Immutable;
 
 namespace MemoizR.Reactive;
 
+// A value source that DELEGATES to a real graph node (OptimisticState wraps its composed view
+// memo). ReactionBuilder unwraps this so the multi-parameter CreateReaction overloads register
+// the dependency and record its stamps against the backing node -- a plain IStateGetR wrapper
+// would be skipped by RegisterDependencies and read untracked on the isolated scope, so the
+// reaction would never re-run when the wrapped state changes.
+internal interface INodeBackedGetR
+{
+    SignalHandlR Node { get; }
+}
+
 /// <summary>
 /// An optimistic view over a source of truth (ADR 0007): reads return the source value with
 /// every in-flight optimistic patch applied on top, so a user action can instantly project its
@@ -12,8 +22,10 @@ namespace MemoizR.Reactive;
 /// ordinary graph nodes; propagation, memoization, laziness and causality evidence all apply
 /// unchanged. Patch functions run inside the view's computation and must be pure.
 /// </summary>
-public sealed class OptimisticState<T> : IStateGetR<T>
+public sealed class OptimisticState<T> : IStateGetR<T>, INodeBackedGetR
 {
+    SignalHandlR INodeBackedGetR.Node => view;
+
     // The overlay is an EagerRelativeSignal so patch add/remove is an atomic read-modify-write
     // under the signal's own lock. Constructed through the internal ctor on purpose: the strict
     // Sendable check would reject the delegate-carrying tuples, but the list is immutable and
@@ -48,8 +60,12 @@ public sealed class OptimisticState<T> : IStateGetR<T>
         return id;
     }
 
-    internal Task RemovePatchAsync(long id)
+    // A run's patches on this state are removed in ONE read-modify-write: dropping them
+    // individually would expose intermediate frames in which a later patch applies without the
+    // earlier patch it builds on (a patch assuming the shape its predecessor produced could
+    // then throw, or project an impossible value to a concurrent Get).
+    internal Task RemovePatchesAsync(IReadOnlyCollection<long> ids)
     {
-        return overlay.Set(list => list.RemoveAll(p => p.Id == id));
+        return overlay.Set(list => list.RemoveAll(p => ids.Contains(p.Id)));
     }
 }

--- a/MemoizR.Reactive/OptimisticState.cs
+++ b/MemoizR.Reactive/OptimisticState.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+
+namespace MemoizR.Reactive;
+
+/// <summary>
+/// An optimistic view over a source of truth (ADR 0007): reads return the source value with
+/// every in-flight optimistic patch applied on top, so a user action can instantly project its
+/// expected future state while the real process (network write, revalidation) runs in the
+/// background. Rollback is STRUCTURAL -- a failed action simply removes its patch, the source
+/// was never touched -- so overlapping actions compose: each owns its patch, and one action's
+/// rollback can never clobber another's projection. The overlay and the composed view are
+/// ordinary graph nodes; propagation, memoization, laziness and causality evidence all apply
+/// unchanged. Patch functions run inside the view's computation and must be pure.
+/// </summary>
+public sealed class OptimisticState<T> : IStateGetR<T>
+{
+    // The overlay is an EagerRelativeSignal so patch add/remove is an atomic read-modify-write
+    // under the signal's own lock. Constructed through the internal ctor on purpose: the strict
+    // Sendable check would reject the delegate-carrying tuples, but the list is immutable and
+    // runtime-owned -- the user-facing value type T is still checked by CreateMemoizR below.
+    private readonly EagerRelativeSignal<ImmutableList<(long Id, Func<T, T> Patch)>> overlay;
+    private readonly MemoizR<T> view;
+    private long nextPatchId;
+
+    internal OptimisticState(MemoFactory factory, IStateGetR<T> source, string label)
+    {
+        overlay = new(ImmutableList<(long Id, Func<T, T> Patch)>.Empty, factory.Context)
+        {
+            Label = $"{label}.Overlay"
+        };
+        view = factory.CreateMemoizR($"{label}.View", async () =>
+        {
+            var baseValue = await source.Get();
+            var patches = await overlay.Get();
+            return patches.Aggregate(baseValue, (acc, p) => p.Patch(acc));
+        });
+    }
+
+    /// <summary>The composed read: source of truth with the in-flight patches applied.</summary>
+    public Task<T> Get() => view.Get();
+
+    // Applies a patch and returns its handle; only OptimisticActionContext calls this, so every
+    // patch is owned by exactly one action run and dropped when that run ends.
+    internal async Task<long> ApplyPatchAsync(Func<T, T> patch)
+    {
+        var id = Interlocked.Increment(ref nextPatchId);
+        await overlay.Set(list => list.Add((id, patch))).ConfigureAwait(false);
+        return id;
+    }
+
+    internal Task RemovePatchAsync(long id)
+    {
+        return overlay.Set(list => list.RemoveAll(p => p.Id == id));
+    }
+}

--- a/MemoizR.Reactive/OptimisticState.cs
+++ b/MemoizR.Reactive/OptimisticState.cs
@@ -51,13 +51,21 @@ public sealed class OptimisticState<T> : IStateGetR<T>, INodeBackedGetR
     /// <summary>The composed read: source of truth with the in-flight patches applied.</summary>
     public Task<T> Get() => view.Get();
 
-    // Applies a patch and returns its handle; only OptimisticActionContext calls this, so every
-    // patch is owned by exactly one action run and dropped when that run ends.
-    internal async Task<long> ApplyPatchAsync(Func<T, T> patch)
+    // Applies a patch, admitting it through the caller's callback INSIDE the overlay's
+    // read-modify-write: admission (recording the id with the owning run) and landing are one
+    // atomic step against the run's close sweep, whose removals serialize on this same overlay
+    // lock -- so a patch can never land unrecorded and outlive the run's settlement. Only
+    // OptimisticActionContext calls this; a rejected patch leaves the overlay untouched.
+    internal async Task<bool> TryApplyPatchAsync(Func<T, T> patch, Func<long, bool> admit)
     {
         var id = Interlocked.Increment(ref nextPatchId);
-        await overlay.Set(list => list.Add((id, patch))).ConfigureAwait(false);
-        return id;
+        var admitted = false;
+        await overlay.Set(list =>
+        {
+            admitted = admit(id);
+            return admitted ? list.Add((id, patch)) : list;
+        }).ConfigureAwait(false);
+        return admitted;
     }
 
     // A run's patches on this state are removed in ONE read-modify-write: dropping them

--- a/MemoizR.Reactive/PendingPublisher.cs
+++ b/MemoizR.Reactive/PendingPublisher.cs
@@ -47,17 +47,33 @@ internal sealed class PendingPublisher(Context context, Func<bool> snapshot, str
             {
                 // The pump inherits the scheduling flow's ExecutionContext -- including any
                 // ambient transition tag, which must not re-register the signal's observers
-                // on the transition (it could never settle).
+                // on the transition (it could never settle)...
                 TransitionFlow.Suppress();
-                await prev.ConfigureAwait(false);
+                // ...and including the flow's lock-scope key: Publish is called from inside
+                // committing evaluations and invalidation cascades whose pinned scope still
+                // HOLDS its ContextLock, so an inherited key would make the Set below a
+                // recursive exclusive acquisition -- which the lock rejects, silently dropping
+                // the publish (the pending flag then misses a whole window; this hung the
+                // gated transition tests on windows-latest). A forced fresh scope gives the
+                // Set its own uncontended lock.
+                var scope = context.ForceNewScope();
                 try
                 {
-                    await signal!.Set(snapshot()).ConfigureAwait(false);
+                    await prev.ConfigureAwait(false);
+                    try
+                    {
+                        await signal!.Set(snapshot()).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // A failed publish must not break the chain; the next state change
+                        // schedules another link that converges the signal.
+                    }
                 }
-                catch
+                finally
                 {
-                    // A failed publish must not break the chain; the next state change
-                    // schedules another link that converges the signal.
+                    context.CleanScope();
+                    GC.KeepAlive(scope);
                 }
             });
         }

--- a/MemoizR.Reactive/PendingPublisher.cs
+++ b/MemoizR.Reactive/PendingPublisher.cs
@@ -1,0 +1,65 @@
+namespace MemoizR.Reactive;
+
+// The one pending-flag publisher (ADR 0007), shared by ReactionBase.IsPending,
+// Transition.Pending and ReactiveAction.IsPending: a lazily created boolean signal that a
+// detached pump converges onto a caller-owned snapshot. The callers flip their state inside
+// invalidation cascades, committing evaluations, or update finallys -- all places where a Set
+// would re-enter the graph -- so every publish runs on a detached, transition-suppressed flow.
+// Publishes are chained in schedule order and each link reads the CURRENT snapshot at Set time:
+// every state change schedules a link, so the last link always publishes the latest truth no
+// matter how the flips raced; intermediate links can lag, which is why the signal is documented
+// as convergent rather than edge-accurate.
+internal sealed class PendingPublisher(Context context, Func<bool> snapshot, string label)
+{
+    private readonly Lock gate = new();
+    private Signal<bool>? signal;
+    private Task chain = Task.CompletedTask;
+
+    // The reactive projection; created on first access so nodes that are never observed
+    // reactively pay nothing. The signal's own equality short-circuit keeps redundant
+    // convergence publishes from propagating.
+    public IStateGetR<bool> Signal
+    {
+        get
+        {
+            if (signal is null)
+            {
+                LazyInitializer.EnsureInitialized(ref signal,
+                    () => new Signal<bool>(snapshot(), context) { Label = label });
+                // Fold any state change that raced the lazy creation into the signal.
+                Publish();
+            }
+            return signal!;
+        }
+    }
+
+    public void Publish()
+    {
+        if (signal is null)
+        {
+            return;
+        }
+
+        lock (gate)
+        {
+            var prev = chain;
+            chain = Task.Run(async () =>
+            {
+                // The pump inherits the scheduling flow's ExecutionContext -- including any
+                // ambient transition tag, which must not re-register the signal's observers
+                // on the transition (it could never settle).
+                TransitionFlow.Suppress();
+                await prev.ConfigureAwait(false);
+                try
+                {
+                    await signal!.Set(snapshot()).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // A failed publish must not break the chain; the next state change
+                    // schedules another link that converges the signal.
+                }
+            });
+        }
+    }
+}

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -65,6 +65,28 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
 
     private async Task RunResumeUpdate(bool detachedScope)
     {
+        // A resume update is in-flight work like any debounced update: a paused reaction's
+        // invalidations already drained the counter (their updates parked out), so without
+        // this the arbitrary-length Execute below would run with IsPending reading false.
+        if (Interlocked.Increment(ref pendingCount) == 1)
+        {
+            SchedulePendingPublish();
+        }
+        try
+        {
+            await RunResumeUpdateCore(detachedScope);
+        }
+        finally
+        {
+            if (Interlocked.Decrement(ref pendingCount) == 0)
+            {
+                SchedulePendingPublish();
+            }
+        }
+    }
+
+    private async Task RunResumeUpdateCore(bool detachedScope)
+    {
         // Serialize like the debounced update path: the node mutex ensures only one update of
         // this reaction runs at a time (Resume vs concurrent debounced updates -- without it, a
         // stale in-flight Execute could apply its side effects after a newer one finished), and

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -36,6 +36,7 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
     {
         this.executor = executor;
         this.timeProvider = timeProvider ?? TimeProvider.System;
+        pendingPublisher = new(context, () => IsPendingSnapshot, "Reaction.IsPending");
         stateCell.Force(CacheState.CacheDirty);
     }
 
@@ -407,9 +408,7 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
     // the asymmetry with transitions: a PAUSED reaction reads not-pending here (nothing is in
     // flight) while a transition it was reached by stays pending until a Resume commits.
     private int pendingCount;
-    private Signal<bool>? isPendingSignal;
-    private Task pendingPublishChain = Task.CompletedTask;
-    private readonly Lock pendingPublishLock = new();
+    private readonly PendingPublisher pendingPublisher;
 
     /// <summary>Snapshot of <see cref="IsPending"/>, sync-readable (e.g. from a render).</summary>
     public bool IsPendingSnapshot => Volatile.Read(ref pendingCount) > 0;
@@ -420,51 +419,9 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
     /// so a progress indicator is just another reaction on it. Published from a detached
     /// runtime flow; it converges on <see cref="IsPendingSnapshot"/>, individual flips can lag.
     /// </summary>
-    public IStateGetR<bool> IsPending
-    {
-        get
-        {
-            if (isPendingSignal is null)
-            {
-                LazyInitializer.EnsureInitialized(ref isPendingSignal,
-                    () => new Signal<bool>(IsPendingSnapshot, Context) { Label = $"{Label}.IsPending" });
-                // Fold any zero-crossing that raced the lazy creation into the signal.
-                SchedulePendingPublish();
-            }
-            return isPendingSignal!;
-        }
-    }
+    public IStateGetR<bool> IsPending => pendingPublisher.Signal;
 
-    // Same chained-pump shape as Transition.SchedulePendingPublish: callers sit inside
-    // invalidation cascades and update finallys where a Set would re-enter the graph, so each
-    // link publishes detached, in schedule order, reading the CURRENT snapshot at Set time --
-    // the last link always converges the signal onto the latest truth.
-    private void SchedulePendingPublish()
-    {
-        if (isPendingSignal is null)
-        {
-            return;
-        }
-
-        lock (pendingPublishLock)
-        {
-            var prev = pendingPublishChain;
-            pendingPublishChain = Task.Run(async () =>
-            {
-                TransitionFlow.Suppress();
-                await prev.ConfigureAwait(false);
-                try
-                {
-                    await isPendingSignal!.Set(IsPendingSnapshot).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // A failed publish must not break the chain; the next zero-crossing
-                    // schedules another link that converges the signal.
-                }
-            });
-        }
-    }
+    private void SchedulePendingPublish() => pendingPublisher.Publish();
 
     // Registration-vs-dispose race recovery for Transition.RegisterReached.
     internal bool IsDisposed => disposed;

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -281,7 +281,7 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
         // Resolved before the locked region: the tag rides the writing flow (the invalidation
         // cascade runs synchronously inside the Set), and registration happens after the
         // monitor exits -- the transition's recovery checks make that ordering free.
-        var transition = TransitionFlow.Current.Value;
+        var transition = TransitionFlow.Current;
         int invalidationGeneration;
         bool pendingRose;
 
@@ -444,7 +444,7 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
     private void RecordStabilizationFault(int token, Exception exception)
     {
         lastStabilizationFault = new(token, exception);
-        NotifyStabilizationFaulted(exception);
+        NotifyStabilizationFaulted(token, exception);
     }
 
     // Eager-run contract: a reaction executes once on creation (SolidJS-style effect semantics),

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -186,9 +186,16 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
         // trigger re-attempts the parent -- but tell the stabilization listeners: no commit will
         // follow and nothing reschedules until the next invalidation, so a transition waiting on
         // this reaction would otherwise hang on a wavefront that already failed (ADR 0007).
+        // UNLESS the Update above committed anyway (another parent dirtied us and the body
+        // caught the faulting read or rewired away from it): the reaction stabilized, waiters
+        // were completed by the commit, and recording the scan fault over it would poison the
+        // fault record against later registrations.
         if (parentFault != null)
         {
-            RecordStabilizationFault(token, parentFault);
+            if (stateCell.State != CacheState.CacheClean)
+            {
+                RecordStabilizationFault(token, parentFault);
+            }
             return;
         }
 

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -485,6 +485,20 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
     // observe the unassigned default.
     internal void ScheduleInitialRun()
     {
-        Stale(CacheState.CacheDirty, TimeSpan.Zero);
+        // Creation is not a write: a reaction built inside a transition scope must not join
+        // that transition's wavefront (ADR 0007 tracks "the reactions invalidated by the Sets
+        // performed inside the scope" -- a slow or failing initial run would otherwise pend or
+        // fault a transition that never wrote anything reaching this reaction). Suppress the
+        // ambient tag for just this schedule, synchronously on this flow, and restore it.
+        var ambient = TransitionFlow.Current;
+        TransitionFlow.Current = null;
+        try
+        {
+            Stale(CacheState.CacheDirty, TimeSpan.Zero);
+        }
+        finally
+        {
+            TransitionFlow.Current = ambient;
+        }
     }
 }

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -130,6 +130,9 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
         // re-acquires locks or re-runs the parent scan.
         pending.Cancel();
         RemoveParentObservers();
+        // A dead reaction will never commit: release waiters (transitions) instead of leaving
+        // them pending forever (ADR 0007).
+        NotifyStabilizationReleased();
     }
 
     protected abstract Task Execute();
@@ -208,7 +211,7 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
             {
                 await InvokeExecute();
             }
-            catch
+            catch (Exception exception)
             {
                 stateCell.Force(CacheState.CacheDirty);
                 // A reaction has no pull path: if a FIRST run throws with no links wired, no
@@ -223,6 +226,9 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
                 {
                     UpdateSourceAndObserverLinks();
                 }
+                // No commit will follow and nothing reschedules until the next invalidation:
+                // waiters (transitions) must hear the fault instead of a commit (ADR 0007).
+                NotifyStabilizationFaulted(exception);
                 throw;
             }
 
@@ -268,12 +274,27 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
             return Task.CompletedTask;
         }
 
+        // Resolved before the locked region: the tag rides the writing flow (the invalidation
+        // cascade runs synchronously inside the Set), and registration happens after the
+        // monitor exits -- the transition's recovery checks make that ordering free.
+        var transition = TransitionFlow.Current.Value;
+        int invalidationGeneration;
+        bool pendingRose;
+
         CancellationTokenSource superseded;
         lock (staleLock)
         {
             // Escalate and bump the generation so an in-flight recompute can't commit Clean over
             // this invalidation; the debounce below still (re)schedules the update regardless.
-            stateCell.Invalidate(state);
+            // The post-bump generation is this invalidation's wavefront membership: a commit
+            // reflects it exactly when its token is >= this value (ADR 0007).
+            stateCell.Invalidate(state, out invalidationGeneration);
+
+            // Every Stale spawns exactly one debounced update, whose outermost finally
+            // decrements -- so the count is exactly "scheduled or running updates", and its
+            // zero-crossings drive IsPending.
+            pendingRose = Interlocked.Increment(ref pendingCount) == 1;
+
             superseded = cts;
             cts = new();
 
@@ -297,11 +318,24 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
         // inline on this stack, and that continuation takes other locks (ExitEvaluationScope).
         superseded.Cancel();
 
+        transition?.RegisterReached(this, invalidationGeneration);
+        if (pendingRose)
+        {
+            SchedulePendingPublish();
+        }
+
         return Task.CompletedTask;
     }
 
     private async Task RunDebouncedUpdateAsync(TimeSpan debounceTime, CancellationToken token)
     {
+        // This detached task inherits the triggering Set's ExecutionContext -- including any
+        // ambient transition tag. The update's incidental Stales (commit-refused renotifies,
+        // diamond marks) are machinery, not writes: left tagged they could re-arm the
+        // transition forever. Local to this method's flow (async methods are an
+        // ExecutionContext boundary), so the caller's tag is untouched.
+        TransitionFlow.Suppress();
+
         // Balances the EnterEvaluationScope performed by the Stale that spawned this task --
         // on the full-run path AND the superseded-early-return path.
         try
@@ -354,6 +388,12 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
         finally
         {
             Context.ExitEvaluationScope();
+            // Balances the Stale that spawned this run; the zero-crossing publishes
+            // IsPending == false ("nothing scheduled or running").
+            if (Interlocked.Decrement(ref pendingCount) == 0)
+            {
+                SchedulePendingPublish();
+            }
         }
     }
 
@@ -361,6 +401,73 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
     {
         return Stale(state, DebounceTime);
     }
+
+    // "An update is scheduled or running" (ADR 0007): incremented by every Stale, decremented
+    // when its spawned update finishes (committed, superseded, paused-out, or faulted). Note
+    // the asymmetry with transitions: a PAUSED reaction reads not-pending here (nothing is in
+    // flight) while a transition it was reached by stays pending until a Resume commits.
+    private int pendingCount;
+    private Signal<bool>? isPendingSignal;
+    private Task pendingPublishChain = Task.CompletedTask;
+    private readonly Lock pendingPublishLock = new();
+
+    /// <summary>Snapshot of <see cref="IsPending"/>, sync-readable (e.g. from a render).</summary>
+    public bool IsPendingSnapshot => Volatile.Read(ref pendingCount) > 0;
+
+    /// <summary>
+    /// The reactive "an update of this reaction is in flight" flag (ADR 0007): true from an
+    /// invalidation scheduling an update until that update has run -- an ordinary graph node,
+    /// so a progress indicator is just another reaction on it. Published from a detached
+    /// runtime flow; it converges on <see cref="IsPendingSnapshot"/>, individual flips can lag.
+    /// </summary>
+    public IStateGetR<bool> IsPending
+    {
+        get
+        {
+            if (isPendingSignal is null)
+            {
+                LazyInitializer.EnsureInitialized(ref isPendingSignal,
+                    () => new Signal<bool>(IsPendingSnapshot, Context) { Label = $"{Label}.IsPending" });
+                // Fold any zero-crossing that raced the lazy creation into the signal.
+                SchedulePendingPublish();
+            }
+            return isPendingSignal!;
+        }
+    }
+
+    // Same chained-pump shape as Transition.SchedulePendingPublish: callers sit inside
+    // invalidation cascades and update finallys where a Set would re-enter the graph, so each
+    // link publishes detached, in schedule order, reading the CURRENT snapshot at Set time --
+    // the last link always converges the signal onto the latest truth.
+    private void SchedulePendingPublish()
+    {
+        if (isPendingSignal is null)
+        {
+            return;
+        }
+
+        lock (pendingPublishLock)
+        {
+            var prev = pendingPublishChain;
+            pendingPublishChain = Task.Run(async () =>
+            {
+                TransitionFlow.Suppress();
+                await prev.ConfigureAwait(false);
+                try
+                {
+                    await isPendingSignal!.Set(IsPendingSnapshot).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // A failed publish must not break the chain; the next zero-crossing
+                    // schedules another link that converges the signal.
+                }
+            });
+        }
+    }
+
+    // Registration-vs-dispose race recovery for Transition.RegisterReached.
+    internal bool IsDisposed => disposed;
 
     // Eager-run contract: a reaction executes once on creation (SolidJS-style effect semantics),
     // scheduled through the same invalidation/debounce machinery as every other trigger.

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -164,8 +164,13 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
         }
 
         // By now, we're clean -- unless a Stale invalidated us along the way, in which case stay
-        // dirty so the debounced update scheduled by that Stale re-runs us.
-        stateCell.TryCommitClean(token);
+        // dirty so the debounced update scheduled by that Stale re-runs us. Already-Clean means
+        // Update's trailing commit won and already notified the stabilization listeners; skip
+        // the gate so one logical stabilization does not notify twice on the quiet path.
+        if (stateCell.State != CacheState.CacheClean)
+        {
+            TryCommitCleanAndNotify(token);
+        }
     }
 
     // Update the cached value by running the computation.
@@ -231,8 +236,11 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
 
         // We've rerun with the latest values from all of our Sources, so we no longer need to
         // update until a signal changes -- unless a Stale invalidated us mid-evaluation, in which
-        // case stay dirty so the debounced update scheduled by that Stale re-runs us.
-        stateCell.TryCommitClean(token);
+        // case stay dirty so the debounced update scheduled by that Stale re-runs us. A
+        // successful commit notifies the stabilization listeners (ADR 0007): for a reaction this
+        // is the "wavefront reached me and my side effects have applied" edge transitions
+        // complete on.
+        TryCommitCleanAndNotify(token);
     }
 
     // Run Execute on the configured executor if one was supplied, otherwise inline. Only

--- a/MemoizR.Reactive/ReactionBase.cs
+++ b/MemoizR.Reactive/ReactionBase.cs
@@ -151,7 +151,7 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
         var token = stateCell.Generation;
 
         // If we are potentially dirty, check if a parent has actually changed value.
-        var parentFaulted = State == CacheState.CacheCheck && await ScanParentsForDirty();
+        var parentFault = State == CacheState.CacheCheck ? await ScanParentsForDirty() : null;
 
         // If we were already dirty or marked dirty by the step above, update.
         if (State == CacheState.CacheDirty)
@@ -161,9 +161,12 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
 
         // A parent that faulted never resolved this node's CacheCheck: committing Clean over it
         // would stop all future re-checks (nothing re-dirties us). Stay CacheCheck so the next
-        // trigger re-attempts the parent.
-        if (parentFaulted)
+        // trigger re-attempts the parent -- but tell the stabilization listeners: no commit will
+        // follow and nothing reschedules until the next invalidation, so a transition waiting on
+        // this reaction would otherwise hang on a wavefront that already failed (ADR 0007).
+        if (parentFault != null)
         {
+            RecordStabilizationFault(token, parentFault);
             return;
         }
 
@@ -229,7 +232,7 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
                 }
                 // No commit will follow and nothing reschedules until the next invalidation:
                 // waiters (transitions) must hear the fault instead of a commit (ADR 0007).
-                NotifyStabilizationFaulted(exception);
+                RecordStabilizationFault(token, exception);
                 throw;
             }
 
@@ -425,6 +428,24 @@ public abstract class ReactionBase : SignalHandlR, IMemoizR, IDisposable
 
     // Registration-vs-dispose race recovery for Transition.RegisterReached.
     internal bool IsDisposed => disposed;
+
+    // The last update fault, with the generation token that update ran against -- the fault
+    // mirror of CacheStateCell.LastCleanCommitToken (ADR 0007): a listener registered AFTER a
+    // fault already fired (the fault can beat the registration when the debounce is zero)
+    // recovers it by comparing the recorded token against its threshold. Recorded before
+    // NotifyStabilizationFaulted so a registrant sees either the record or the notification.
+    // Never cleared: generations only grow, so an old record can never satisfy a newer
+    // threshold.
+    internal sealed record StabilizationFaultRecord(int Token, Exception Exception);
+
+    private volatile StabilizationFaultRecord? lastStabilizationFault;
+    internal StabilizationFaultRecord? LastStabilizationFault => lastStabilizationFault;
+
+    private void RecordStabilizationFault(int token, Exception exception)
+    {
+        lastStabilizationFault = new(token, exception);
+        NotifyStabilizationFaulted(exception);
+    }
 
     // Eager-run contract: a reaction executes once on creation (SolidJS-style effect semantics),
     // scheduled through the same invalidation/debounce machinery as every other trigger.

--- a/MemoizR.Reactive/ReactionBuilder.cs
+++ b/MemoizR.Reactive/ReactionBuilder.cs
@@ -150,14 +150,16 @@ public sealed class ReactionBuilder
     // Performed for ALL parameters BEFORE the parallel evaluation starts, so a Set landing
     // mid-evaluation already sees this reaction as observer and refuses the stale commit, and a
     // faulting first run still leaves every parameter wired (the sequential composition only
-    // wired the prefix read before the fault). Non-graph IStateGetR implementations are skipped,
-    // exactly as their untracked Get would be. The params array costs one small allocation per
-    // update run, dwarfed by the detached evaluation tasks that follow.
+    // wired the prefix read before the fault). Node-backed wrappers (OptimisticState) register
+    // their backing node; other non-graph IStateGetR implementations are skipped, exactly as
+    // their untracked Get would be. The params array costs one small allocation per update run,
+    // dwarfed by the detached evaluation tasks that follow.
     private void RegisterDependencies(params object[] dependencies)
     {
         foreach (var dependency in dependencies)
         {
-            if (dependency is IMemoHandlR handler)
+            var unwrapped = dependency is INodeBackedGetR backed ? backed.Node : dependency;
+            if (unwrapped is IMemoHandlR handler)
             {
                 memoFactory.Context.CheckDependenciesTheSame(handler);
             }
@@ -193,6 +195,14 @@ public sealed class ReactionBuilder
             var scope = context.ForceNewScope();
             try
             {
+                // Node-backed wrappers (OptimisticState) delegate their Get to a real node;
+                // evaluate THAT node so the stamped-read branch below records its evidence --
+                // the wrapper itself matches neither pattern and would be read stampless.
+                if (memo is INodeBackedGetR backed && backed.Node is IStateGetR<T> backingNode)
+                {
+                    memo = backingNode;
+                }
+
                 // Matched via the INTERFACE, not MemoHandlR<T>: a value-type Signal<int> enters
                 // here as IStateGetR<int?> (T == int?), and the node is MemoHandlR<int> -- a
                 // class pattern on T would silently miss it and drop the signal's stamp.

--- a/MemoizR.Reactive/ReactiveAction.cs
+++ b/MemoizR.Reactive/ReactiveAction.cs
@@ -1,0 +1,159 @@
+namespace MemoizR.Reactive;
+
+/// <summary>
+/// The process-layer write primitive (ADR 0007), MemoizR's analog of Solid 2.0's
+/// generator-driven actions: a reusable async body that projects optimistic patches, runs the
+/// real process (network write, revalidation), and is automatically rolled back -- patches
+/// dropped, source untouched -- when it faults or is cancelled. Each <see cref="Run"/> executes
+/// on a detached flow tagged with its own <see cref="Transition"/>, so the projection, the
+/// confirmed write and the rollback all have their effect wavefronts tracked; the run's
+/// <see cref="ActionRun.Settled"/> completes when the UI reflects the final outcome.
+/// </summary>
+public sealed class ReactiveAction<TPayload>
+{
+    private readonly Context context;
+    private readonly Func<TPayload, OptimisticActionContext, Task> body;
+    private int runningCount;
+    private readonly PendingPublisher pendingPublisher;
+
+    internal ReactiveAction(Context context, Func<TPayload, OptimisticActionContext, Task> body, string label)
+    {
+        this.context = context;
+        this.body = body;
+        pendingPublisher = new(context, () => IsPendingSnapshot, $"{label}.IsPending");
+    }
+
+    /// <summary>Snapshot: is any run of this action still executing?</summary>
+    public bool IsPendingSnapshot => Volatile.Read(ref runningCount) > 0;
+
+    /// <summary>
+    /// The reactive "a run is in flight" flag -- an ordinary graph node (disable the submit
+    /// button with a reaction on it). Converges on <see cref="IsPendingSnapshot"/>.
+    /// </summary>
+    public IStateGetR<bool> IsPending => pendingPublisher.Signal;
+
+    public ActionRun Run(TPayload payload)
+    {
+        // The transition is created untagged and attached to the BODY flow below: the caller's
+        // flow never carries this run's writes.
+        var transition = new Transition(context, tagAmbientFlow: false);
+        var cts = new CancellationTokenSource();
+        var ctx = new OptimisticActionContext(cts.Token);
+        if (Interlocked.Increment(ref runningCount) == 1)
+        {
+            pendingPublisher.Publish();
+        }
+
+        var completion = Task.Run(async () =>
+        {
+            // Tag the detached body flow: the optimistic projection, the confirmed base write,
+            // and the rollback all register their effect wavefronts on this run's transition.
+            // Local to this async flow; the caller's ambient tag is untouched.
+            TransitionFlow.Current.Value = transition;
+            try
+            {
+                await body(payload, ctx).ConfigureAwait(false);
+            }
+            finally
+            {
+                // Success and failure alike drop this run's patches: on success the confirmed
+                // source value carries the truth (the debounce coalesces the hand-off for
+                // reactions), on failure the removal IS the rollback -- structural, so it can
+                // never clobber a concurrent action's projection. Sealing the transition last
+                // makes Settled mean "the UI reflects the final outcome, patches gone".
+                await ctx.DropPatchesAsync().ConfigureAwait(false);
+                transition.Dispose();
+                if (Interlocked.Decrement(ref runningCount) == 0)
+                {
+                    pendingPublisher.Publish();
+                }
+            }
+        });
+
+        return new ActionRun(completion, transition, cts);
+    }
+}
+
+/// <summary>
+/// One execution of a <see cref="ReactiveAction{TPayload}"/>. <see cref="Completion"/> carries
+/// the body's outcome (fault, cancellation); <see cref="Settled"/> tracks the effect wavefront
+/// -- both ends of Solid's split between the process and the propagation it causes.
+/// </summary>
+public sealed class ActionRun
+{
+    private readonly CancellationTokenSource cts;
+
+    internal ActionRun(Task completion, Transition transition, CancellationTokenSource cts)
+    {
+        Completion = completion;
+        Transition = transition;
+        this.cts = cts;
+    }
+
+    /// <summary>The body's outcome: faults and cancellations surface here, after rollback.</summary>
+    public Task Completion { get; }
+
+    /// <summary>The run's write wavefront; pending state and settlement live here.</summary>
+    public Transition Transition { get; }
+
+    /// <summary>Shorthand for <c>Transition.Settled</c>.</summary>
+    public Task Settled => Transition.Settled;
+
+    /// <summary>Cancels the run's <see cref="OptimisticActionContext.Token"/>; the body's
+    /// cancellation then triggers the same automatic rollback as a fault.</summary>
+    public void Cancel() => cts.Cancel();
+}
+
+/// <summary>
+/// Handed to an action body: the run's cancellation token plus the optimistic projection API.
+/// Every patch applied through it is owned by this run and dropped when the run ends,
+/// whatever the outcome.
+/// </summary>
+public sealed class OptimisticActionContext
+{
+    private readonly Lock gate = new();
+    private readonly List<Func<Task>> patchRemovals = new();
+
+    internal OptimisticActionContext(CancellationToken token)
+    {
+        Token = token;
+    }
+
+    public CancellationToken Token { get; }
+
+    /// <summary>
+    /// Instantly projects the expected future state onto the optimistic view; the patch stays
+    /// applied until this run ends (confirmed or rolled back).
+    /// </summary>
+    public async Task Apply<T>(OptimisticState<T> state, Func<T, T> patch)
+    {
+        var id = await state.ApplyPatchAsync(patch).ConfigureAwait(false);
+        lock (gate)
+        {
+            patchRemovals.Add(() => state.RemovePatchAsync(id));
+        }
+    }
+
+    internal async Task DropPatchesAsync()
+    {
+        Func<Task>[] removals;
+        lock (gate)
+        {
+            removals = [.. patchRemovals];
+            patchRemovals.Clear();
+        }
+
+        foreach (var removal in removals)
+        {
+            try
+            {
+                await removal().ConfigureAwait(false);
+            }
+            catch
+            {
+                // A failed removal must not mask the body's outcome; the overlay is runtime
+                // state and the next successful write converges it.
+            }
+        }
+    }
+}

--- a/MemoizR.Reactive/ReactiveAction.cs
+++ b/MemoizR.Reactive/ReactiveAction.cs
@@ -49,7 +49,7 @@ public sealed class ReactiveAction<TPayload>
             // Tag the detached body flow: the optimistic projection, the confirmed base write,
             // and the rollback all register their effect wavefronts on this run's transition.
             // Local to this async flow; the caller's ambient tag is untouched.
-            TransitionFlow.Current.Value = transition;
+            TransitionFlow.Current = transition;
             // The detached body also inherits the CALLER's lock-scope key: a Run issued from
             // inside a graph evaluation would make the body's Sets recursive acquisitions of
             // the caller's held ContextLock. A forced fresh scope gives the body its own.

--- a/MemoizR.Reactive/ReactiveAction.cs
+++ b/MemoizR.Reactive/ReactiveAction.cs
@@ -50,6 +50,10 @@ public sealed class ReactiveAction<TPayload>
             // and the rollback all register their effect wavefronts on this run's transition.
             // Local to this async flow; the caller's ambient tag is untouched.
             TransitionFlow.Current.Value = transition;
+            // The detached body also inherits the CALLER's lock-scope key: a Run issued from
+            // inside a graph evaluation would make the body's Sets recursive acquisitions of
+            // the caller's held ContextLock. A forced fresh scope gives the body its own.
+            var scope = context.ForceNewScope();
             try
             {
                 await body(payload, ctx).ConfigureAwait(false);
@@ -63,6 +67,8 @@ public sealed class ReactiveAction<TPayload>
                 // makes Settled mean "the UI reflects the final outcome, patches gone".
                 await ctx.DropPatchesAsync().ConfigureAwait(false);
                 transition.Dispose();
+                context.CleanScope();
+                GC.KeepAlive(scope);
                 if (Interlocked.Decrement(ref runningCount) == 0)
                 {
                     pendingPublisher.Publish();
@@ -112,7 +118,11 @@ public sealed class ActionRun
 public sealed class OptimisticActionContext
 {
     private readonly Lock gate = new();
-    private readonly List<Func<Task>> patchRemovals = new();
+    // One entry per touched optimistic state: the ids this run applied to it plus the
+    // type-erased batch remover. Grouped so the rollback drops all of a run's patches on one
+    // state in a single read-modify-write -- removing them one by one would expose frames in
+    // which a later patch applies without the earlier patch it builds on.
+    private readonly Dictionary<object, (Func<IReadOnlyCollection<long>, Task> RemoveBatch, List<long> Ids)> applied = new();
 
     internal OptimisticActionContext(CancellationToken token)
     {
@@ -130,24 +140,29 @@ public sealed class OptimisticActionContext
         var id = await state.ApplyPatchAsync(patch).ConfigureAwait(false);
         lock (gate)
         {
-            patchRemovals.Add(() => state.RemovePatchAsync(id));
+            if (!applied.TryGetValue(state, out var entry))
+            {
+                entry = (state.RemovePatchesAsync, new List<long>());
+                applied[state] = entry;
+            }
+            entry.Ids.Add(id);
         }
     }
 
     internal async Task DropPatchesAsync()
     {
-        Func<Task>[] removals;
+        (Func<IReadOnlyCollection<long>, Task> RemoveBatch, List<long> Ids)[] batches;
         lock (gate)
         {
-            removals = [.. patchRemovals];
-            patchRemovals.Clear();
+            batches = [.. applied.Values];
+            applied.Clear();
         }
 
-        foreach (var removal in removals)
+        foreach (var (removeBatch, ids) in batches)
         {
             try
             {
-                await removal().ConfigureAwait(false);
+                await removeBatch(ids).ConfigureAwait(false);
             }
             catch
             {

--- a/MemoizR.Reactive/ReactiveAction.cs
+++ b/MemoizR.Reactive/ReactiveAction.cs
@@ -145,31 +145,35 @@ public sealed class OptimisticActionContext
             ThrowIfClosed();
         }
 
-        var id = await state.ApplyPatchAsync(patch).ConfigureAwait(false);
-        var closedMidApply = false;
-        lock (gate)
+        // Admission runs INSIDE the overlay's read-modify-write: checking `closed` and
+        // recording the id are atomic with the patch landing, and the close sweep's removals
+        // serialize on the same overlay lock -- so either this patch is rejected (the sweep
+        // won) or it lands recorded and the sweep removes it before the run seals. A patch can
+        // no longer land unrecorded in the close window and outlive the run's settlement.
+        var admitted = await state.TryApplyPatchAsync(patch, id =>
         {
-            if (closed)
+            lock (gate)
             {
-                // The run's drop swept between the overlay write above and this recording: the
-                // patch is orphaned unless removed here, on this flow.
-                closedMidApply = true;
-            }
-            else
-            {
+                if (closed)
+                {
+                    return false;
+                }
                 if (!applied.TryGetValue(state, out var entry))
                 {
                     entry = (state.RemovePatchesAsync, new List<long>());
                     applied[state] = entry;
                 }
                 entry.Ids.Add(id);
+                return true;
             }
-        }
+        }).ConfigureAwait(false);
 
-        if (closedMidApply)
+        if (!admitted)
         {
-            await state.RemovePatchesAsync([id]).ConfigureAwait(false);
-            ThrowIfClosed();
+            lock (gate)
+            {
+                ThrowIfClosed();
+            }
         }
     }
 

--- a/MemoizR.Reactive/ReactiveAction.cs
+++ b/MemoizR.Reactive/ReactiveAction.cs
@@ -123,6 +123,7 @@ public sealed class OptimisticActionContext
     // state in a single read-modify-write -- removing them one by one would expose frames in
     // which a later patch applies without the earlier patch it builds on.
     private readonly Dictionary<object, (Func<IReadOnlyCollection<long>, Task> RemoveBatch, List<long> Ids)> applied = new();
+    private bool closed;
 
     internal OptimisticActionContext(CancellationToken token)
     {
@@ -133,19 +134,51 @@ public sealed class OptimisticActionContext
 
     /// <summary>
     /// Instantly projects the expected future state onto the optimistic view; the patch stays
-    /// applied until this run ends (confirmed or rolled back).
+    /// applied until this run ends (confirmed or rolled back). Only valid while the run's body
+    /// executes: a context leaked to fire-and-forget work throws here after the run ended --
+    /// its patch would be owned by no drop and stay applied forever.
     /// </summary>
     public async Task Apply<T>(OptimisticState<T> state, Func<T, T> patch)
     {
-        var id = await state.ApplyPatchAsync(patch).ConfigureAwait(false);
         lock (gate)
         {
-            if (!applied.TryGetValue(state, out var entry))
+            ThrowIfClosed();
+        }
+
+        var id = await state.ApplyPatchAsync(patch).ConfigureAwait(false);
+        var closedMidApply = false;
+        lock (gate)
+        {
+            if (closed)
             {
-                entry = (state.RemovePatchesAsync, new List<long>());
-                applied[state] = entry;
+                // The run's drop swept between the overlay write above and this recording: the
+                // patch is orphaned unless removed here, on this flow.
+                closedMidApply = true;
             }
-            entry.Ids.Add(id);
+            else
+            {
+                if (!applied.TryGetValue(state, out var entry))
+                {
+                    entry = (state.RemovePatchesAsync, new List<long>());
+                    applied[state] = entry;
+                }
+                entry.Ids.Add(id);
+            }
+        }
+
+        if (closedMidApply)
+        {
+            await state.RemovePatchesAsync([id]).ConfigureAwait(false);
+            ThrowIfClosed();
+        }
+    }
+
+    private void ThrowIfClosed()
+    {
+        if (closed)
+        {
+            throw new InvalidOperationException(
+                "This action run has completed; optimistic patches can only be applied while the run's body executes.");
         }
     }
 
@@ -154,6 +187,7 @@ public sealed class OptimisticActionContext
         (Func<IReadOnlyCollection<long>, Task> RemoveBatch, List<long> Ids)[] batches;
         lock (gate)
         {
+            closed = true;
             batches = [.. applied.Values];
             applied.Clear();
         }

--- a/MemoizR.Reactive/ReactiveMemoFactory.cs
+++ b/MemoizR.Reactive/ReactiveMemoFactory.cs
@@ -59,6 +59,10 @@ public static class ReactiveMemoFactory
     /// </summary>
     public static OptimisticState<T> CreateOptimistic<T>(this MemoFactory memoFactory, IStateGetR<T> source, string label = "Optimistic")
     {
+        // The composed view's CreateMemoizR checks T too; the explicit gate here makes the
+        // strict contract visible at the API boundary (and survives view-construction
+        // refactors) -- the source need not come from a strict MemoizR creation at all.
+        memoFactory.EnsureSendableIfStrict<T>();
         return new(memoFactory, source, label);
     }
 

--- a/MemoizR.Reactive/ReactiveMemoFactory.cs
+++ b/MemoizR.Reactive/ReactiveMemoFactory.cs
@@ -37,6 +37,20 @@ public static class ReactiveMemoFactory
         return new(memoFactory, memoFactory.Executor, label);
     }
 
+    /// <summary>
+    /// Opens a transition scope (ADR 0007): Sets performed inside it are tagged, and the
+    /// returned <see cref="Transition"/> tracks every reaction the writes invalidate until all
+    /// of them have committed clean again -- observable via <see cref="Transition.IsPending"/> /
+    /// <see cref="Transition.Pending"/> and awaitable via <see cref="Transition.Settled"/>.
+    /// <c>using</c> seals the wavefront at scope end; <c>await using</c> additionally awaits
+    /// settlement. Scopes nest innermost-wins: writes inside an inner scope are tracked by the
+    /// inner transition only.
+    /// </summary>
+    public static Transition BeginTransition(this MemoFactory memoFactory)
+    {
+        return new(memoFactory.Context);
+    }
+
     // Factory-level sugar for the common case: identical to BuildReaction().CreateReaction(..)
     // with the default label and debounce -- use BuildReaction to configure either. The
     // threading contract is the builder's: dependencies are registered in parameter order, the

--- a/MemoizR.Reactive/ReactiveMemoFactory.cs
+++ b/MemoizR.Reactive/ReactiveMemoFactory.cs
@@ -51,6 +51,29 @@ public static class ReactiveMemoFactory
         return new(memoFactory.Context);
     }
 
+    /// <summary>
+    /// Creates an optimistic view over <paramref name="source"/> (ADR 0007): reads return the
+    /// source value with every in-flight optimistic patch applied on top. Pair with
+    /// <see cref="CreateAction"/> -- patches are applied through an action run and dropped
+    /// automatically when it ends, giving instant projection with structural rollback.
+    /// </summary>
+    public static OptimisticState<T> CreateOptimistic<T>(this MemoFactory memoFactory, IStateGetR<T> source, string label = "Optimistic")
+    {
+        return new(memoFactory, source, label);
+    }
+
+    /// <summary>
+    /// Creates a reusable process-layer action (ADR 0007): the body projects optimistic
+    /// patches via the context, runs the real process on the context's token, and writes the
+    /// confirmed result to the source of truth. A faulted or cancelled run rolls back
+    /// automatically (its patches are dropped, the source was never touched); every run's
+    /// effect wavefront is tracked by its own <see cref="Transition"/>.
+    /// </summary>
+    public static ReactiveAction<TPayload> CreateAction<TPayload>(this MemoFactory memoFactory, Func<TPayload, OptimisticActionContext, Task> body, string label = "Action")
+    {
+        return new(memoFactory.Context, body, label);
+    }
+
     // Factory-level sugar for the common case: identical to BuildReaction().CreateReaction(..)
     // with the default label and debounce -- use BuildReaction to configure either. The
     // threading contract is the builder's: dependencies are registered in parameter order, the

--- a/MemoizR.Reactive/ReactiveMemoFactory.cs
+++ b/MemoizR.Reactive/ReactiveMemoFactory.cs
@@ -71,6 +71,9 @@ public static class ReactiveMemoFactory
     /// </summary>
     public static ReactiveAction<TPayload> CreateAction<TPayload>(this MemoFactory memoFactory, Func<TPayload, OptimisticActionContext, Task> body, string label = "Action")
     {
+        // The payload crosses flows (Run captures it onto a detached body task), so strict mode
+        // holds it to the same Sendable bar as every other cross-flow value.
+        memoFactory.EnsureSendableIfStrict<TPayload>();
         return new(memoFactory.Context, body, label);
     }
 

--- a/MemoizR.Reactive/Transition.cs
+++ b/MemoizR.Reactive/Transition.cs
@@ -29,24 +29,30 @@ internal static class TransitionFlow
 public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationListener
 {
     private readonly Lock gate = new();
-    private readonly Context context;
     private readonly Transition? prior;
+    private readonly bool taggedAmbientFlow;
     // Per reached reaction, the highest invalidation generation a tagged Stale registered: a
     // commit reflects the wavefront's writes to that reaction exactly when its token is >= this
     // threshold (see IStabilizationListener).
     private readonly Dictionary<ReactionBase, int> outstanding = new();
     private readonly Dictionary<ReactionBase, Exception> faults = new();
     private readonly TaskCompletionSource settled = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private Signal<bool>? pendingSignal;
-    private Task pendingPublishChain = Task.CompletedTask;
+    private readonly PendingPublisher pendingPublisher;
     private volatile bool isPending;
     private bool isSealed;
 
-    internal Transition(Context context)
+    // tagAmbientFlow: BeginTransition tags the caller's flow here; a ReactiveAction run passes
+    // false and tags its detached body flow itself, because the caller's flow never carries the
+    // writes.
+    internal Transition(Context context, bool tagAmbientFlow = true)
     {
-        this.context = context;
-        prior = TransitionFlow.Current.Value;
-        TransitionFlow.Current.Value = this;
+        pendingPublisher = new(context, () => isPending, "Transition.Pending");
+        taggedAmbientFlow = tagAmbientFlow;
+        if (tagAmbientFlow)
+        {
+            prior = TransitionFlow.Current.Value;
+            TransitionFlow.Current.Value = this;
+        }
     }
 
     /// <summary>Snapshot: is any reached reaction still awaiting its clean commit?</summary>
@@ -57,20 +63,7 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
     /// spinners and disabled-states are just reactions on it. Published from a detached runtime
     /// flow; it converges on the snapshot but individual flips can lag it.
     /// </summary>
-    public IStateGetR<bool> Pending
-    {
-        get
-        {
-            if (pendingSignal is null)
-            {
-                LazyInitializer.EnsureInitialized(ref pendingSignal,
-                    () => new Signal<bool>(isPending, context) { Label = "Transition.Pending" });
-                // Fold any state change that raced the lazy creation into the signal.
-                SchedulePendingPublish();
-            }
-            return pendingSignal!;
-        }
-    }
+    public IStateGetR<bool> Pending => pendingPublisher.Signal;
 
     /// <summary>
     /// Completes when the scope has been disposed (sealing the wavefront) AND every reached
@@ -82,7 +75,10 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
     /// <summary>Seals the wavefront and restores the prior ambient transition tag.</summary>
     public void Dispose()
     {
-        TransitionFlow.Current.Value = prior;
+        if (taggedAmbientFlow)
+        {
+            TransitionFlow.Current.Value = prior;
+        }
         bool completed;
         lock (gate)
         {
@@ -230,36 +226,5 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
         }
     }
 
-    // Publish the current pending state into the reactive signal from a detached flow: the
-    // callers run inside committing evaluations (OnStabilized) or invalidation cascades
-    // (RegisterReached), where a Set would re-enter the graph. Publishes are chained so they
-    // apply in schedule order, and each link reads the CURRENT snapshot at Set time -- every
-    // state change schedules a link, so the last link always publishes the latest truth no
-    // matter how the flips raced.
-    private void SchedulePendingPublish()
-    {
-        if (pendingSignal is null)
-        {
-            return;
-        }
-
-        lock (gate)
-        {
-            var prev = pendingPublishChain;
-            pendingPublishChain = Task.Run(async () =>
-            {
-                TransitionFlow.Suppress();
-                await prev.ConfigureAwait(false);
-                try
-                {
-                    await pendingSignal!.Set(isPending).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // A failed publish must not break the chain; the next state change
-                    // schedules another link that converges the signal.
-                }
-            });
-        }
-    }
+    private void SchedulePendingPublish() => pendingPublisher.Publish();
 }

--- a/MemoizR.Reactive/Transition.cs
+++ b/MemoizR.Reactive/Transition.cs
@@ -42,6 +42,13 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
     // threshold (see IStabilizationListener).
     private readonly Dictionary<ReactionBase, int> outstanding = new();
     private readonly Dictionary<ReactionBase, Exception> faults = new();
+    // Every reaction this transition ever subscribed to. Listeners live until SETTLEMENT, not
+    // until per-reaction completion: removing on completion raced a re-registration of the same
+    // reaction by a later write in this still-open scope -- the stale removal could strip the
+    // listener the re-registration just added, leaving an outstanding entry nobody notifies.
+    // A completed-but-still-subscribed reaction only costs no-op callbacks.
+    private readonly HashSet<ReactionBase> subscribed = new();
+    private bool listenersCleaned;
     private readonly TaskCompletionSource settled = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly PendingPublisher pendingPublisher;
     private volatile bool isPending;
@@ -134,8 +141,8 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
             else
             {
                 outstanding[reaction] = threshold;
-                subscribe = true;
             }
+            subscribe = subscribed.Add(reaction);
             isPending = true;
         }
 
@@ -183,7 +190,6 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
         }
         if (remove)
         {
-            reaction.RemoveStabilizationListener(this);
             SchedulePendingPublish();
         }
         if (completed)
@@ -220,7 +226,6 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
         }
         if (remove)
         {
-            reaction.RemoveStabilizationListener(this);
             SchedulePendingPublish();
         }
         if (completed)
@@ -232,9 +237,20 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
     private void CompleteSettled()
     {
         Exception[] recorded;
+        ReactionBase[] toUnsubscribe;
         lock (gate)
         {
             recorded = [.. faults.Values];
+            // Listener cleanup happens exactly once, at settlement (see `subscribed`); a
+            // settled transition ignores every further registration, so nothing re-subscribes.
+            toUnsubscribe = listenersCleaned ? [] : [.. subscribed];
+            listenersCleaned = true;
+            subscribed.Clear();
+        }
+
+        foreach (var reaction in toUnsubscribe)
+        {
+            reaction.RemoveStabilizationListener(this);
         }
 
         if (recorded.Length > 0)

--- a/MemoizR.Reactive/Transition.cs
+++ b/MemoizR.Reactive/Transition.cs
@@ -3,10 +3,16 @@ namespace MemoizR.Reactive;
 // The ambient transition tag (ADR 0007): set on the writing flow by BeginTransition and read by
 // ReactionBase.Stale. A Set's invalidation cascade runs synchronously on the writing flow, so
 // the tag reaches every transitively invalidated reaction with no extra plumbing -- the same
-// AsyncLocal pattern as RaceBranchFlow.
+// AsyncLocal pattern as RaceBranchFlow. Backed by the core's WavefrontFlow holder, whose
+// presence also tells the core's cascade not to prune at already-dirty nodes (a pruned cascade
+// would hide the tagged write from downstream registrations).
 internal static class TransitionFlow
 {
-    internal static readonly AsyncLocal<Transition?> Current = new();
+    internal static Transition? Current
+    {
+        get => WavefrontFlow.Current.Value as Transition;
+        set => WavefrontFlow.Current.Value = value;
+    }
 
     // Detached runtime flows (debounced updates, pending-publish pumps) inherit the writing
     // flow's ExecutionContext -- and with it the tag. Their incidental Stales (commit-refused
@@ -14,7 +20,7 @@ internal static class TransitionFlow
     // transition's own Pending signal would re-register that signal's observers on the
     // transition forever and it could never settle. Suppress() cuts the inheritance at the
     // detachment point; inside an async method the write stays local to that method's flow.
-    internal static void Suppress() => Current.Value = null;
+    internal static void Suppress() => WavefrontFlow.Current.Value = null;
 }
 
 /// <summary>
@@ -50,8 +56,8 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
         taggedAmbientFlow = tagAmbientFlow;
         if (tagAmbientFlow)
         {
-            prior = TransitionFlow.Current.Value;
-            TransitionFlow.Current.Value = this;
+            prior = TransitionFlow.Current;
+            TransitionFlow.Current = this;
         }
     }
 
@@ -77,7 +83,7 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
     {
         if (taggedAmbientFlow)
         {
-            TransitionFlow.Current.Value = prior;
+            TransitionFlow.Current = prior;
         }
         bool completed;
         lock (gate)
@@ -139,11 +145,12 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
         }
         OnStabilizedCore(reaction, reaction.stateCell.LastCleanCommitToken);
         // A fault can beat the registration the same way a commit can (a zero-debounce update
-        // faulting before the listener is added); the recorded fault token recovers it.
+        // faulting before the listener is added); the recorded fault token recovers it, gated
+        // by the same threshold as live fault notifications.
         var fault = reaction.LastStabilizationFault;
-        if (fault != null && fault.Token >= threshold)
+        if (fault != null)
         {
-            OnFaultedCore(reaction, fault.Exception);
+            OnFaultedCore(reaction, fault.Token, fault.Exception);
         }
         if (reaction.IsDisposed)
         {
@@ -185,23 +192,27 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
         }
     }
 
-    void IStabilizationListener.OnStabilizationFaulted(SignalHandlR node, Exception exception)
+    void IStabilizationListener.OnStabilizationFaulted(SignalHandlR node, int token, Exception exception)
     {
         if (node is ReactionBase reaction)
         {
-            OnFaultedCore(reaction, exception);
+            OnFaultedCore(reaction, token, exception);
         }
     }
 
-    private void OnFaultedCore(ReactionBase reaction, Exception exception)
+    private void OnFaultedCore(ReactionBase reaction, int token, Exception exception)
     {
         bool remove;
         var completed = false;
         lock (gate)
         {
-            remove = outstanding.Remove(reaction);
+            // Same threshold gate as the clean-commit path: a fault whose update ran against an
+            // OLDER generation than this wavefront's registration belongs to a superseded
+            // trigger -- the update our own Stale scheduled is still coming and may commit.
+            remove = outstanding.TryGetValue(reaction, out var threshold) && token >= threshold;
             if (remove)
             {
+                outstanding.Remove(reaction);
                 faults[reaction] = exception;
                 isPending = outstanding.Count > 0;
                 completed = isSealed && outstanding.Count == 0 && !settled.Task.IsCompleted;

--- a/MemoizR.Reactive/Transition.cs
+++ b/MemoizR.Reactive/Transition.cs
@@ -1,0 +1,265 @@
+namespace MemoizR.Reactive;
+
+// The ambient transition tag (ADR 0007): set on the writing flow by BeginTransition and read by
+// ReactionBase.Stale. A Set's invalidation cascade runs synchronously on the writing flow, so
+// the tag reaches every transitively invalidated reaction with no extra plumbing -- the same
+// AsyncLocal pattern as RaceBranchFlow.
+internal static class TransitionFlow
+{
+    internal static readonly AsyncLocal<Transition?> Current = new();
+
+    // Detached runtime flows (debounced updates, pending-publish pumps) inherit the writing
+    // flow's ExecutionContext -- and with it the tag. Their incidental Stales (commit-refused
+    // renotifies, pending-signal propagation) are machinery, not user writes: left tagged, a
+    // transition's own Pending signal would re-register that signal's observers on the
+    // transition forever and it could never settle. Suppress() cuts the inheritance at the
+    // detachment point; inside an async method the write stays local to that method's flow.
+    internal static void Suppress() => Current.Value = null;
+}
+
+/// <summary>
+/// One write wavefront (ADR 0007): the reactions invalidated by the Sets performed inside the
+/// scope, tracked until every one of them has committed clean again. <c>using</c> the scope
+/// seals the wavefront on dispose; <c>await using</c> additionally awaits <see cref="Settled"/>
+/// -- the onSettled analog. Faulted effects surface structured-concurrency-style: Settled
+/// faults with an <see cref="AggregateException"/> of every reaction fault in the wavefront.
+/// A paused reaction keeps the transition pending until a Resume commits; a disposed reaction
+/// releases it.
+/// </summary>
+public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationListener
+{
+    private readonly Lock gate = new();
+    private readonly Context context;
+    private readonly Transition? prior;
+    // Per reached reaction, the highest invalidation generation a tagged Stale registered: a
+    // commit reflects the wavefront's writes to that reaction exactly when its token is >= this
+    // threshold (see IStabilizationListener).
+    private readonly Dictionary<ReactionBase, int> outstanding = new();
+    private readonly Dictionary<ReactionBase, Exception> faults = new();
+    private readonly TaskCompletionSource settled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Signal<bool>? pendingSignal;
+    private Task pendingPublishChain = Task.CompletedTask;
+    private volatile bool isPending;
+    private bool isSealed;
+
+    internal Transition(Context context)
+    {
+        this.context = context;
+        prior = TransitionFlow.Current.Value;
+        TransitionFlow.Current.Value = this;
+    }
+
+    /// <summary>Snapshot: is any reached reaction still awaiting its clean commit?</summary>
+    public bool IsPending => isPending;
+
+    /// <summary>
+    /// The reactive projection of <see cref="IsPending"/> -- an ordinary graph node, so
+    /// spinners and disabled-states are just reactions on it. Published from a detached runtime
+    /// flow; it converges on the snapshot but individual flips can lag it.
+    /// </summary>
+    public IStateGetR<bool> Pending
+    {
+        get
+        {
+            if (pendingSignal is null)
+            {
+                LazyInitializer.EnsureInitialized(ref pendingSignal,
+                    () => new Signal<bool>(isPending, context) { Label = "Transition.Pending" });
+                // Fold any state change that raced the lazy creation into the signal.
+                SchedulePendingPublish();
+            }
+            return pendingSignal!;
+        }
+    }
+
+    /// <summary>
+    /// Completes when the scope has been disposed (sealing the wavefront) AND every reached
+    /// reaction has committed clean; faults with an AggregateException when any reached
+    /// reaction's update threw instead.
+    /// </summary>
+    public Task Settled => settled.Task;
+
+    /// <summary>Seals the wavefront and restores the prior ambient transition tag.</summary>
+    public void Dispose()
+    {
+        TransitionFlow.Current.Value = prior;
+        bool completed;
+        lock (gate)
+        {
+            isSealed = true;
+            completed = outstanding.Count == 0 && !settled.Task.IsCompleted;
+        }
+        if (completed)
+        {
+            CompleteSettled();
+        }
+    }
+
+    /// <summary>Seals the wavefront, then awaits <see cref="Settled"/>.</summary>
+    public async ValueTask DisposeAsync()
+    {
+        Dispose();
+        await settled.Task.ConfigureAwait(false);
+    }
+
+    // A tagged invalidation reached `reaction` (called by ReactionBase.Stale, outside its
+    // staleLock). Registration order vs. the scheduled update is free: a commit that races the
+    // registration window is recovered by the LastCleanCommitToken check below, and a
+    // dispose that races it by the IsDisposed check -- both re-drive the same threshold logic
+    // the listener notification would have.
+    internal void RegisterReached(ReactionBase reaction, int threshold)
+    {
+        var subscribe = false;
+        lock (gate)
+        {
+            if (settled.Task.IsCompleted)
+            {
+                // A fully settled transition is immutable; a Set performed on a flow that
+                // still carries the tag after settlement is not tracked.
+                return;
+            }
+
+            // A newer invalidation supersedes a recorded fault: the reaction gets another
+            // chance to commit inside this wavefront.
+            faults.Remove(reaction);
+            if (outstanding.TryGetValue(reaction, out var existing))
+            {
+                if (threshold > existing)
+                {
+                    outstanding[reaction] = threshold;
+                }
+            }
+            else
+            {
+                outstanding[reaction] = threshold;
+                subscribe = true;
+            }
+            isPending = true;
+        }
+
+        if (subscribe)
+        {
+            reaction.AddStabilizationListener(this);
+        }
+        OnStabilizedCore(reaction, reaction.stateCell.LastCleanCommitToken);
+        if (reaction.IsDisposed)
+        {
+            OnStabilizedCore(reaction, int.MaxValue);
+        }
+        SchedulePendingPublish();
+    }
+
+    void IStabilizationListener.OnStabilized(SignalHandlR node, int token)
+    {
+        if (node is ReactionBase reaction)
+        {
+            OnStabilizedCore(reaction, token);
+        }
+    }
+
+    private void OnStabilizedCore(ReactionBase reaction, int token)
+    {
+        bool remove;
+        var completed = false;
+        lock (gate)
+        {
+            remove = outstanding.TryGetValue(reaction, out var threshold) && token >= threshold;
+            if (remove)
+            {
+                outstanding.Remove(reaction);
+                isPending = outstanding.Count > 0;
+                completed = isSealed && outstanding.Count == 0 && !settled.Task.IsCompleted;
+            }
+        }
+        if (remove)
+        {
+            reaction.RemoveStabilizationListener(this);
+            SchedulePendingPublish();
+        }
+        if (completed)
+        {
+            CompleteSettled();
+        }
+    }
+
+    void IStabilizationListener.OnStabilizationFaulted(SignalHandlR node, Exception exception)
+    {
+        if (node is not ReactionBase reaction)
+        {
+            return;
+        }
+
+        bool remove;
+        var completed = false;
+        lock (gate)
+        {
+            remove = outstanding.Remove(reaction);
+            if (remove)
+            {
+                faults[reaction] = exception;
+                isPending = outstanding.Count > 0;
+                completed = isSealed && outstanding.Count == 0 && !settled.Task.IsCompleted;
+            }
+        }
+        if (remove)
+        {
+            reaction.RemoveStabilizationListener(this);
+            SchedulePendingPublish();
+        }
+        if (completed)
+        {
+            CompleteSettled();
+        }
+    }
+
+    private void CompleteSettled()
+    {
+        Exception[] recorded;
+        lock (gate)
+        {
+            recorded = [.. faults.Values];
+        }
+
+        if (recorded.Length > 0)
+        {
+            settled.TrySetException(new AggregateException(recorded));
+        }
+        else
+        {
+            settled.TrySetResult();
+        }
+    }
+
+    // Publish the current pending state into the reactive signal from a detached flow: the
+    // callers run inside committing evaluations (OnStabilized) or invalidation cascades
+    // (RegisterReached), where a Set would re-enter the graph. Publishes are chained so they
+    // apply in schedule order, and each link reads the CURRENT snapshot at Set time -- every
+    // state change schedules a link, so the last link always publishes the latest truth no
+    // matter how the flips raced.
+    private void SchedulePendingPublish()
+    {
+        if (pendingSignal is null)
+        {
+            return;
+        }
+
+        lock (gate)
+        {
+            var prev = pendingPublishChain;
+            pendingPublishChain = Task.Run(async () =>
+            {
+                TransitionFlow.Suppress();
+                await prev.ConfigureAwait(false);
+                try
+                {
+                    await pendingSignal!.Set(isPending).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // A failed publish must not break the chain; the next state change
+                    // schedules another link that converges the signal.
+                }
+            });
+        }
+    }
+}

--- a/MemoizR.Reactive/Transition.cs
+++ b/MemoizR.Reactive/Transition.cs
@@ -121,10 +121,12 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
         var subscribe = false;
         lock (gate)
         {
-            if (settled.Task.IsCompleted)
+            if (isSealed)
             {
-                // A fully settled transition is immutable; a Set performed on a flow that
-                // still carries the tag after settlement is not tracked.
+                // Dispose FIXES the wavefront: a Set performed by work that still carries the
+                // tag after the scope closed (fire-and-forget spawned inside it) must not
+                // extend, fault, or hang the sealed transition. Covers settled too (settlement
+                // implies sealed).
                 return;
             }
 

--- a/MemoizR.Reactive/Transition.cs
+++ b/MemoizR.Reactive/Transition.cs
@@ -138,6 +138,13 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
             reaction.AddStabilizationListener(this);
         }
         OnStabilizedCore(reaction, reaction.stateCell.LastCleanCommitToken);
+        // A fault can beat the registration the same way a commit can (a zero-debounce update
+        // faulting before the listener is added); the recorded fault token recovers it.
+        var fault = reaction.LastStabilizationFault;
+        if (fault != null && fault.Token >= threshold)
+        {
+            OnFaultedCore(reaction, fault.Exception);
+        }
         if (reaction.IsDisposed)
         {
             OnStabilizedCore(reaction, int.MaxValue);
@@ -180,11 +187,14 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
 
     void IStabilizationListener.OnStabilizationFaulted(SignalHandlR node, Exception exception)
     {
-        if (node is not ReactionBase reaction)
+        if (node is ReactionBase reaction)
         {
-            return;
+            OnFaultedCore(reaction, exception);
         }
+    }
 
+    private void OnFaultedCore(ReactionBase reaction, Exception exception)
+    {
         bool remove;
         var completed = false;
         lock (gate)

--- a/MemoizR.Reactive/Transition.cs
+++ b/MemoizR.Reactive/Transition.cs
@@ -88,7 +88,10 @@ public sealed class Transition : IDisposable, IAsyncDisposable, IStabilizationLi
     /// <summary>Seals the wavefront and restores the prior ambient transition tag.</summary>
     public void Dispose()
     {
-        if (taggedAmbientFlow)
+        // Restore only when THIS scope is still the ambient one: a second Dispose, or a
+        // Dispose running on a Task.Run copy of the ExecutionContext, must not clobber
+        // whatever transition is active on that flow with a stale prior.
+        if (taggedAmbientFlow && ReferenceEquals(TransitionFlow.Current, this))
         {
             TransitionFlow.Current = prior;
         }

--- a/MemoizR.StructuredConcurrency/ConcurrentRace.cs
+++ b/MemoizR.StructuredConcurrency/ConcurrentRace.cs
@@ -160,12 +160,15 @@ public sealed class ConcurrentRace<T, I> : MemoHandlR<T>, IMemoizR, IStampedGetR
 
     async Task IMemoizR.Stale(CacheState state)
     {
-        if (state <= State)
+        // Like SignalHandlR.InvalidateAndPropagateAsync, an active write-wavefront observer
+        // (ADR 0007) overrides the already-dirty pruning: the cascade must reach downstream
+        // reactions so the tagged write registers with them.
+        if (state <= State && !WavefrontFlow.IsActive)
         {
             return;
         }
 
-        State = state;
+        State = state > State ? state : State;
 
         await PropagateStaleToObserversAsync(CacheState.CacheDirty);
     }

--- a/MemoizR.Tests/CacheStateCellTests.cs
+++ b/MemoizR.Tests/CacheStateCellTests.cs
@@ -131,4 +131,42 @@ public class CacheStateCellTests
         Assert.True(cell.TryCommitClean(token));
         Assert.Equal(CacheState.CacheClean, cell.State);
     }
+
+    [Fact]
+    public void Invalidate_OutGeneration_IsTheCommitThreshold()
+    {
+        // ADR 0007: a commit reflects an invalidation exactly when its token is >= the
+        // invalidation's post-bump generation -- the wavefront-membership rule transitions
+        // complete on.
+        var cell = new CacheStateCell(CacheState.CacheClean);
+        var preToken = cell.BeginEvaluation();
+
+        Assert.True(cell.Invalidate(CacheState.CacheDirty, out var threshold));
+        Assert.True(threshold > preToken);        // strictly above every pre-bump snapshot
+        Assert.False(cell.TryCommitClean(preToken)); // a pre-invalidation evaluation can't satisfy it
+
+        var postToken = cell.BeginEvaluation();
+        Assert.True(postToken >= threshold);      // an evaluation started after the bump can
+        Assert.True(cell.TryCommitClean(postToken));
+    }
+
+    [Fact]
+    public void LastCleanCommitToken_TracksOnlySuccessfulCommits()
+    {
+        // The registration-race recovery read (ADR 0007): -1 before any commit, unchanged by a
+        // refused commit, the committed token after a successful one.
+        var cell = new CacheStateCell(CacheState.CacheClean);
+        Assert.Equal(-1, cell.LastCleanCommitToken);
+
+        var token = cell.BeginEvaluation();
+        cell.Invalidate(CacheState.CacheDirty, out var threshold);
+        Assert.False(cell.TryCommitClean(token));
+        Assert.Equal(-1, cell.LastCleanCommitToken);
+        Assert.True(cell.LastCleanCommitToken < threshold); // the recovery check would not fire
+
+        var freshToken = cell.BeginEvaluation();
+        Assert.True(cell.TryCommitClean(freshToken));
+        Assert.Equal(freshToken, cell.LastCleanCommitToken);
+        Assert.True(cell.LastCleanCommitToken >= threshold); // now it would
+    }
 }

--- a/MemoizR.Tests/CoyoteTests.cs
+++ b/MemoizR.Tests/CoyoteTests.cs
@@ -117,4 +117,58 @@ public class CoyoteTests
         var result = await c.Get();
         if (result != 20) throw new Exception($"c.Get() expected 20, but got {result}");
     }
+
+    // Systematic exploration of Invalidate (ADR 0007) racing Gets: an Invalidate landing
+    // mid-recompute must refuse that recompute's Clean commit, or the memo caches a value
+    // computed from pre-refresh out-of-band state with nothing ever re-dirtying it.
+    [Fact]
+    public void TestInvalidateWithCoyote()
+    {
+        if (!IsCoyoteRewritten(typeof(MemoFactory).Assembly))
+        {
+            return;
+        }
+
+        // Same uncontrolled-Lock caveat as TestChainLostUpdateWithCoyote (CacheStateCell's gate).
+        var configuration = Configuration.Create()
+            .WithTestingIterations(100)
+            .WithDeadlockTimeout(100)
+            .WithPotentialDeadlocksReportedAsBugs(false);
+        var engine = TestingEngine.Create(configuration, TestInvalidateIteration);
+        engine.Run();
+        if (engine.TestReport.NumOfFoundBugs > 0)
+        {
+            var bug = engine.TestReport.BugReports.First();
+            throw new Exception($"Coyote found a bug: {bug}");
+        }
+    }
+
+    private async Task TestInvalidateIteration()
+    {
+        var f = new MemoFactory();
+        var external = 0;
+        var m = f.CreateMemoizR(() => Task.FromResult(Volatile.Read(ref external)));
+        await m.Get(); // prime so the race starts from a committed Clean value
+
+        var tasks = new List<Task>();
+        for (var i = 1; i <= 3; i++)
+        {
+            var j = i;
+            tasks.Add(Task.Run(async () =>
+            {
+                Volatile.Write(ref external, j);
+                await m.Invalidate();
+            }));
+            tasks.Add(Task.Run(async () => await m.Get()));
+        }
+        await Task.WhenAll(tasks);
+
+        // After the race quiesces, a final refresh must always surface the latest out-of-band
+        // state: a recompute that wrongly committed Clean over a racing Invalidate serves the
+        // pre-refresh value here.
+        Volatile.Write(ref external, 40);
+        await m.Invalidate();
+        var result = await m.Get();
+        if (result != 40) throw new Exception($"m.Get() expected 40, but got {result}");
+    }
 }

--- a/MemoizR.Tests/OptimisticTests.cs
+++ b/MemoizR.Tests/OptimisticTests.cs
@@ -215,6 +215,29 @@ public class OptimisticTests
         Assert.Empty(await items.Get());
     }
 
+    [Fact(Timeout = 5000)]
+    public async Task Apply_AfterTheRunEnded_IsRejected_AndOrphansNoPatch()
+    {
+        var f = new MemoFactory();
+        var value = f.CreateSignal(10);
+        var optimistic = f.CreateOptimistic<int>(value);
+
+        // A body that leaks its context to later fire-and-forget work.
+        OptimisticActionContext leaked = null!;
+        var act = f.CreateAction<int>((x, ctx) =>
+        {
+            leaked = ctx;
+            return Task.CompletedTask;
+        });
+        var run = act.Run(1);
+        await run.Completion;
+        await run.Settled;
+
+        // A late Apply must throw instead of adding a patch no drop will ever own.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => leaked.Apply(optimistic, x => x + 5));
+        Assert.Equal(10, await optimistic.Get());
+    }
+
     [Fact]
     public void CreateAction_StrictMode_HoldsThePayloadToTheSendableBar()
     {

--- a/MemoizR.Tests/OptimisticTests.cs
+++ b/MemoizR.Tests/OptimisticTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Immutable;
+using MemoizR.Reactive;
+
+namespace MemoizR.Tests;
+
+// Phase 3 of ADR 0007: optimistic state with structural rollback, driven by process-layer
+// actions. The test matrix is Solid 2.0's transition lifecycle table: initial -> optimistic
+// projection -> awaiting resolution -> confirm-and-refresh | rollback.
+public class OptimisticTests
+{
+    [Fact(Timeout = 5000)]
+    public async Task Optimistic_ProjectsInstantly_ThenConfirmsAndDropsThePatch()
+    {
+        var f = new MemoFactory();
+        var todos = f.CreateSignal(ImmutableList.Create("existing"));
+        var optimistic = f.CreateOptimistic<ImmutableList<string>>(todos);
+        Assert.Equal(new[] { "existing" }, await optimistic.Get());
+
+        var server = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var addTodo = f.CreateAction<string>(async (todo, ctx) =>
+        {
+            await ctx.Apply(optimistic, list => list.Add($"{todo} (pending)"));
+            var confirmed = await server.Task;                       // the network call
+            await todos.Set((await todos.Get()).Add(confirmed));     // confirm the source of truth
+        });
+
+        var run = addTodo.Run("write docs");
+
+        // 2. Action triggered: the view instantly projects the future state; the source of
+        // truth is untouched while the "server" is still deciding.
+        await TestHelpers.WaitForConvergenceAsync(() => optimistic.Get().Result.Count == 2);
+        Assert.Equal(new[] { "existing", "write docs (pending)" }, await optimistic.Get());
+        Assert.Equal(new[] { "existing" }, await todos.Get());
+
+        // 4. Server commit: the confirmed value replaces the projection, the patch is dropped.
+        server.SetResult("write docs");
+        await run.Completion;
+        await run.Settled;
+        Assert.Equal(new[] { "existing", "write docs" }, await optimistic.Get());
+        Assert.Equal(new[] { "existing", "write docs" }, await todos.Get());
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Optimistic_RollsBackOnFault_WithoutTouchingTheSource()
+    {
+        var f = new MemoFactory();
+        var value = f.CreateSignal(10);
+        var optimistic = f.CreateOptimistic<int>(value);
+        Assert.Equal(10, await optimistic.Get());
+
+        var server = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bump = f.CreateAction<int>(async (delta, ctx) =>
+        {
+            await ctx.Apply(optimistic, x => x + delta);
+            await server.Task;
+            throw new InvalidOperationException("server rejected");
+        });
+
+        var run = bump.Run(5);
+        await TestHelpers.WaitForConvergenceAsync(() => optimistic.Get().Result == 15);
+
+        // 5. Rollback: the temporary projection vanishes, no manual recovery logic anywhere.
+        server.SetResult();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => run.Completion);
+        await run.Settled; // the rollback's own effect wavefront settles cleanly
+        Assert.Equal(10, await optimistic.Get());
+        Assert.Equal(10, await value.Get());
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Optimistic_RollsBackOnCancellation()
+    {
+        var f = new MemoFactory();
+        var value = f.CreateSignal(10);
+        var optimistic = f.CreateOptimistic<int>(value);
+
+        var bump = f.CreateAction<int>(async (delta, ctx) =>
+        {
+            await ctx.Apply(optimistic, x => x + delta);
+            await Task.Delay(Timeout.Infinite, ctx.Token);
+        });
+
+        var run = bump.Run(5);
+        await TestHelpers.WaitForConvergenceAsync(() => optimistic.Get().Result == 15);
+
+        run.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run.Completion);
+        await run.Settled;
+        Assert.Equal(10, await optimistic.Get());
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Optimistic_OverlappingActions_RollBackIndependently()
+    {
+        var f = new MemoFactory();
+        var items = f.CreateSignal(ImmutableList<string>.Empty);
+        var optimistic = f.CreateOptimistic<ImmutableList<string>>(items);
+
+        var serverA = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var serverB = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var add = f.CreateAction<(string Item, Task Server, bool Fail)>(async (p, ctx) =>
+        {
+            await ctx.Apply(optimistic, list => list.Add(p.Item));
+            await p.Server;
+            if (p.Fail)
+            {
+                throw new InvalidOperationException("rejected");
+            }
+            await items.Set((await items.Get()).Add(p.Item));
+        });
+
+        var runA = add.Run(("a", serverA.Task, true));
+        var runB = add.Run(("b", serverB.Task, false));
+        await TestHelpers.WaitForConvergenceAsync(() => optimistic.Get().Result.Count == 2);
+
+        // A fails: only A's projection vanishes -- B's stays, because rollback is patch
+        // removal, not a compensating write over shared state.
+        serverA.SetResult();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => runA.Completion);
+        await runA.Settled;
+        Assert.Equal(new[] { "b" }, await optimistic.Get());
+        Assert.Empty(await items.Get() ?? []);
+
+        serverB.SetResult();
+        await runB.Completion;
+        await runB.Settled;
+        Assert.Equal(new[] { "b" }, await optimistic.Get());
+        Assert.Equal(new[] { "b" }, await items.Get());
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Action_IsPending_CoversTheWholeRun()
+    {
+        var f = new MemoFactory();
+        var value = f.CreateSignal(1);
+        var optimistic = f.CreateOptimistic<int>(value);
+        var server = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var act = f.CreateAction<int>(async (x, ctx) =>
+        {
+            await ctx.Apply(optimistic, v => v + x);
+            await server.Task;
+        });
+
+        Assert.False(act.IsPendingSnapshot);
+        Assert.False(await act.IsPending.Get());
+
+        var run = act.Run(1);
+        await TestHelpers.WaitForConvergenceAsync(() => act.IsPending.Get().Result);
+        Assert.True(act.IsPendingSnapshot);
+
+        server.SetResult();
+        await run.Completion;
+        Assert.False(act.IsPendingSnapshot);
+        await TestHelpers.WaitForConvergenceAsync(() => !act.IsPending.Get().Result);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ActionRun_Settled_MeansTheUiReflectsTheFinalOutcome()
+    {
+        var f = new MemoFactory();
+        var todos = f.CreateSignal(ImmutableList.Create("existing"));
+        var optimistic = f.CreateOptimistic<ImmutableList<string>>(todos);
+
+        ImmutableList<string> observed = ImmutableList<string>.Empty;
+        var r = f.BuildReaction().CreateReaction(optimistic, list => Volatile.Write(ref observed, list));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed).Count == 1);
+
+        var addTodo = f.CreateAction<string>(async (todo, ctx) =>
+        {
+            await ctx.Apply(optimistic, list => list.Add($"{todo} (pending)"));
+            await todos.Set((await todos.Get()).Add(todo));
+        });
+
+        var run = addTodo.Run("ship it");
+        await run.Completion;
+        await run.Settled;
+
+        // The patch-drop is the run's LAST write, so settlement guarantees the reaction's
+        // committed view reflects it: the confirmed item, no pending duplicate.
+        Assert.Equal(new[] { "existing", "ship it" }, Volatile.Read(ref observed));
+    }
+}

--- a/MemoizR.Tests/OptimisticTests.cs
+++ b/MemoizR.Tests/OptimisticTests.cs
@@ -248,8 +248,18 @@ public class OptimisticTests
         Assert.Throws<InvalidOperationException>(
             () => f.CreateAction<List<int>>((p, ctx) => Task.CompletedTask));
 
+        // The optimistic view publishes T across flows, even when the source is not a strict
+        // MemoizR creation.
+        Assert.Throws<InvalidOperationException>(
+            () => f.CreateOptimistic<List<int>>(new ExternalListSource()));
+
         // Immutable payloads pass.
         _ = f.CreateAction<string>((p, ctx) => Task.CompletedTask);
+    }
+
+    private sealed class ExternalListSource : IStateGetR<List<int>>
+    {
+        public Task<List<int>> Get() => Task.FromResult(new List<int>());
     }
 
     [Fact(Timeout = 5000)]

--- a/MemoizR.Tests/OptimisticTests.cs
+++ b/MemoizR.Tests/OptimisticTests.cs
@@ -119,7 +119,7 @@ public class OptimisticTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => runA.Completion);
         await runA.Settled;
         Assert.Equal(new[] { "b" }, await optimistic.Get());
-        Assert.Empty(await items.Get() ?? []);
+        Assert.Empty(await items.Get());
 
         serverB.SetResult();
         await runB.Completion;
@@ -152,6 +152,81 @@ public class OptimisticTests
         await run.Completion;
         Assert.False(act.IsPendingSnapshot);
         await TestHelpers.WaitForConvergenceAsync(() => !act.IsPending.Get().Result);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Optimistic_IsTracked_InMultiParameterReactions()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(10);
+        var optimistic = f.CreateOptimistic<int>(v);
+        var other = f.CreateSignal(1);
+        var sum = 0;
+        var r = f.BuildReaction().CreateReaction(optimistic, other, (a, b) => Volatile.Write(ref sum, a + b));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref sum) == 11);
+
+        // A patch on the optimistic view ALONE must re-run the two-parameter reaction: the
+        // builder unwraps the node-backed wrapper, so the reaction subscribes to the view.
+        var server = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var act = f.CreateAction<int>(async (delta, ctx) =>
+        {
+            await ctx.Apply(optimistic, x => x + delta);
+            await server.Task;
+        });
+        var run = act.Run(5);
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref sum) == 16);
+        Assert.Equal(16, Volatile.Read(ref sum));
+
+        server.SetResult();
+        await run.Completion;
+        await run.Settled;
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref sum) == 11); // rollback
+
+        // Source-of-truth changes flow through the wrapper too.
+        await v.Set(20);
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref sum) == 21);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Optimistic_DependentPatches_RollBackAtomically()
+    {
+        var f = new MemoFactory();
+        var items = f.CreateSignal(ImmutableList<string>.Empty);
+        var optimistic = f.CreateOptimistic<ImmutableList<string>>(items);
+        var server = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var act = f.CreateAction<string>(async (item, ctx) =>
+        {
+            await ctx.Apply(optimistic, list => list.Add(item));
+            // Depends on the first patch's shape: the last element must exist. The rollback
+            // removes both in ONE overlay write, so no frame ever applies this patch alone.
+            await ctx.Apply(optimistic, list => list.SetItem(list.Count - 1, $"{list[^1]} (pending)"));
+            await server.Task;
+            throw new InvalidOperationException("rejected");
+        });
+
+        var run = act.Run("a");
+        await TestHelpers.WaitForConvergenceAsync(() => optimistic.Get().Result.Count == 1);
+        Assert.Equal(new[] { "a (pending)" }, await optimistic.Get());
+
+        server.SetResult();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => run.Completion);
+        await run.Settled;
+        Assert.Empty(await optimistic.Get());
+        Assert.Empty(await items.Get());
+    }
+
+    [Fact]
+    public void CreateAction_StrictMode_HoldsThePayloadToTheSendableBar()
+    {
+        var f = new MemoFactory(null, MemoFactoryOptions.StrictSendableChecks);
+
+        // The payload is captured onto a detached body flow, so strict mode must reject a
+        // mutable reference type exactly as it would for a signal of that type.
+        Assert.Throws<InvalidOperationException>(
+            () => f.CreateAction<List<int>>((p, ctx) => Task.CompletedTask));
+
+        // Immutable payloads pass.
+        _ = f.CreateAction<string>((p, ctx) => Task.CompletedTask);
     }
 
     [Fact(Timeout = 5000)]

--- a/MemoizR.Tests/StabilizationAndInvalidateTests.cs
+++ b/MemoizR.Tests/StabilizationAndInvalidateTests.cs
@@ -1,0 +1,212 @@
+using MemoizR.Reactive;
+
+namespace MemoizR.Tests;
+
+// Phase 1 of ADR 0007: MemoBase.Invalidate() (the refresh primitive) and the stabilization
+// notification (the internal "committed Clean" half of the observer protocol). These pin the
+// contracts transitions and pending indicators are built on.
+public class StabilizationAndInvalidateTests
+{
+    // Records every stabilization callback; ConcurrentQueue because commits arrive from
+    // reaction update flows, not the test flow.
+    private sealed class RecordingListener : IStabilizationListener
+    {
+        public readonly System.Collections.Concurrent.ConcurrentQueue<int> Tokens = new();
+
+        public void OnStabilized(SignalHandlR node, int token) => Tokens.Enqueue(token);
+    }
+
+    [Fact]
+    public async Task Invalidate_ForcesRecomputeOnNextGet()
+    {
+        var f = new MemoFactory();
+        var external = 0;
+        var invocations = 0;
+        var m = f.CreateMemoizR(() =>
+        {
+            Interlocked.Increment(ref invocations);
+            return Task.FromResult(Volatile.Read(ref external));
+        });
+
+        Assert.Equal(0, await m.Get());
+        Assert.Equal(0, await m.Get());
+        Assert.Equal(1, invocations);
+
+        // Out-of-band state changed; the memo cannot know until it is invalidated.
+        Volatile.Write(ref external, 5);
+        Assert.Equal(0, await m.Get());
+        Assert.Equal(1, invocations);
+
+        await m.Invalidate();
+        Assert.Equal(5, await m.Get());
+        Assert.Equal(2, invocations);
+
+        // Memoized again after the refresh.
+        Assert.Equal(5, await m.Get());
+        Assert.Equal(2, invocations);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Invalidate_ReactionReRunsOnlyWhenTheValueActuallyChanged()
+    {
+        var f = new MemoFactory();
+        var external = 0;
+        var m = f.CreateMemoizR(() => Task.FromResult(Volatile.Read(ref external)));
+        var executions = 0;
+        var r = f.BuildReaction().CreateReaction(m, v => Interlocked.Increment(ref executions));
+
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref executions) == 1);
+
+        // The reaction's stabilization notification doubles as the deterministic "this update
+        // pass finished" probe -- it fires on the CacheCheck resolution even when the action
+        // does not run.
+        var listener = new RecordingListener();
+        r.AddStabilizationListener(listener);
+        var tokensBefore = listener.Tokens.Count;
+
+        // Refresh with an UNCHANGED value: the memo recomputes, the reaction re-checks and
+        // commits without executing its side effect.
+        await m.Invalidate();
+        await TestHelpers.WaitForConvergenceAsync(() => listener.Tokens.Count > tokensBefore);
+        Assert.Equal(1, Volatile.Read(ref executions));
+
+        // Refresh with a CHANGED value: now the side effect re-runs.
+        Volatile.Write(ref external, 7);
+        await m.Invalidate();
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref executions) == 2);
+        Assert.Equal(2, Volatile.Read(ref executions));
+    }
+
+    [Fact]
+    public async Task Invalidate_InsideComputation_IsRejectedLikeSet()
+    {
+        var f = new MemoFactory();
+        var m1 = f.CreateMemoizR(() => Task.FromResult(1));
+        Assert.Equal(1, await m1.Get());
+
+        var m2 = f.CreateMemoizR(async () =>
+        {
+            await m1.Invalidate();
+            return 2;
+        });
+
+        // Same contract as Signal.Set inside a computation (MZR003): the exclusive acquisition
+        // inside the evaluation's upgradeable lock is rejected instead of deadlocking.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => m2.Get());
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Invalidate_MidEvaluation_RefusesTheStaleCommit()
+    {
+        var f = new MemoFactory();
+        var gate = new RecomputeGate();
+        var external = 0;
+        var invocations = 0;
+        var m = f.CreateMemoizR(async () =>
+        {
+            var value = Volatile.Read(ref external);
+            Interlocked.Increment(ref invocations);
+            await gate.PauseIfArmedAsync();
+            return value;
+        });
+
+        Assert.Equal(0, await m.Get());
+        var listener = new RecordingListener();
+        m.AddStabilizationListener(listener);
+
+        Volatile.Write(ref external, 1);
+        await m.Invalidate();
+
+        gate.Arm();
+        var pending = Task.Run(() => m.Get());
+        await gate.ReadDone; // the recompute is parked, having already read external == 1
+
+        // A refresh landing mid-evaluation must refuse that evaluation's commit: without the
+        // generation bump the node would cache 1 as Clean and never observe external == 2.
+        Volatile.Write(ref external, 2);
+        await m.Invalidate();
+
+        gate.Proceed();
+        Assert.Equal(1, await pending);   // the evaluation returns what it computed...
+        Assert.Empty(listener.Tokens);    // ...but no stabilization was notified for it
+        Assert.Equal(2, await m.Get());   // and the next Get recomputes fresh
+        Assert.Equal(3, invocations);
+        var token = Assert.Single(listener.Tokens);
+        Assert.Equal(m.stateCell.LastCleanCommitToken, token);
+    }
+
+    [Fact]
+    public async Task StabilizationListener_NotifiedOnMemoCommit_AndLazyUntilPulled()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var m = f.CreateMemoizR(async () => await v.Get() * 2);
+        Assert.Equal(2, await m.Get());
+
+        var listener = new RecordingListener();
+        m.AddStabilizationListener(listener);
+
+        // Pull-based laziness (ADR 0007): a Set only marks the memo stale; nothing stabilizes
+        // -- so nothing is notified -- until someone pulls.
+        await v.Set(5);
+        Assert.Empty(listener.Tokens);
+
+        Assert.Equal(10, await m.Get());
+        var token = Assert.Single(listener.Tokens);
+        Assert.Equal(m.stateCell.LastCleanCommitToken, token);
+
+        // A removed listener hears nothing further.
+        m.RemoveStabilizationListener(listener);
+        await v.Set(6);
+        Assert.Equal(12, await m.Get());
+        Assert.Single(listener.Tokens);
+    }
+
+    [Fact]
+    public async Task StabilizationListener_NotifiedWhenCacheCheckResolvesWithoutRecompute()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var m1 = f.CreateMemoizR(async () => await v.Get() > 0 ? 1 : 0);
+        var m2Invocations = 0;
+        var m2 = f.CreateMemoizR(async () =>
+        {
+            Interlocked.Increment(ref m2Invocations);
+            return await m1.Get() * 10;
+        });
+
+        Assert.Equal(10, await m2.Get());
+        var listener = new RecordingListener();
+        m2.AddStabilizationListener(listener);
+
+        // v changes, but m1 recomputes to the same value: m2's CacheCheck resolves without a
+        // recompute -- and that commit must still notify (a transition anchored on m2 would
+        // otherwise never complete for this write).
+        await v.Set(2);
+        Assert.Equal(10, await m2.Get());
+        Assert.Single(listener.Tokens);
+        Assert.Equal(1, m2Invocations);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task StabilizationListener_NotifiedOnReactionCommit()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var observed = 0;
+        var r = f.BuildReaction().CreateReaction(v, x => Volatile.Write(ref observed, x));
+
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 1);
+
+        var listener = new RecordingListener();
+        r.AddStabilizationListener(listener);
+        var tokensBefore = listener.Tokens.Count;
+
+        await v.Set(5);
+        await TestHelpers.WaitForConvergenceAsync(
+            () => Volatile.Read(ref observed) == 5 && listener.Tokens.Count > tokensBefore);
+
+        Assert.Equal(5, Volatile.Read(ref observed));
+        Assert.True(listener.Tokens.Count > tokensBefore);
+    }
+}

--- a/MemoizR.Tests/StabilizationAndInvalidateTests.cs
+++ b/MemoizR.Tests/StabilizationAndInvalidateTests.cs
@@ -16,7 +16,7 @@ public class StabilizationAndInvalidateTests
 
         public void OnStabilized(SignalHandlR node, int token) => Tokens.Enqueue(token);
 
-        public void OnStabilizationFaulted(SignalHandlR node, Exception exception) => Faults.Enqueue(exception);
+        public void OnStabilizationFaulted(SignalHandlR node, int token, Exception exception) => Faults.Enqueue(exception);
     }
 
     [Fact]

--- a/MemoizR.Tests/StabilizationAndInvalidateTests.cs
+++ b/MemoizR.Tests/StabilizationAndInvalidateTests.cs
@@ -12,8 +12,11 @@ public class StabilizationAndInvalidateTests
     private sealed class RecordingListener : IStabilizationListener
     {
         public readonly System.Collections.Concurrent.ConcurrentQueue<int> Tokens = new();
+        public readonly System.Collections.Concurrent.ConcurrentQueue<Exception> Faults = new();
 
         public void OnStabilized(SignalHandlR node, int token) => Tokens.Enqueue(token);
+
+        public void OnStabilizationFaulted(SignalHandlR node, Exception exception) => Faults.Enqueue(exception);
     }
 
     [Fact]

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -235,6 +235,70 @@ public class TransitionTests
     }
 
     [Fact(Timeout = 5000)]
+    public async Task Transition_ParentFaultDuringCheck_FaultsSettled()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var shouldThrow = false;
+        var m = f.CreateMemoizR(async () =>
+        {
+            var x = await v.Get();
+            if (Volatile.Read(ref shouldThrow))
+            {
+                throw new InvalidOperationException("parent boom");
+            }
+            return x;
+        });
+        var observed = 0;
+        var r = f.BuildReaction().CreateReaction(m, x => Volatile.Write(ref observed, x));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 1);
+
+        // The write reaches the reaction only as CacheCheck; the parent scan then hits the
+        // faulting memo, no commit follows, and nothing reschedules -- the transition must
+        // hear the fault instead of hanging on a wavefront that already failed.
+        Volatile.Write(ref shouldThrow, true);
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+
+        var aggregate = await Assert.ThrowsAsync<AggregateException>(() => t.Settled);
+        var inner = Assert.Single(aggregate.InnerExceptions);
+        Assert.Equal("parent boom", Assert.IsType<InvalidOperationException>(inner).Message);
+        Assert.False(t.IsPending);
+        Assert.Equal(1, Volatile.Read(ref observed)); // the effect never ran with a broken parent
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_FaultThatBeatsRegistration_IsRecovered()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5)
+            {
+                throw new InvalidOperationException("boom");
+            }
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        // Fault once with NO transition listening: only the (token, exception) record remains.
+        await v.Set(5);
+        await TestHelpers.WaitForConvergenceAsync(() => r.LastStabilizationFault != null);
+
+        // A registration whose threshold the recorded fault token satisfies must recover the
+        // fault instead of waiting for a commit that will never come -- the fault mirror of the
+        // LastCleanCommitToken recovery, driven directly through the internal registration.
+        var t = f.BeginTransition();
+        t.RegisterReached(r, r.LastStabilizationFault!.Token);
+        t.Dispose();
+
+        var aggregate = await Assert.ThrowsAsync<AggregateException>(() => t.Settled);
+        Assert.Contains(aggregate.InnerExceptions, e => e.Message == "boom");
+        Assert.False(t.IsPending);
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task Transition_PendingSignal_DrivesOtherReactions()
     {
         var f = new MemoFactory();

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -210,6 +210,37 @@ public class TransitionTests
     }
 
     [Fact(Timeout = 5000)]
+    public async Task Reaction_IsPending_CoversResumeUpdates()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5)
+            {
+                await gate.Task;
+            }
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        // Paused: the scheduled update parks out without executing, draining the counter.
+        r.Pause();
+        await v.Set(5);
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        // The resume update runs the arbitrary-length effect; the pending flag must cover it.
+        var resume = r.Resume();
+        await TestHelpers.WaitForConvergenceAsync(() => r.IsPendingSnapshot);
+        Assert.True(r.IsPendingSnapshot);
+
+        gate.SetResult();
+        await resume;
+        Assert.False(r.IsPendingSnapshot);
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPending.Get().Result);
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task Transition_PausedReaction_KeepsPendingUntilResumeCommits()
     {
         var f = new MemoFactory();

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -300,6 +300,52 @@ public class TransitionTests
     }
 
     [Fact(Timeout = 5000)]
+    public async Task Transition_ParentFaultWithSuccessfulRerun_SettlesClean_WithoutAFaultRecord()
+    {
+        var f = new MemoFactory();
+        var va = f.CreateSignal(1);
+        var vb = f.CreateSignal(1);
+        var faultA = false;
+        var mA = f.CreateMemoizR(async () =>
+        {
+            var x = await va.Get();
+            if (Volatile.Read(ref faultA))
+            {
+                throw new InvalidOperationException("A boom");
+            }
+            return x;
+        });
+        var mB = f.CreateMemoizR(async () => await vb.Get() * 2);
+        var observed = 0;
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            try
+            {
+                await mA.Get();
+            }
+            catch
+            {
+                // Tolerated: the body falls back to B alone.
+            }
+            Volatile.Write(ref observed, await mB.Get());
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 2);
+
+        // Inside the transition, parent A's recompute faults during the scan but parent B's
+        // change dirties the reaction and its rerun commits: the wavefront stabilized, so the
+        // transition settles clean and the scan fault must NOT be recorded over the commit.
+        Volatile.Write(ref faultA, true);
+        var t = f.BeginTransition();
+        await va.Set(2);
+        await vb.Set(5);
+        t.Dispose();
+
+        await t.Settled;
+        Assert.Equal(10, Volatile.Read(ref observed));
+        Assert.Null(r.LastStabilizationFault);
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task Transition_FaultThatBeatsRegistration_IsRecovered()
     {
         var f = new MemoFactory();

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -1,0 +1,264 @@
+using MemoizR.Reactive;
+
+namespace MemoizR.Tests;
+
+// Phase 2 of ADR 0007: transition scopes (BeginTransition / Settled / Pending) and the
+// per-reaction IsPending flag. The gated AdvancedReaction bodies make the pending windows
+// deterministic: an effect parked on a TaskCompletionSource cannot commit, so IsPending is
+// provably true at the assertion point.
+public class TransitionTests
+{
+    [Fact(Timeout = 5000)]
+    public async Task Transition_SettlesAfterTheReachedReactionCommits()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var observed = 0;
+        var r = f.BuildReaction().CreateReaction(v, x => Volatile.Write(ref observed, x));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 1);
+
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+
+        await t.Settled;
+        Assert.False(t.IsPending);
+        Assert.Equal(5, Volatile.Read(ref observed));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_AwaitUsing_IsTheOnSettledAnalog()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var observed = 0;
+        var r = f.BuildReaction().CreateReaction(v, x => Volatile.Write(ref observed, x));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 1);
+
+        await using (var t = f.BeginTransition())
+        {
+            await v.Set(7);
+        }
+
+        // DisposeAsync sealed the scope and awaited settlement: the effect has applied.
+        Assert.Equal(7, Volatile.Read(ref observed));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_IsPendingWhileTheEffectIsInFlight()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            var x = await v.Get();
+            if (x == 5)
+            {
+                await gate.Task;
+            }
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+
+        // The effect is parked on the gate, so it cannot have committed: both the transition
+        // and the reaction are deterministically pending here.
+        Assert.True(t.IsPending);
+        Assert.True(await t.Pending.Get());
+        Assert.True(r.IsPendingSnapshot);
+        Assert.True(await r.IsPending.Get());
+
+        gate.SetResult();
+        await t.Settled;
+        Assert.False(t.IsPending);
+
+        // The reactive projections are published from a detached pump; they converge.
+        await TestHelpers.WaitForConvergenceAsync(() => t.Pending.Get().Result == false);
+        await TestHelpers.WaitForConvergenceAsync(() => r.IsPending.Get().Result == false);
+        Assert.False(r.IsPendingSnapshot);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_MemoOnlyWavefront_SettlesAtDispose()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var m = f.CreateMemoizR(async () => await v.Get() * 2);
+        Assert.Equal(2, await m.Get());
+
+        var t = f.BeginTransition();
+        await v.Set(5);
+
+        // Pull-based laziness: no reaction was reached, so nothing is in flight (the memo
+        // recomputes whenever someone pulls) -- the transition settles at the seal.
+        Assert.False(t.IsPending);
+        t.Dispose();
+        await t.Settled;
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_DisposedWithoutWrites_SettlesImmediately()
+    {
+        var f = new MemoFactory();
+        var t = f.BeginTransition();
+        t.Dispose();
+        await t.Settled;
+        Assert.False(t.IsPending);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_TracksEveryReachedReaction()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var gate1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gate2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var r1 = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5) await gate1.Task;
+        });
+        var r2 = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5) await gate2.Task;
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r1.IsPendingSnapshot && !r2.IsPendingSnapshot);
+
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+
+        Assert.True(t.IsPending);
+        gate1.SetResult();
+        await TestHelpers.WaitForConvergenceAsync(() => !r1.IsPendingSnapshot);
+        Assert.True(t.IsPending); // one of two reached reactions is still in flight
+
+        gate2.SetResult();
+        await t.Settled;
+        Assert.False(t.IsPending);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_ReachesReactionsThroughDerivedMemos()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var m = f.CreateMemoizR(async () => await v.Get() * 2);
+        var observed = 0;
+        var r = f.BuildReaction().CreateReaction(m, x => Volatile.Write(ref observed, x));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 2);
+
+        // The invalidation cascade runs synchronously on the tagged flow, so the transition
+        // sees the whole transitive wavefront, not just the signal's direct observers: the
+        // settlement below can only be correct if the reaction registered through the memo.
+        await using (var t = f.BeginTransition())
+        {
+            await v.Set(5);
+        }
+
+        Assert.Equal(10, Volatile.Read(ref observed));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_FaultedEffect_FaultsSettled()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5)
+            {
+                throw new InvalidOperationException("boom");
+            }
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+
+        var aggregate = await Assert.ThrowsAsync<AggregateException>(() => t.Settled);
+        var inner = Assert.Single(aggregate.InnerExceptions);
+        Assert.Equal("boom", Assert.IsType<InvalidOperationException>(inner).Message);
+        Assert.False(t.IsPending);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_DisposedReaction_ReleasesTheTransition()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5) await gate.Task;
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+        Assert.True(t.IsPending);
+
+        // A dead reaction can never commit; the transition must not stay pending forever.
+        r.Dispose();
+        await t.Settled;
+        Assert.False(t.IsPending);
+        gate.SetResult(); // unpark the abandoned effect
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_PausedReaction_KeepsPendingUntilResumeCommits()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var observed = 0;
+        var r = f.BuildReaction().CreateReaction(v, x => Volatile.Write(ref observed, x));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 1);
+
+        r.Pause();
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+
+        // The paused update ran and parked dirty without committing: the reaction itself is
+        // not pending (nothing scheduled) but the transition honestly still is.
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+        Assert.True(t.IsPending);
+        Assert.NotEqual(5, Volatile.Read(ref observed));
+
+        await r.Resume();
+        await t.Settled;
+        Assert.Equal(5, Volatile.Read(ref observed));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_PendingSignal_DrivesOtherReactions()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5) await gate.Task;
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        var t = f.BeginTransition();
+
+        // A spinner is just another reaction -- on the transition's Pending node. Built OUTSIDE
+        // the tagged flow's writes so it observes, not participates.
+        var spinnerShown = false;
+        var spinner = f.BuildReaction().CreateReaction(t.Pending, pending => Volatile.Write(ref spinnerShown, pending));
+
+        await v.Set(5);
+        t.Dispose();
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref spinnerShown));
+
+        gate.SetResult();
+        await t.Settled;
+        await TestHelpers.WaitForConvergenceAsync(() => !Volatile.Read(ref spinnerShown));
+    }
+}

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -300,6 +300,54 @@ public class TransitionTests
     }
 
     [Fact(Timeout = 5000)]
+    public async Task Transition_InitialReactionRun_DoesNotJoinTheWavefront()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // A reaction BUILT inside the scope, with a parked initial run: creation is not a
+        // write, so the transition (which performed no Sets) settles at the seal instead of
+        // waiting on the eager first run.
+        var t = f.BeginTransition();
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            await v.Get();
+            await gate.Task;
+        });
+        t.Dispose();
+        Assert.False(t.IsPending);
+        await t.Settled;
+
+        gate.SetResult();
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_RedundantDispose_DoesNotClobberANewerAmbientScope()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var observed = 0;
+        var r = f.BuildReaction().CreateReaction(v, x => Volatile.Write(ref observed, x));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 1);
+
+        var t1 = f.BeginTransition();
+        t1.Dispose();
+
+        // A second scope is now ambient; a redundant second Dispose of the OLD scope must not
+        // restore its stale prior over the active one -- t2 would silently stop tracking.
+        var t2 = f.BeginTransition();
+        t1.Dispose();
+        Assert.Same(t2, TransitionFlow.Current);
+
+        await v.Set(5);
+        t2.Dispose();
+        await t2.Settled;
+        Assert.Equal(5, Volatile.Read(ref observed));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task Transition_WritesAfterSeal_DoNotExtendTheWavefront()
     {
         var f = new MemoFactory();

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -298,6 +298,71 @@ public class TransitionTests
         Assert.False(t.IsPending);
     }
 
+    [Fact(Timeout = 10000)]
+    public async Task Transition_TracksWritesThroughAnAlreadyDirtyMemo()
+    {
+        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var m = f.CreateMemoizR(async () => await v.Get() * 2);
+        var observed = 0;
+        var r = f.BuildReaction()
+            .AddTimeProvider(timeProvider)
+            .AddDebounceTime(TimeSpan.FromMinutes(5))
+            .CreateReaction(m, x => Volatile.Write(ref observed, x));
+        await TestHelpers.WaitForConvergenceAsync(() => Volatile.Read(ref observed) == 2);
+
+        // Write 1 (untagged) dirties the memo; the frozen fake clock keeps the reaction's
+        // update parked in its debounce window, so nothing pulls the memo clean.
+        await v.Set(2);
+
+        // The tagged write hits the ALREADY-DIRTY memo. The pruned cascade would hide it from
+        // the reaction's registration -- the transition would settle at dispose with the effect
+        // still unapplied; the wavefront-aware cascade must reach and register the reaction.
+        var t = f.BeginTransition();
+        await v.Set(5);
+        t.Dispose();
+        Assert.True(t.IsPending);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(6));
+        await t.Settled;
+        Assert.Equal(10, Volatile.Read(ref observed));
+        Assert.False(t.IsPending);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Transition_OldFault_DoesNotSettleANewerRegistration()
+    {
+        var f = new MemoFactory();
+        var v = f.CreateSignal(1);
+        var r = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v.Get() == 5)
+            {
+                throw new InvalidOperationException("boom");
+            }
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r.IsPendingSnapshot);
+
+        await v.Set(5);
+        await TestHelpers.WaitForConvergenceAsync(() => r.LastStabilizationFault != null);
+        var oldFault = r.LastStabilizationFault!;
+
+        // A registration with a NEWER threshold than the recorded fault: the old fault belongs
+        // to a superseded trigger and must not fault this wavefront -- its own update is still
+        // owed a commit-or-fault at or above the threshold.
+        var t = f.BeginTransition();
+        t.RegisterReached(r, oldFault.Token + 1);
+        t.Dispose();
+        Assert.True(t.IsPending);
+        Assert.False(t.Settled.IsCompleted);
+
+        // The newer trigger arrives and commits cleanly: the transition settles unfaulted.
+        await v.Set(6);
+        await t.Settled;
+        Assert.False(t.IsPending);
+    }
+
     [Fact(Timeout = 5000)]
     public async Task Transition_PendingSignal_DrivesOtherReactions()
     {

--- a/MemoizR.Tests/TransitionTests.cs
+++ b/MemoizR.Tests/TransitionTests.cs
@@ -300,6 +300,42 @@ public class TransitionTests
     }
 
     [Fact(Timeout = 5000)]
+    public async Task Transition_WritesAfterSeal_DoNotExtendTheWavefront()
+    {
+        var f = new MemoFactory();
+        var v1 = f.CreateSignal(1);
+        var v2 = f.CreateSignal(1);
+        var gate1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gate2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var r1 = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v1.Get() == 5) await gate1.Task;
+        });
+        var r2 = f.BuildReaction().CreateAdvancedReaction(async () =>
+        {
+            if (await v2.Get() == 9) await gate2.Task;
+        });
+        await TestHelpers.WaitForConvergenceAsync(() => !r1.IsPendingSnapshot && !r2.IsPendingSnapshot);
+
+        var t = f.BeginTransition();
+        await v1.Set(5);
+        t.Dispose();
+        Assert.True(t.IsPending); // r1 is parked, the sealed wavefront is {r1}
+
+        // Fire-and-forget work that escaped the scope still carries the tag: its write must not
+        // extend the SEALED wavefront -- r2 stays parked forever, so joining it would hang
+        // settlement on a write the scope never made.
+        TransitionFlow.Current = t;
+        await v2.Set(9);
+        TransitionFlow.Suppress();
+
+        gate1.SetResult();
+        await t.Settled; // settles on r1 alone
+        Assert.False(t.IsPending);
+        gate2.SetResult(); // unpark the stray effect
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task Transition_ParentFaultWithSuccessfulRerun_SettlesClean_WithoutAFaultRecord()
     {
         var f = new MemoFactory();

--- a/MemoizR.sln
+++ b/MemoizR.sln
@@ -25,6 +25,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{5D20
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedGraphSample", "samples\DistributedGraphSample\DistributedGraphSample.csproj", "{7279F82E-8813-41E2-A9B5-C9EBDDD0F3E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MemoizR.Blazor", "MemoizR.Blazor\MemoizR.Blazor.csproj", "{0E5B6436-A601-48FD-8F35-411C28DDDB8E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MemoizR.Blazor.Tests", "MemoizR.Blazor.Tests\MemoizR.Blazor.Tests.csproj", "{CC3A9595-C1B3-41C6-83B0-95B917777A29}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -155,6 +159,30 @@ Global
 		{7279F82E-8813-41E2-A9B5-C9EBDDD0F3E2}.Release|x64.Build.0 = Release|Any CPU
 		{7279F82E-8813-41E2-A9B5-C9EBDDD0F3E2}.Release|x86.ActiveCfg = Release|Any CPU
 		{7279F82E-8813-41E2-A9B5-C9EBDDD0F3E2}.Release|x86.Build.0 = Release|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Debug|x64.Build.0 = Debug|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Debug|x86.Build.0 = Debug|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Release|x64.ActiveCfg = Release|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Release|x64.Build.0 = Release|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Release|x86.ActiveCfg = Release|Any CPU
+		{0E5B6436-A601-48FD-8F35-411C28DDDB8E}.Release|x86.Build.0 = Release|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Debug|x64.Build.0 = Debug|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Debug|x86.Build.0 = Debug|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Release|x64.ActiveCfg = Release|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Release|x64.Build.0 = Release|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Release|x86.ActiveCfg = Release|Any CPU
+		{CC3A9595-C1B3-41C6-83B0-95B917777A29}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MemoizR/CacheStateCell.cs
+++ b/MemoizR/CacheStateCell.cs
@@ -45,11 +45,21 @@ internal sealed class CacheStateCell(CacheState initial)
     // observers, which were already notified when this node first reached that state -- an
     // observer that commits Clean inside the race window is re-notified by the failed commit
     // instead (see SignalHandlR.CommitCleanOrRenotifyAsync).
-    public bool Invalidate(CacheState newState)
+    public bool Invalidate(CacheState newState) => Invalidate(newState, out _);
+
+    // The out parameter returns the post-bump generation: the wavefront membership of THIS
+    // invalidation (ADR 0007). A later Clean commit reflects this invalidation exactly when its
+    // token is >= generationAfter, because TryCommitClean only succeeds against an unchanged
+    // generation -- so a registrant comparing against generationAfter can never be completed by
+    // a commit that predates its write. Taken under the gate, not read back via Generation: a
+    // stale-low volatile read could hand the registrant a pre-bump threshold that a commit from
+    // BEFORE the invalidation (delivered late) would wrongly satisfy.
+    public bool Invalidate(CacheState newState, out int generationAfter)
     {
         lock (gate)
         {
             generation++;
+            generationAfter = generation;
             if (newState <= state) return false;
             state = newState;
             return true;
@@ -88,7 +98,16 @@ internal sealed class CacheStateCell(CacheState initial)
         {
             if (generation != token) return false;
             state = CacheState.CacheClean;
+            lastCleanCommitToken = token;
             return true;
         }
     }
+
+    // The token of the last successful Clean commit; -1 before the first one. Volatile so a
+    // stabilization registrant on another flow can run the missed-notification recovery check
+    // (ADR 0007): after registering its listener it compares this against its invalidation's
+    // generationAfter -- a commit that raced the registration window is caught here, while a
+    // stale-low read only defers to the listener notification that registration now guarantees.
+    private volatile int lastCleanCommitToken = -1;
+    public int LastCleanCommitToken => lastCleanCommitToken;
 }

--- a/MemoizR/MemoBase.cs
+++ b/MemoizR/MemoBase.cs
@@ -221,7 +221,7 @@ public abstract class MemoBase<T> : MemoHandlR<T>, IMemoizR, IStampedGetR<T>
             // early so lock-free fast-path readers can serve the new value while the links are
             // rewired; the trailing commit below re-confirms after the diamond propagation.
             PublishValueWithCapturedStamps(newValue);
-            stateCell.TryCommitClean(token);
+            TryCommitCleanAndNotify(token);
 
             if (RewireOwnLinks)
             {
@@ -270,6 +270,39 @@ public abstract class MemoBase<T> : MemoHandlR<T>, IMemoizR, IStampedGetR<T>
         // case the commit is dropped, the node stays dirty for the next Get, and observers that
         // raced us to Clean are re-notified.
         await CommitCleanOrRenotifyAsync(token);
+    }
+
+    /// <summary>
+    /// Forces this memo to recompute on its next evaluation, exactly as if a source signal had
+    /// changed: the refresh primitive (ADR 0007) for cache expiry, server-push invalidation, or
+    /// reconciling an optimistic projection with its source of truth. Observers are marked
+    /// CacheCheck, so downstream effects re-run only if the recomputed value actually changed.
+    /// An in-flight evaluation that started before this call can no longer commit (the
+    /// generation bump refuses it), so the next Get always recomputes. Like
+    /// <see cref="Signal{T}.Set"/>, it must not be called from inside a computation -- the
+    /// evaluation lock rejects that with <see cref="InvalidOperationException"/>.
+    /// </summary>
+    public async Task Invalidate()
+    {
+        // Resolve the scope once and keep it strongly rooted for the whole write, for the same
+        // reason as Signal.Set: repeated getter access can resolve different instances (weak
+        // registry + resurrection), which would hand the body a ContextLock other than the one
+        // held here.
+        var scope = Context.ReactionScope;
+        try
+        {
+            using (await scope.ContextLock.ExclusiveLockAsync())
+            {
+                // Self to Dirty (must recompute), observers to CacheCheck (they re-run only if
+                // the recompute changes the value) -- the same shape as a parent-driven Stale,
+                // including the always-bumped generation that refuses in-flight commits.
+                await InvalidateAndPropagateAsync(CacheState.CacheDirty);
+            }
+        }
+        finally
+        {
+            GC.KeepAlive(scope);
+        }
     }
 
     // The IMemoizR fan-in (a parent scanning this node, or a reaction flow where no root Get holds

--- a/MemoizR/MemoBase.cs
+++ b/MemoizR/MemoBase.cs
@@ -167,7 +167,7 @@ public abstract class MemoBase<T> : MemoHandlR<T>, IMemoizR, IStampedGetR<T>
         var token = stateCell.Generation;
 
         // If we are potentially dirty, see if a parent has actually changed value.
-        var parentFaulted = State == CacheState.CacheCheck && await ScanParentsForDirty();
+        var parentFault = State == CacheState.CacheCheck ? await ScanParentsForDirty() : null;
 
         // If we were already dirty or marked dirty by the step above, update.
         if (State == CacheState.CacheDirty)
@@ -181,7 +181,7 @@ public abstract class MemoBase<T> : MemoHandlR<T>, IMemoizR, IStampedGetR<T>
         // stop all future re-checks (this Get serves the last good value, but nothing would ever
         // re-dirty us, so the failed parent would never be retried). Stay CacheCheck so every
         // later Get re-attempts the parent until it recovers.
-        if (parentFaulted)
+        if (parentFault != null)
         {
             return;
         }

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -183,6 +183,28 @@ public abstract class SignalHandlR : IMemoHandlR
         }
     }
 
+    // Dispose-time release (ADR 0007): the node will never commit again, so waiters must be
+    // released regardless of their thresholds -- int.MaxValue satisfies them all by fiat.
+    internal void NotifyStabilizationReleased() => NotifyStabilized(int.MaxValue);
+
+    // An update faulted instead of committing (called by ReactionBase's catch; memo faults
+    // surface to the Get caller through the pull path instead).
+    internal void NotifyStabilizationFaulted(Exception exception)
+    {
+        foreach (var listener in stabilizationListeners)
+        {
+            try
+            {
+                listener.OnStabilizationFaulted(this, exception);
+            }
+            catch
+            {
+                // Same contract as NotifyStabilized: listener faults must not escape into the
+                // faulting evaluation's control flow.
+            }
+        }
+    }
+
     // Rewire our source up-links and the parents' observer down-links to match the sources
     // captured during the current evaluation (Context.ReactionScope.CurrentGets). Must only be
     // called by IMemoizR nodes, inside their ContextLock-serialized evaluation.

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -120,12 +120,15 @@ public abstract class SignalHandlR : IMemoHandlR
 
     // Stabilization listeners (ADR 0007): notified after every successful Clean commit of this
     // node, with the generation token the commit succeeded against. Whole-array swaps under
-    // Lock, like Observers; the commit-path read is unsynchronized, so a listener registered on
-    // another flow can miss an in-flight commit -- exactly the race the registration protocol on
-    // IStabilizationListener recovers via CacheStateCell.LastCleanCommitToken. Strong references
-    // on purpose (unlike the weak Observers): a listener's lifetime is owned by its registrant,
-    // which must unregister -- transitions are short-lived and do.
-    private IStabilizationListener[] stabilizationListeners = [];
+    // Lock, like Observers; volatile because the commit-path read has no lock (ADR 0001 rule 2:
+    // the swap's release needs a pairing acquire, or a weakly-ordered CPU could enumerate a
+    // stale array indefinitely). The recovery protocol still matters for the REAL race -- a
+    // commit that read the array before a registration landed -- but with the volatile pairing
+    // that window is bounded by the registrant's subsequent LastCleanCommitToken read instead
+    // of being unbounded. Strong references on purpose (unlike the weak Observers): a
+    // listener's lifetime is owned by its registrant, which must unregister -- transitions are
+    // short-lived and do.
+    private volatile IStabilizationListener[] stabilizationListeners = [];
 
     internal void AddStabilizationListener(IStabilizationListener listener)
     {

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -187,15 +187,17 @@ public abstract class SignalHandlR : IMemoHandlR
     // released regardless of their thresholds -- int.MaxValue satisfies them all by fiat.
     internal void NotifyStabilizationReleased() => NotifyStabilized(int.MaxValue);
 
-    // An update faulted instead of committing (called by ReactionBase's catch; memo faults
-    // surface to the Get caller through the pull path instead).
-    internal void NotifyStabilizationFaulted(Exception exception)
+    // An update faulted instead of committing (called by ReactionBase's fault paths; memo
+    // faults surface to the Get caller through the pull path instead). The token is the
+    // generation the faulted update ran against, so waiters can gate old in-flight faults
+    // exactly like old commits.
+    internal void NotifyStabilizationFaulted(int token, Exception exception)
     {
         foreach (var listener in stabilizationListeners)
         {
             try
             {
-                listener.OnStabilizationFaulted(this, exception);
+                listener.OnStabilizationFaulted(this, token, exception);
             }
             catch
             {
@@ -293,11 +295,14 @@ public abstract class SignalHandlR : IMemoHandlR
     // dirty (see CacheStateCell.Invalidate); propagation is skipped then because the observers
     // were already notified when this node first reached that state -- an observer that commits
     // Clean inside the race window is re-notified by CommitCleanOrRenotifyAsync instead.
+    // EXCEPT when a write-wavefront observer is active (ADR 0007): a pruned cascade would hide
+    // the tagged write from the downstream reactions' registrations, so it always propagates
+    // (see WavefrontFlow).
     // Non-async on purpose: the suppressed case is the common one under write storms and should
     // not pay for an async state machine.
     internal Task InvalidateAndPropagateAsync(CacheState state)
     {
-        if (!stateCell.Invalidate(state))
+        if (!stateCell.Invalidate(state) && !WavefrontFlow.IsActive)
         {
             return Task.CompletedTask;
         }

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -118,6 +118,71 @@ public abstract class SignalHandlR : IMemoHandlR
         }
     }
 
+    // Stabilization listeners (ADR 0007): notified after every successful Clean commit of this
+    // node, with the generation token the commit succeeded against. Whole-array swaps under
+    // Lock, like Observers; the commit-path read is unsynchronized, so a listener registered on
+    // another flow can miss an in-flight commit -- exactly the race the registration protocol on
+    // IStabilizationListener recovers via CacheStateCell.LastCleanCommitToken. Strong references
+    // on purpose (unlike the weak Observers): a listener's lifetime is owned by its registrant,
+    // which must unregister -- transitions are short-lived and do.
+    private IStabilizationListener[] stabilizationListeners = [];
+
+    internal void AddStabilizationListener(IStabilizationListener listener)
+    {
+        lock (Lock)
+        {
+            foreach (var existing in stabilizationListeners)
+            {
+                if (ReferenceEquals(existing, listener))
+                {
+                    return;
+                }
+            }
+            stabilizationListeners = [.. stabilizationListeners, listener];
+        }
+    }
+
+    internal void RemoveStabilizationListener(IStabilizationListener listener)
+    {
+        lock (Lock)
+        {
+            stabilizationListeners = [.. stabilizationListeners.Where(x => !ReferenceEquals(x, listener))];
+        }
+    }
+
+    // The one Clean-commit gate every commit site goes through (MemoBase's early and CacheCheck
+    // commits, ReactionBase's update commits): commit against the token, then notify the
+    // stabilization listeners OUTSIDE the cell's gate. A newer invalidation can land between the
+    // commit and the callbacks, so a notification is only ever level information -- the token
+    // threshold on the listener side absorbs any reordering.
+    internal bool TryCommitCleanAndNotify(int token)
+    {
+        if (!stateCell.TryCommitClean(token))
+        {
+            return false;
+        }
+        NotifyStabilized(token);
+        return true;
+    }
+
+    private void NotifyStabilized(int token)
+    {
+        foreach (var listener in stabilizationListeners)
+        {
+            try
+            {
+                listener.OnStabilized(this, token);
+            }
+            catch
+            {
+                // Internal listeners must not throw (see IStabilizationListener); a fault
+                // escaping here would corrupt the committing evaluation's control flow
+                // (e.g. MemoBase.Update's catch would strip capture-time links for a value
+                // that WAS published). Swallowed like resource-disposal faults.
+            }
+        }
+    }
+
     // Rewire our source up-links and the parents' observer down-links to match the sources
     // captured during the current evaluation (Context.ReactionScope.CurrentGets). Must only be
     // called by IMemoizR nodes, inside their ContextLock-serialized evaluation.
@@ -239,10 +304,11 @@ public abstract class SignalHandlR : IMemoHandlR
     // Non-async, with a lock-free pre-check: if the state is already Clean, either this very
     // token's early commit succeeded (every invalidation escalates the state away from Clean, so
     // Clean here implies an unchanged generation) or a newer evaluation committed -- in both
-    // cases there is nothing to do, and the common recompute path skips the gate entirely.
+    // cases there is nothing to do (whichever commit won already notified the stabilization
+    // listeners), and the common recompute path skips the gate entirely.
     internal Task CommitCleanOrRenotifyAsync(int token)
     {
-        if (stateCell.State == CacheState.CacheClean || stateCell.TryCommitClean(token))
+        if (stateCell.State == CacheState.CacheClean || TryCommitCleanAndNotify(token))
         {
             return Task.CompletedTask;
         }

--- a/MemoizR/MemoHandlR.cs
+++ b/MemoizR/MemoHandlR.cs
@@ -342,21 +342,25 @@ public abstract class SignalHandlR : IMemoHandlR
     // ReactionBase.UpdateIfNecessary: re-check each source that is itself a node, in order. A
     // source that recomputes to a CHANGED value marks THIS node dirty through the diamond
     // down-link, at which point we stop -- our computation may no longer use the remaining sources,
-    // so we must not update a source we used last time but now don't. Returns whether any parent's
-    // recompute FAULTED; the caller then stays un-committed so a later pass retries it. Faults are
-    // suppressed here (not thrown) so one bad parent does not abort the scan of the others. Only
-    // the scan is shared -- the commit that follows differs per node type, so it stays at the call
-    // site.
-    internal async Task<bool> ScanParentsForDirty()
+    // so we must not update a source we used last time but now don't. Returns the first parent
+    // fault (null when none); the caller then stays un-committed so a later pass retries it --
+    // and a reaction additionally reports the fault to its stabilization listeners, because no
+    // commit will follow (ADR 0007). Faults are suppressed here (not thrown) so one bad parent
+    // does not abort the scan of the others. Only the scan is shared -- the commit that follows
+    // differs per node type, so it stays at the call site.
+    internal async Task<Exception?> ScanParentsForDirty()
     {
-        var parentFaulted = false;
+        Exception? parentFault = null;
         foreach (var source in Sources)
         {
             if (source is IMemoizR memoizR)
             {
                 var update = memoizR.UpdateIfNecessary(); // UpdateIfNecessary can change our state
                 await update.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-                parentFaulted |= update.IsFaulted;
+                if (update.IsFaulted)
+                {
+                    parentFault ??= update.Exception!.InnerException ?? update.Exception;
+                }
             }
 
             if (stateCell.State == CacheState.CacheDirty)
@@ -364,7 +368,7 @@ public abstract class SignalHandlR : IMemoHandlR
                 break;
             }
         }
-        return parentFaulted;
+        return parentFault;
     }
 }
 

--- a/MemoizR/StabilizationListener.cs
+++ b/MemoizR/StabilizationListener.cs
@@ -1,0 +1,26 @@
+namespace MemoizR;
+
+// The internal "committed Clean" half of the observer protocol (ADR 0007 phase 1). Observers
+// hear about invalidations (Stale) but nothing hears about a node committing Clean again --
+// which is exactly the edge transitions and pending indicators anchor to. Kept internal and
+// separate from IMemoizR on purpose: observers are graph structure (they receive semantics --
+// re-check, recompute), listeners are pure telemetry and must never influence propagation.
+//
+// Registration protocol for consumers (the reason the token exists): take the invalidation's
+// post-bump generation from CacheStateCell.Invalidate(state, out generationAfter), register the
+// listener, then check node.stateCell.LastCleanCommitToken >= generationAfter to recover a
+// commit that raced the registration window. From then on, a notification with
+// token >= generationAfter means the node's committed state reflects that invalidation --
+// TryCommitClean only succeeds against an unchanged generation, so a commit whose evaluation
+// predates the invalidation can never carry a satisfying token, no matter how late its
+// notification is delivered.
+internal interface IStabilizationListener
+{
+    // Called after `node` committed Clean against `token`. Runs INSIDE the committing
+    // evaluation (node mutex + flow ContextLock held), so implementations must be fast,
+    // non-blocking, must not re-enter the graph (no Get/Set/Invalidate), and must complete any
+    // TaskCompletionSource with RunContinuationsAsynchronously. Calls can arrive out of order
+    // across flows and more than once per logical stabilization -- treat the token as level
+    // information (threshold comparison), never as an edge.
+    void OnStabilized(SignalHandlR node, int token);
+}

--- a/MemoizR/StabilizationListener.cs
+++ b/MemoizR/StabilizationListener.cs
@@ -31,6 +31,10 @@ internal interface IStabilizationListener
     // Execute threw, or whose CacheCheck parent scan hit a faulting source -- the pull path
     // surfaces memo faults to the Get caller instead). The node stays dirty/checked and nothing
     // is rescheduled until its next invalidation, so a waiter must not keep waiting for a
-    // commit that will never come. Same execution constraints as OnStabilized.
-    void OnStabilizationFaulted(SignalHandlR node, Exception exception);
+    // commit that will never come. `token` is the generation the faulted update ran against,
+    // with the same threshold semantics as OnStabilized: a fault with token < a waiter's
+    // threshold belongs to an OLDER invalidation whose superseding update is still scheduled --
+    // the waiter must ignore it, or an old in-flight failure would fault a newer wavefront the
+    // rescheduled update may yet commit. Same execution constraints as OnStabilized.
+    void OnStabilizationFaulted(SignalHandlR node, int token, Exception exception);
 }

--- a/MemoizR/StabilizationListener.cs
+++ b/MemoizR/StabilizationListener.cs
@@ -21,6 +21,14 @@ internal interface IStabilizationListener
     // non-blocking, must not re-enter the graph (no Get/Set/Invalidate), and must complete any
     // TaskCompletionSource with RunContinuationsAsynchronously. Calls can arrive out of order
     // across flows and more than once per logical stabilization -- treat the token as level
-    // information (threshold comparison), never as an edge.
+    // information (threshold comparison), never as an edge. A dispose-time release arrives as
+    // token == int.MaxValue: the node will never commit again, so every threshold is moot.
     void OnStabilized(SignalHandlR node, int token);
+
+    // Called when an update of `node` faulted instead of committing (today: a reaction whose
+    // Execute threw -- the pull path surfaces memo faults to the Get caller instead). The node
+    // stays dirty and nothing is rescheduled until its next invalidation, so a waiter must not
+    // keep waiting for a commit that will never come. Same execution constraints as
+    // OnStabilized.
+    void OnStabilizationFaulted(SignalHandlR node, Exception exception);
 }

--- a/MemoizR/StabilizationListener.cs
+++ b/MemoizR/StabilizationListener.cs
@@ -16,19 +16,21 @@ namespace MemoizR;
 // notification is delivered.
 internal interface IStabilizationListener
 {
-    // Called after `node` committed Clean against `token`. Runs INSIDE the committing
-    // evaluation (node mutex + flow ContextLock held), so implementations must be fast,
-    // non-blocking, must not re-enter the graph (no Get/Set/Invalidate), and must complete any
-    // TaskCompletionSource with RunContinuationsAsynchronously. Calls can arrive out of order
-    // across flows and more than once per logical stabilization -- treat the token as level
-    // information (threshold comparison), never as an edge. A dispose-time release arrives as
-    // token == int.MaxValue: the node will never commit again, so every threshold is moot.
+    // Called after `node` committed Clean against `token` -- usually from INSIDE the committing
+    // evaluation (node mutex + flow ContextLock held), but not always: the dispose-time release
+    // arrives from Dispose with no graph locks held, as token == int.MaxValue ("the node will
+    // never commit again, every threshold is moot"). Implementations must therefore assume
+    // nothing about ambient locks in EITHER direction: be fast, non-blocking, never re-enter
+    // the graph (no Get/Set/Invalidate), and complete any TaskCompletionSource with
+    // RunContinuationsAsynchronously. Calls can arrive out of order across flows and more than
+    // once per logical stabilization -- treat the token as level information (threshold
+    // comparison), never as an edge.
     void OnStabilized(SignalHandlR node, int token);
 
     // Called when an update of `node` faulted instead of committing (today: a reaction whose
-    // Execute threw -- the pull path surfaces memo faults to the Get caller instead). The node
-    // stays dirty and nothing is rescheduled until its next invalidation, so a waiter must not
-    // keep waiting for a commit that will never come. Same execution constraints as
-    // OnStabilized.
+    // Execute threw, or whose CacheCheck parent scan hit a faulting source -- the pull path
+    // surfaces memo faults to the Get caller instead). The node stays dirty/checked and nothing
+    // is rescheduled until its next invalidation, so a waiter must not keep waiting for a
+    // commit that will never come. Same execution constraints as OnStabilized.
     void OnStabilizationFaulted(SignalHandlR node, Exception exception);
 }

--- a/MemoizR/WavefrontFlow.cs
+++ b/MemoizR/WavefrontFlow.cs
@@ -1,0 +1,19 @@
+namespace MemoizR;
+
+// The ambient write-wavefront observer (ADR 0007): set on a writing flow by MemoizR.Reactive's
+// transition scopes and action runs, held as an opaque object so the core stays ignorant of the
+// Reactive types (Reactive reads it back with a cast). Its presence changes ONE core behavior:
+// an invalidation cascade normally prunes at a node that is already at least as dirty -- its
+// observers were notified when it first reached that state -- but a pruned cascade never reaches
+// the downstream reactions, so a tagged write through an already-dirty node would be invisible
+// to the wavefront observer: it could settle before the write's effects applied, and a repeated
+// write could not raise the completion thresholds of already-registered reactions. With an
+// observer active the cascade therefore always propagates. The cost is re-walking
+// already-notified subgraphs -- bounded by the DAG's path count, small in UI-shaped graphs --
+// and only for tagged writes; untagged writes keep the pruned cascade.
+internal static class WavefrontFlow
+{
+    internal static readonly AsyncLocal<object?> Current = new();
+
+    internal static bool IsActive => Current.Value != null;
+}

--- a/README.md
+++ b/README.md
@@ -128,6 +128,48 @@ var m2 = f.CreateMemoizR(async() => await v1.Get() * 2);
 var r1 = f.CreateReaction(m1, m2, (val1, val2) => val1 + val2);
 ```
 
+### Transitions, pending indicators, and optimistic state
+
+The Solid 2.0-style process layer ([ADR 0007](docs/adr/0007-transitions-pending-and-optimistic-state.md)),
+re-derived for a pull-based, multi-threaded graph. A **transition** tracks one write wavefront —
+every reaction the writes invalidate — until all its effects have applied:
+
+```cs
+await using (var t = f.BeginTransition()) // seals on dispose; await using also awaits settlement
+{
+    await v1.Set(5);      // Sets inside the scope are tracked, transitively through memos
+    _ = t.IsPending;      // snapshot: effects still in flight?
+    _ = t.Pending;        // reactive IStateGetR<bool> — a spinner is just a reaction on it
+}
+await t.Settled;          // the onSettled analog; reaction faults aggregate here
+
+r1.IsPending;             // per-reaction reactive "an update is scheduled or running" flag
+```
+
+**Optimistic state** instantly projects an expected future value while the real process runs,
+and rolls back *structurally* — a failed action just drops its patch, the source of truth was
+never touched, so overlapping actions can never clobber each other:
+
+```cs
+var todos      = f.CreateSignal(ImmutableList.Create("existing"));
+var optimistic = f.CreateOptimistic<ImmutableList<string>>(todos);
+
+var addTodo = f.CreateAction<string>(async (todo, ctx) =>
+{
+    await ctx.Apply(optimistic, list => list.Add($"{todo} (pending)")); // instant projection
+    var confirmed = await api.SaveAsync(todo, ctx.Token);               // the process step
+    await todos.Set((await todos.Get()).Add(confirmed));                // confirm the source
+});                                        // fault/cancel => patch dropped => automatic rollback
+
+var run = addTodo.Run("write docs");
+addTodo.IsPending;    // reactive: disable the submit button with a reaction on it
+await run.Settled;    // the UI reflects the final outcome (patch gone, value confirmed)
+```
+
+Memos stay lazy — a write that reaches no reaction has nothing in flight — and refreshing
+out-of-band state is first-class via `memo.Invalidate()`: recompute on next pull, with
+downstream effects re-running only if the value actually changed.
+
 ### Causality Stamps (preparation for distributed graphs)
 
 Every node carries a causality stamp recording exactly which signal versions its current value

--- a/README.md
+++ b/README.md
@@ -135,13 +135,15 @@ re-derived for a pull-based, multi-threaded graph. A **transition** tracks one w
 every reaction the writes invalidate — until all its effects have applied:
 
 ```cs
-await using (var t = f.BeginTransition()) // seals on dispose; await using also awaits settlement
-{
-    await v1.Set(5);      // Sets inside the scope are tracked, transitively through memos
-    _ = t.IsPending;      // snapshot: effects still in flight?
-    _ = t.Pending;        // reactive IStateGetR<bool> — a spinner is just a reaction on it
-}
+var t = f.BeginTransition();
+await v1.Set(5);          // Sets inside the scope are tracked, transitively through memos
+_ = t.IsPending;          // snapshot: effects still in flight?
+_ = t.Pending;            // reactive IStateGetR<bool> — a spinner is just a reaction on it
+t.Dispose();              // seals the wavefront (writes after this are no longer tracked)
 await t.Settled;          // the onSettled analog; reaction faults aggregate here
+
+// or in one step — seal at the block end AND await settlement:
+await using (f.BeginTransition()) { await v1.Set(5); }
 
 r1.IsPending;             // per-reaction reactive "an update is scheduled or running" flag
 ```

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ await t.Settled;          // the onSettled analog; reaction faults aggregate her
 // or in one step — seal at the block end AND await settlement:
 await using (f.BeginTransition()) { await v1.Set(5); }
 
-r1.IsPending;             // per-reaction reactive "an update is scheduled or running" flag
+_ = r1.IsPending;         // per-reaction reactive "an update is scheduled or running" flag
 ```
 
 **Optimistic state** instantly projects an expected future value while the real process runs,
@@ -164,8 +164,8 @@ var addTodo = f.CreateAction<string>(async (todo, ctx) =>
 });                                        // fault/cancel => patch dropped => automatic rollback
 
 var run = addTodo.Run("write docs");
-addTodo.IsPending;    // reactive: disable the submit button with a reaction on it
-await run.Settled;    // the UI reflects the final outcome (patch gone, value confirmed)
+_ = addTodo.IsPending; // reactive: disable the submit button with a reaction on it
+await run.Settled;     // the UI reflects the final outcome (patch gone, value confirmed)
 ```
 
 Memos stay lazy — a write that reaches no reaction has nothing in flight — and refreshing

--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ and rolls back *structurally* — a failed action just drops its patch, the sour
 never touched, so overlapping actions can never clobber each other:
 
 ```cs
-var todos      = f.CreateSignal(ImmutableList.Create("existing"));
+var todos      = f.CreateEagerRelativeSignal(ImmutableList.Create("existing"));
 var optimistic = f.CreateOptimistic<ImmutableList<string>>(todos);
 
 var addTodo = f.CreateAction<string>(async (todo, ctx) =>
 {
     await ctx.Apply(optimistic, list => list.Add($"{todo} (pending)")); // instant projection
     var confirmed = await api.SaveAsync(todo, ctx.Token);               // the process step
-    await todos.Set((await todos.Get()).Add(confirmed));                // confirm the source
+    await todos.Set(list => list.Add(confirmed));  // confirm atomically: overlapping runs compose
 });                                        // fault/cancel => patch dropped => automatic rollback
 
 var run = addTodo.Run("write docs");

--- a/README.md
+++ b/README.md
@@ -262,6 +262,26 @@ See [ADR 0003](docs/adr/0003-sendable-checking-and-isolation-assertions.md) (run
 [ADR 0005](docs/adr/0005-custom-executors.md) (executors), and
 [ADR 0006](docs/adr/0006-actor-engine-prototype.md) (actor engine) for the design and its limits.
 
+### Blazor
+
+With the `MemoizR.Blazor` package the same threading contract reaches Blazor — Server and
+WebAssembly. `services.AddMemoizR()` registers one graph per circuit (circuits are genuinely
+multi-threaded, exactly what the cross-flow guarantees are for), and components inheriting
+`MemoizRComponentBase` project nodes into render-ready fields: dependency evaluation on the
+thread pool, only the field write plus `StateHasChanged` marshalled through the component's
+`InvokeAsync`:
+
+```cs
+protected override void OnInitialized()
+{
+    Bind(optimistic, value => todos = value);          // re-renders on every committed change
+    Bind(addTodo.IsPending, p => submitDisabled = p);  // pending indicator drives the button
+}
+```
+
+Reactions owned by services rather than components can target a renderer dispatcher directly
+with `f.AddBlazorDispatcher(dispatcher)`.
+
 ### WPF / UI threads
 
 With the `MemoizR.Wpf` package the whole dependency graph keeps evaluating on the thread pool;

--- a/docs/NUGET_BLAZOR_README.md
+++ b/docs/NUGET_BLAZOR_README.md
@@ -1,0 +1,53 @@
+# MemoizR.Blazor: Thread-pool reactivity, renderer-context reactions
+
+Blazor wiring for MemoizR.Reactive: signals, memos and every reaction's dependency evaluation
+run on the thread pool, and only the reaction's action is marshalled to the renderer's
+dispatcher — the circuit's synchronization context on Blazor Server, the UI thread on
+WebAssembly. Blazor Server circuits are genuinely multi-threaded, which is exactly what
+MemoizR's cross-flow correctness guarantees are for.
+
+Register one reactive graph per circuit:
+
+```csharp
+builder.Services.AddMemoizR();
+```
+
+Bind graph nodes into components — renders stay synchronous while the graph stays async:
+
+```csharp
+public partial class TodoList : MemoizRComponentBase
+{
+    private ImmutableList<string> todos = ImmutableList<string>.Empty;
+    private OptimisticState<ImmutableList<string>> optimistic = default!;
+    private ReactiveAction<string> addTodo = default!;
+
+    protected override void OnInitialized()
+    {
+        var source = MemoFactory.CreateSignal(ImmutableList<string>.Empty);
+        optimistic = MemoFactory.CreateOptimistic<ImmutableList<string>>(source);
+        addTodo = MemoFactory.CreateAction<string>(async (todo, ctx) =>
+        {
+            await ctx.Apply(optimistic, list => list.Add($"{todo} (pending)")); // instant
+            var confirmed = await Api.SaveAsync(todo, ctx.Token);               // the process
+            await source.Set((await source.Get()).Add(confirmed));              // confirm
+        }); // fault/cancel => automatic rollback
+
+        Bind(optimistic, value => todos = value); // dependency eval on the thread pool,
+                                                  // field write + StateHasChanged via InvokeAsync
+    }
+}
+```
+
+```razor
+<button disabled="@addTodo.IsPendingSnapshot" @onclick='() => addTodo.Run(newTodo)'>Add</button>
+@foreach (var todo in todos) { <TodoRow Item="@todo" /> }
+```
+
+Transitions (`MemoFactory.BeginTransition()`), pending indicators and optimistic state come
+from MemoizR.Reactive; see the [MemoizR repository](https://github.com/timonkrebs/MemoizR)
+and ADR 0007 for the design. For reactions owned by services rather than components, route a
+factory's actions to a renderer dispatcher directly:
+
+```csharp
+var f = new MemoFactory().AddBlazorDispatcher(dispatcher);
+```

--- a/docs/NUGET_BLAZOR_README.md
+++ b/docs/NUGET_BLAZOR_README.md
@@ -23,13 +23,13 @@ public partial class TodoList : MemoizRComponentBase
 
     protected override void OnInitialized()
     {
-        var source = MemoFactory.CreateSignal(ImmutableList<string>.Empty);
+        var source = MemoFactory.CreateEagerRelativeSignal(ImmutableList<string>.Empty);
         optimistic = MemoFactory.CreateOptimistic<ImmutableList<string>>(source);
         addTodo = MemoFactory.CreateAction<string>(async (todo, ctx) =>
         {
             await ctx.Apply(optimistic, list => list.Add($"{todo} (pending)")); // instant
             var confirmed = await Api.SaveAsync(todo, ctx.Token);               // the process
-            await source.Set((await source.Get()).Add(confirmed));              // confirm
+            await source.Set(list => list.Add(confirmed));                      // confirm atomically
         }); // fault/cancel => automatic rollback
 
         Bind(optimistic, value => todos = value); // dependency eval on the thread pool,

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -269,7 +269,11 @@ Where the landed code deliberately deviates from the sketches above:
   writable fields, so a structural runtime check would reject every capturing lambda, including
   harmless immutable captures. This is exactly MZR002-shaped compile-time work: an analyzer
   rule flagging optimistic patches that capture mutable state (the payload type itself IS
-  checked — `CreateAction` gates `TPayload` through the strict Sendable bar).
+  checked — `CreateAction` gates `TPayload` through the strict Sendable bar). Action BODIES
+  are deliberately not classified as MZR002 computation hosts: they are user-driven process
+  code whose runs overlap only when the caller overlaps them, and the common
+  one-run-at-a-time pattern legitimately writes captured state — if wanted, that is a
+  separate, lower-severity rule.
 - Phase 4 landed as `MemoizR.Blazor`: `BlazorDispatcherExecutor` (the exact
   `WpfDispatcherExecutor` mirror), a component-agnostic `ReactionBinder` (the render-snapshot
   pattern: apply-into-field plus `StateHasChanged`, both marshalled through `InvokeAsync`),

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -1,6 +1,6 @@
 # ADR 0007 — Transitions, `IsPending`, and optimistic state with automatic rollback
 
-- Status: Proposed
+- Status: Proposed (phases 1–3 implemented on this branch; 4–5 open)
 - Date: 2026-07-15
 - Deciders: MemoizR maintainers
 - Inspiration: Solid 2.0's async architecture (deferred stabilization, `isPending`,
@@ -227,6 +227,27 @@ Suggested spike order inside phase 1: stabilization notification first — it is
 mechanism parts A, B, and a future `CreatePendingIndicator` all stand on, and the one with
 real concurrency risk (it must fire outside the locks it is called under, on the detached
 runtime flow, without reordering against a newer invalidation).
+
+### Implementation notes (phases 1–3, this branch)
+
+Where the landed code deliberately deviates from the sketches above:
+
+- The stabilization notification carries the committed generation token; consumers compare it
+  against the invalidation's post-bump generation (`Invalidate(state, out generationAfter)`),
+  with a `LastCleanCommitToken` recovery read that makes registration-vs-commit ordering free.
+  A faulted reaction update notifies `OnStabilizationFaulted`; a disposed reaction releases
+  its waiters (`int.MaxValue` satisfies every threshold).
+- The ambient tag (`TransitionFlow`) lives in `MemoizR.Reactive`, not core: both its writer
+  (`BeginTransition` / action runs) and its reader (`ReactionBase.Stale`) are in the Reactive
+  assembly. Detached runtime flows — debounced updates, pending-publish pumps — suppress the
+  inherited tag, otherwise a transition's own machinery Stales (renotifies, pending-signal
+  propagation) would re-arm it forever.
+- The action sketch's explicit `Confirm` step was dropped: a run's patches are removed
+  unconditionally when the body ends, so "confirm" is simply the body writing the source of
+  truth before returning — one less concept, same lifecycle table.
+- `CreateAction` uses a plain per-run `CancellationTokenSource` instead of depending on
+  `MemoizR.StructuredConcurrency`; an overload wrapping a structured resource group can be
+  layered in that assembly later without touching the Reactive types.
 
 ## Consequences
 

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -249,6 +249,14 @@ Where the landed code deliberately deviates from the sketches above:
 - `CreateAction` uses a plain per-run `CancellationTokenSource` instead of depending on
   `MemoizR.StructuredConcurrency`; an overload wrapping a structured resource group can be
   layered in that assembly later without touching the Reactive types.
+- A tagged write's cascade does NOT prune at already-dirty nodes (core `WavefrontFlow`, an
+  opaque ambient the Reactive tag rides in): the pruning optimization is sound for
+  invalidation but would hide the write from downstream registrations — a transition through
+  an already-dirty memo could settle before the write's effects applied, and repeated writes
+  could not raise registered thresholds. Untagged writes keep the pruned cascade. Fault
+  notifications carry the faulted update's generation token and are gated by the same
+  threshold rule as commits, so an old in-flight failure cannot fault a newer wavefront whose
+  superseding update is still owed a commit.
 - Phase 4 landed as `MemoizR.Blazor`: `BlazorDispatcherExecutor` (the exact
   `WpfDispatcherExecutor` mirror), a component-agnostic `ReactionBinder` (the render-snapshot
   pattern: apply-into-field plus `StateHasChanged`, both marshalled through `InvokeAsync`),

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -1,6 +1,7 @@
 # ADR 0007 — Transitions, `IsPending`, and optimistic state with automatic rollback
 
-- Status: Proposed (phases 1–3 implemented on this branch; 4–5 open)
+- Status: Proposed (phases 1–4 implemented on this branch — phase 4 without the sample app and
+  bUnit component tests; phase 5 open)
 - Date: 2026-07-15
 - Deciders: MemoizR maintainers
 - Inspiration: Solid 2.0's async architecture (deferred stabilization, `isPending`,
@@ -248,6 +249,13 @@ Where the landed code deliberately deviates from the sketches above:
 - `CreateAction` uses a plain per-run `CancellationTokenSource` instead of depending on
   `MemoizR.StructuredConcurrency`; an overload wrapping a structured resource group can be
   layered in that assembly later without touching the Reactive types.
+- Phase 4 landed as `MemoizR.Blazor`: `BlazorDispatcherExecutor` (the exact
+  `WpfDispatcherExecutor` mirror), a component-agnostic `ReactionBinder` (the render-snapshot
+  pattern: apply-into-field plus `StateHasChanged`, both marshalled through `InvokeAsync`),
+  `MemoizRComponentBase` gluing it to components, and `services.AddMemoizR()` for the
+  scoped-per-circuit factory. Integration-tested against `Dispatcher.CreateDefault()` — the
+  renderer dispatcher Blazor Server uses — so the thread-pool/renderer split is pinned without
+  a renderer; the optimistic-todo sample app and bUnit component tests remain open.
 
 ## Consequences
 

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -60,16 +60,21 @@ A **transition** is the unit "this write (or group of writes), until every react
 invalidated has committed clean again."
 
 ```csharp
-await using var t = f.BeginTransition();
+var t = f.BeginTransition();
 await v1.Set(5);                  // Sets inside the scope are tagged with the transition
 await v2.Set("x");
+t.Dispose();                      // seals the wavefront (or: await using (t) { ...Sets... })
 
 // observable state:
 t.IsPending          // bool snapshot (sync-readable, e.g. from a render)
 t.Pending            // IStateGetR<bool> — reactive, other nodes can depend on it
-await t.Settled;     // Task — completes when the wavefront has stabilized (onSettled analog)
-t.Exception          // set when a reached reaction's update faulted
+await t.Settled;     // completes once sealed AND the wavefront stabilized (onSettled analog);
+                     // reached-reaction faults surface here as an AggregateException
 ```
+
+Settlement requires the seal (only sealing fixes the wavefront — early drain between two Sets
+must not settle), so `Settled` is awaited AFTER the scope: an `await using` block seals at the
+block end and additionally awaits settlement itself.
 
 **Mechanics** (all hooks exist today):
 
@@ -138,17 +143,18 @@ concurrent writers and can resurrect stale state; removing an overlay cannot.
 var todos     = f.CreateSignal(ImmutableList<Todo>.Empty);
 
 // optimistic view = base + pending patches, in one node
-var optimistic = f.CreateOptimistic(todos);        // IStateGetR<ImmutableList<Todo>>
+var optimistic = f.CreateOptimistic<ImmutableList<Todo>>(todos);
 
-var addTodo = f.CreateAction<Todo>(async (todo, action) =>
+var addTodo = f.CreateAction<Todo>(async (todo, ctx) =>
 {
-    action.Apply(optimistic, list => list.Add(todo with { Pending = true })); // instant projection
-    var confirmed = await api.SaveAsync(todo, action.Token);                  // the process step
-    await action.Confirm(todos, list => list.Add(confirmed));                 // commit + drop patch
-});                                                                            // fault/cancel ⇒ patch removed ⇒ automatic rollback
+    await ctx.Apply(optimistic, list => list.Add(todo with { Pending = true })); // instant projection
+    var confirmed = await api.SaveAsync(todo, ctx.Token);                        // the process step
+    await todos.Set((await todos.Get()).Add(confirmed));                         // confirm the source
+});                       // run end drops the patches: on fault/cancel that IS the rollback
 
-await addTodo.Run(newTodo);      // returns the action's Transition
-addTodo.IsPending                // pending indicator for free (it IS a transition)
+var run = addTodo.Run(newTodo);  // detached; run.Completion is the body, run.Settled the effects
+addTodo.IsPending                // reactive pending indicator across all runs
+await run.Settled;               // the UI reflects the final outcome (patch gone)
 ```
 
 **Internals:**
@@ -257,6 +263,13 @@ Where the landed code deliberately deviates from the sketches above:
   notifications carry the faulted update's generation token and are gated by the same
   threshold rule as commits, so an old in-flight failure cannot fault a newer wavefront whose
   superseding update is still owed a commit.
+- Known strict-mode gap, deferred to the phase-5 analyzers: optimistic patch DELEGATES are not
+  runtime-validated. A patch runs inside the view's computation on whichever flow pulls, so a
+  lambda closing over mutable state crosses flows — but closure display classes always carry
+  writable fields, so a structural runtime check would reject every capturing lambda, including
+  harmless immutable captures. This is exactly MZR002-shaped compile-time work: an analyzer
+  rule flagging optimistic patches that capture mutable state (the payload type itself IS
+  checked — `CreateAction` gates `TPayload` through the strict Sendable bar).
 - Phase 4 landed as `MemoizR.Blazor`: `BlazorDispatcherExecutor` (the exact
   `WpfDispatcherExecutor` mirror), a component-agnostic `ReactionBinder` (the render-snapshot
   pattern: apply-into-field plus `StateHasChanged`, both marshalled through `InvokeAsync`),

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -1,0 +1,256 @@
+# ADR 0007 — Transitions, `IsPending`, and optimistic state with automatic rollback
+
+- Status: Proposed
+- Date: 2026-07-15
+- Deciders: MemoizR maintainers
+- Inspiration: Solid 2.0's async architecture (deferred stabilization, `isPending`,
+  `createOptimistic`, generator actions), re-derived for a pull-based, multi-threaded graph
+- Builds on: [ADR 0002](0002-choosing-a-lock.md) (the lock layers this must not re-enter),
+  [ADR 0005](0005-custom-executors.md) (the executor seam UI integration rides on),
+  [Concurrency Architecture](../architecture/concurrency.md) (the cache-state protocol all
+  hooks attach to)
+
+## Context
+
+MemoizR's propagation core is the same design family as Solid 2.0's: writes push staleness
+marks without recomputing, reads pull stabilization lazily, reactions are deferred and
+debounced, equal-value writes short-circuit. What MemoizR lacks is Solid 2.0's **process
+layer for user interfaces**:
+
+1. **Transitions / `isPending`** — an observable "a stabilization is in flight" state, so a
+   UI can keep showing the previous committed view (no teardown, no spinner-blanking) while
+   indicating background work.
+2. **Optimistic state** — a write primitive that instantly projects an expected future value
+   onto readers, reconciles with the confirmed value when the backing process completes, and
+   **rolls back automatically** when it fails — with no manual recovery logic at the call
+   site.
+
+The target surfaces are Blazor first (Server and WebAssembly) and WPF second; both already
+have an integration seam in `IExecutor` (ADR 0005).
+
+### Why Solid's primitives cannot be copied 1:1
+
+Three structural differences force a re-derivation rather than a port:
+
+- **Pull-based laziness.** In Solid, a transition is "in flight" from write to scheduler
+  flush — the scheduler is global and eager-ish, so *the graph itself* has a notion of
+  unfinished work. In MemoizR, a lazy memo that nobody pulls has **no** in-flight work; there
+  is nothing pending until a puller exists. The only nodes with autonomous, observable
+  latency are **reactions** (debounce window + recompute duration). Therefore pending state
+  must anchor to *reactions and explicit transitions*, never to lazy memos alone.
+- **True concurrency.** A pending flag flipped from inside evaluation windows would have to
+  `Set` a signal while holding the flow's `ContextLock` — exactly the
+  exclusive-inside-upgradeable re-entrance the lock rejects (ADR 0002). All runtime-driven
+  publications must ride the detached-flow pattern `ReactionBase.RunDebouncedUpdateAsync`
+  already uses (`ForceNewScope` on a `Task.Run` flow). And because detached flips can land
+  out of order, pending must be a **counter crossing zero**, never a boolean.
+- **The process layer already exists.** Solid needed generator actions because JavaScript
+  loses the tracking context at `await`; .NET's `ExecutionContext` flows `AsyncLocal` state
+  across awaits natively. MemoizR additionally already has the process-side machinery Solid
+  had to invent: structured concurrency jobs with cancellation trees and resource groups.
+  The "action" primitive below is deliberately a thin composition of `Set` + a structured
+  job + a transition — not a new execution model.
+
+## Decision (proposed design)
+
+### A. Transitions: `BeginTransition` and the stabilization wavefront
+
+A **transition** is the unit "this write (or group of writes), until every reaction it
+invalidated has committed clean again."
+
+```csharp
+await using var t = f.BeginTransition();
+await v1.Set(5);                  // Sets inside the scope are tagged with the transition
+await v2.Set("x");
+
+// observable state:
+t.IsPending          // bool snapshot (sync-readable, e.g. from a render)
+t.Pending            // IStateGetR<bool> — reactive, other nodes can depend on it
+await t.Settled;     // Task — completes when the wavefront has stabilized (onSettled analog)
+t.Exception          // set when a reached reaction's update faulted
+```
+
+**Mechanics** (all hooks exist today):
+
+1. *Tagging.* `BeginTransition` sets an ambient `AsyncLocal<Transition?>` — the exact pattern
+   of `RaceBranchFlow` (`Context.cs`). `Signal.Set` → `PropagateStaleToObserversAsync` →
+   `IMemoizR.Stale` runs on the same async flow, so the tag arrives at every reached node
+   with zero new plumbing.
+2. *Registration.* In `ReactionBase.Stale` (under `staleLock`, where the debounced update is
+   scheduled), a tagged invalidation registers `(reaction, transition)` — deduplicated per
+   reaction, because coalesced staleness commits once.
+3. *Completion.* A reaction notifies its registered transitions when its update **commits
+   clean** — the `stateCell.TryCommitClean(token)` success at the end of
+   `ReactionBase.UpdateIfNecessary`/`Update`. A refused commit (newer invalidation won) is
+   *not* completion; the rescheduled update completes it later. This is monotone and safe:
+   the reaction then reflects at-least-as-new state as the tagged write.
+4. *Termination edge cases*, each pinned by a test:
+   - **Fault**: an `Execute` that throws completes the transition as faulted, carrying the
+     exception (structured-concurrency-style error surfacing). The reaction stays Dirty per
+     its existing contract.
+   - **Dispose**: a disposed reaction completes its transitions (the wavefront can no longer
+     stabilize through it).
+   - **Pause**: a paused reaction keeps the transition pending until `Resume()` commits —
+     honest, but a documented footgun (a paused UI keeps `IsPending` true).
+   - **Memo-only cascades**: if propagation reaches no reaction, the transition completes
+     when propagation finishes — lazy semantics, documented. An opt-in
+     `TransitionOptions.Stabilize` variant may additionally pull every reached memo
+     (turning lazy into eager for that one write); deferred until a use case demands it.
+
+The per-context `EnterEvaluationScope`/`ExitEvaluationScope` refcount is the model for the
+transition's internal counter; the counter's zero-crossing publishes `Pending` via a detached
+runtime flow.
+
+### B. `Reaction.IsPending` — the per-reaction pending indicator
+
+The finest-grained, cheapest primitive, and the one Blazor/WPF bindings will actually use:
+
+```csharp
+var save = f.BuildReaction().CreateReaction(m1, v => viewModel.Value = v);
+save.IsPending   // IStateGetR<bool>: true from "a Stale scheduled an update"
+                 // until "that update committed clean"
+```
+
+Protocol: an `int pendingCount` on `ReactionBase`, incremented in `Stale` when an update is
+scheduled, decremented on the superseded-early-return path of `RunDebouncedUpdateAsync` and
+on clean commit. The boolean projection `count > 0` is published on zero-crossings through a
+detached flow into an internal leaf signal. Supersession storms therefore keep
+`IsPending == true` continuously (correct: work *is* in flight) instead of flickering.
+
+Because `IsPending` is itself a graph node, "show a progress bar while revalidating, keep the
+current view" is just another reaction — Solid's `isPending`-preserves-the-DOM behavior falls
+out of the composition rather than needing framework support.
+
+A convenience `f.CreatePendingIndicator(params ...)` OR-ing several nodes' pending states can
+be layered later; it needs the same internal stabilization notification and adds no new
+semantics.
+
+### C. Optimistic state: overlay composition, structural rollback
+
+The optimistic primitive is deliberately **not** a new node type in the propagation core. It
+is a composition of existing primitives, chosen so that rollback is *structural* (remove an
+overlay) instead of *compensating* (write the old value back) — a compensating write races
+concurrent writers and can resurrect stale state; removing an overlay cannot.
+
+```csharp
+// base: the confirmed truth — a Signal<T>, or a memo over a fetch
+var todos     = f.CreateSignal(ImmutableList<Todo>.Empty);
+
+// optimistic view = base + pending patches, in one node
+var optimistic = f.CreateOptimistic(todos);        // IStateGetR<ImmutableList<Todo>>
+
+var addTodo = f.CreateAction<Todo>(async (todo, action) =>
+{
+    action.Apply(optimistic, list => list.Add(todo with { Pending = true })); // instant projection
+    var confirmed = await api.SaveAsync(todo, action.Token);                  // the process step
+    await action.Confirm(todos, list => list.Add(confirmed));                 // commit + drop patch
+});                                                                            // fault/cancel ⇒ patch removed ⇒ automatic rollback
+
+await addTodo.Run(newTodo);      // returns the action's Transition
+addTodo.IsPending                // pending indicator for free (it IS a transition)
+```
+
+**Internals:**
+
+- `CreateOptimistic(base)` creates an internal `Signal<ImmutableList<Patch<T>>>` (the
+  overlay) plus a `MemoizR<T>` computing `Apply(await base.Get(), await overlay.Get())`.
+  Everything — instant projection, propagation, memoization, evidence — is the existing
+  machinery; strict mode's Sendable checking covers patch payloads unchanged.
+- `CreateAction` wraps the body in a **structured-concurrency job** (cancellation token,
+  resource group — this is MemoizR's analog of Solid's generator actions) and a
+  **transition** (part A). Its guarantees:
+  - *Apply* pushes a keyed patch onto the overlay signal — one ordinary `Set`.
+  - *Confirm* writes the confirmed value to the base **and removes the patch**. The two
+    `Set`s land within one debounce window, so reactions coalesce them into a single update
+    and never render the intermediate frame; direct concurrent `Get`s can observe it, which
+    is acceptable for UI state and honestly stamped (each publication carries its own
+    causality evidence). A later `WriteBatch` API (one exclusive acquisition, one combined
+    propagation) can make the pair atomic for non-UI consumers — explicitly out of scope
+    here.
+  - *Rollback* is the `catch`/cancellation path: remove the patch, nothing else. The base
+    was never touched, so there is nothing to compensate. Overlapping actions compose: each
+    owns its patch; a failed action's rollback cannot disturb a concurrent action's
+    projection.
+- **Refresh/reconcile** for memo-backed bases needs one small core addition: a public
+  `Invalidate()` on `MemoBase<T>` (force `CacheDirty` + propagate `Stale`, modeled on
+  `Signal.Set`'s locking) — the analog of Solid's `refresh(todos)`. This is independently
+  useful (cache-expiry, server-push invalidation) and is the only change the propagation
+  core needs for part C.
+
+The causality stamps (issue #39) tie in naturally: a patch can capture the base stamp it was
+projected against, which a distributed reconciler can later use to detect that the server
+truth moved under an optimistic projection. Not in scope here, but the overlay design keeps
+that door open where a compensating-write design would close it.
+
+### D. Blazor and WPF integration
+
+**New package `MemoizR.Blazor`** (mirroring `MemoizR.Wpf`'s size and shape):
+
+- `BlazorDispatcherExecutor : IExecutor` — the exact mirror of `WpfDispatcherExecutor`:
+  `Enqueue → Dispatcher.InvokeAsync`, `IsCurrent → Dispatcher.CheckAccess()`. Reaction
+  dependency evaluation stays on the thread pool; only the action (typically
+  `StateHasChanged`) runs on the renderer's dispatcher — the #13 contract, unchanged.
+- `services.AddMemoizR()` — a **scoped** `MemoFactory` per circuit (Blazor Server) /
+  per app (WASM). Blazor Server circuits are genuinely multi-threaded, which is exactly
+  where MemoizR's cross-flow correctness (generation guards, tear-free boxes) pays off over
+  single-threaded signal ports.
+- `MemoizRComponentBase` (or a standalone `ReactionBinder` for people who cannot change base
+  class): `Bind(memo, v => field = v)` builds a `Reaction` via the existing
+  `ReactionBuilder.CreateReaction(dep, action)` overloads whose action stores the value and
+  calls `InvokeAsync(StateHasChanged)`; all binders are disposed with the component
+  (prerender-then-dispose safe). Because `BuildRenderTree` is synchronous, markup reads the
+  binder's cached snapshot — including cached `IsPending`/`Transition.IsPending` booleans:
+
+  ```razor
+  <button disabled="@addTodo.IsPendingSnapshot" @onclick="() => addTodo.Run(newTodo)">Add</button>
+  @foreach (var todo in _todos) { ... }   @* optimistic view, pending items styled muted *@
+  ```
+
+**WPF** gets parts A–C for free through the existing executor seam. One optional addition:
+`BindableValue<T>` — an `INotifyPropertyChanged` wrapper backed by a reaction — so optimistic
+views and pending flags bind directly in XAML without hand-written reactions.
+
+## Implementation plan
+
+Phases are ordered so each ships alone and each unlocks the next; nothing lands in the
+propagation core without a Coyote story.
+
+| Phase | Deliverable | Key touch points | Tests |
+|---|---|---|---|
+| **1. Core instrumentation** | Internal *stabilization notification* (the missing "committed clean" half of the observer protocol, internal-only); `MemoBase<T>.Invalidate()`; ambient transition tagging (`AsyncLocal`, `RaceBranchFlow` pattern) | `CacheStateCell`, `SignalHandlR.CommitCleanOrRenotifyAsync`, `MemoBase`, `Context` | Coyote interleavings for notify-vs-invalidate races; `Invalidate()` storm tests alongside `StormTests` |
+| **2. Transitions + `IsPending`** (`MemoizR.Reactive`) | `Transition` (`IsPending`/`Pending`/`Settled`/`Exception`), `MemoFactory.BeginTransition()`, `ReactionBase.pendingCount` + `Reaction.IsPending` | `ReactionBase.Stale`, `RunDebouncedUpdateAsync`, `UpdateIfNecessary` commit sites | `FakeTimeProvider` debounce tests (supersession keeps pending true; zero-crossing publishes once); fault/dispose/pause edge cases; Coyote on the counter |
+| **3. Optimistic state** | `CreateOptimistic`, `Patch` overlay, `CreateAction` (structured job + transition + rollback) | New files in `MemoizR.Reactive` (or a new `MemoizR.Optimistic`); no core changes beyond phase 1 | Lifecycle table from the Solid PDF as a test matrix: initial → apply → in-flight → confirm → rollback; overlapping actions; cancellation; strict-mode Sendable patches |
+| **4. UI packages** | `MemoizR.Blazor` (executor, DI, `MemoizRComponentBase`), optimistic-todo sample (Server + WASM); WPF sample update, optional `BindableValue<T>` | New project; mirrors `MemoizR.Wpf` | bUnit component tests (render coalescing, dispose-during-prerender, `IsPending` snapshot flips); manual sample validation |
+| **5. Hardening & docs** | README section, architecture doc chapter, analyzer follow-ups (e.g. flag non-pure patch functions, `Set` outside actions on optimistic bases), `WriteBatch` decision | `MemoizR.Analyzers`, docs | Analyzer golden tests |
+
+Suggested spike order inside phase 1: stabilization notification first — it is the one
+mechanism parts A, B, and a future `CreatePendingIndicator` all stand on, and the one with
+real concurrency risk (it must fire outside the locks it is called under, on the detached
+runtime flow, without reordering against a newer invalidation).
+
+## Consequences
+
+- The propagation core stays untouched except for two additive, independently useful
+  mechanisms (stabilization notification, `Invalidate()`); everything UI-facing composes on
+  top. The actor engine (ADR 0006) can adopt the same notification in a later pass —
+  transitions/optimism are lock-engine-first, like every other feature.
+- Pending semantics are honest about laziness: they describe reactions and transitions, and
+  the docs must say so (a lazy memo nobody observes is never "pending").
+- Optimistic rollback is correct by construction (overlay removal), at the cost of one extra
+  node + one list signal per optimistic view — negligible against the recompute it fronts.
+- The debounce window doubles as the write-batching mechanism; the `WriteBatch` question is
+  deferred, not decided.
+
+## Alternatives considered
+
+- **Boolean pending flag flipped in place** — rejected: detached publications reorder; a
+  counter with zero-crossing publication is race-free by construction.
+- **Compensating-write rollback** (snapshot old value, `Set` it back on failure) — rejected:
+  races concurrent writers, resurrects stale state, and cannot compose across overlapping
+  actions. Overlay removal has none of these failure modes.
+- **A `PendingSignal` node type inside the core** — rejected: it would push UI semantics into
+  the propagation engine and require `Set`-under-evaluation, which the lock architecture
+  forbids for good reasons (ADR 0002).
+- **Auto-tracking Blazor renders** (dependency capture inside `BuildRenderTree`) — deferred:
+  renders are synchronous, MemoizR reads are async; the snapshot-binder pattern covers the
+  need without a sync-read escape hatch into the graph.

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -139,8 +139,8 @@ overlay) instead of *compensating* (write the old value back) — a compensating
 concurrent writers and can resurrect stale state; removing an overlay cannot.
 
 ```csharp
-// base: the confirmed truth — a Signal<T>, or a memo over a fetch
-var todos     = f.CreateSignal(ImmutableList<Todo>.Empty);
+// base: the confirmed truth — an atomically updatable source, or a memo over a fetch
+var todos     = f.CreateEagerRelativeSignal(ImmutableList<Todo>.Empty);
 
 // optimistic view = base + pending patches, in one node
 var optimistic = f.CreateOptimistic<ImmutableList<Todo>>(todos);
@@ -149,7 +149,7 @@ var addTodo = f.CreateAction<Todo>(async (todo, ctx) =>
 {
     await ctx.Apply(optimistic, list => list.Add(todo with { Pending = true })); // instant projection
     var confirmed = await api.SaveAsync(todo, ctx.Token);                        // the process step
-    await todos.Set((await todos.Get()).Add(confirmed));                         // confirm the source
+    await todos.Set(list => list.Add(confirmed));  // confirm atomically: overlapping runs compose
 });                       // run end drops the patches: on fault/cancel that IS the rollback
 
 var run = addTodo.Run(newTodo);  // detached; run.Completion is the body, run.Settled the effects

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ capture a significant decision, its context, and its consequences.
 | [0004](0004-compile-time-data-race-diagnostics.md) | Compile-time data-race diagnostics: the MemoizR.Analyzers rule set | Accepted |
 | [0005](0005-custom-executors.md) | Custom executors for reactive side effects | Accepted |
 | [0006](0006-actor-engine-prototype.md) | The actor-engine prototype: GraphActor turns instead of locks | Accepted (experimental) |
+| [0007](0007-transitions-pending-and-optimistic-state.md) | Transitions, `IsPending`, and optimistic state with automatic rollback | Proposed |
 
 New ADRs are numbered sequentially (`NNNN-title.md`).
 


### PR DESCRIPTION
## Summary

Implements ADR 0007 — a Solid 2.0-style process layer for MemoizR, re-derived for pull-based lazy evaluation and true multi-threaded concurrency. Adds transitions (write wavefront tracking), reactive pending indicators, and optimistic state with automatic structural rollback.

## Key Changes

### Core Transition & Pending Infrastructure
- **Transition.cs**: New `Transition` class tracking write wavefronts until all invalidated reactions commit clean. Provides `IsPending` snapshot, reactive `Pending` signal, and `Settled` task for awaiting completion.
- **PendingPublisher.cs**: Shared pending-flag publisher for reactions, transitions, and actions. Publishes on detached flows to avoid re-entrance, converges reactively onto caller-owned snapshots.
- **StabilizationListener.cs**: Internal observer protocol for "committed Clean" events — the edge transitions anchor to. Separate from IMemoizR observers to keep listeners as pure telemetry.

### Optimistic State & Actions
- **OptimisticState.cs**: Overlay view over a source of truth. Applies in-flight patches on reads; rollback is structural (patches simply removed on failure), so overlapping actions compose safely.
- **ReactiveAction.cs**: Process-layer write primitive. Runs on detached flow tagged with its own transition; projects optimistic patches, runs the real process, and automatically rolls back on fault/cancellation.

### Graph Integration
- **MemoHandlR.cs**: Added stabilization listener registration/removal and `NotifyStabilizationClean()` callback after successful Clean commits.
- **MemoBase.cs**: Added `Invalidate()` refresh primitive and `TryCommitCleanAndNotify()` to trigger stabilization callbacks.
- **ReactionBase.cs**: Integrated `IsPending` reactive signal, pending publisher, and stabilization release on disposal. Calls `TryCommitCleanAndNotify()` after update commits.
- **CacheStateCell.cs**: Modified `Invalidate()` to return the post-bump generation threshold for wavefront membership checks.
- **ReactiveMemoFactory.cs**: Added `BeginTransition()`, `CreateOptimistic<T>()`, and `CreateAction<TPayload>()` factory methods.

### Blazor Integration (Phase 4)
- **MemoizR.Blazor** (new package): Thread-pool reactivity with renderer-context reactions.
  - **BlazorMemoFactory.cs**: Routes reaction actions to Blazor dispatcher.
  - **ReactionBinder.cs**: Binds graph nodes to UI surfaces; dependency evaluation on thread pool, apply+notify marshalled through dispatcher.
  - **MemoizRComponentBase.cs**: Component base for MemoizR-driven Blazor UIs.
  - **ServiceCollectionExtensions.cs**: DI registration for scoped MemoFactory.

### Testing
- **StabilizationAndInvalidateTests.cs** (Phase 1): Pins `Invalidate()` and stabilization notification contracts.
- **TransitionTests.cs** (Phase 2): Transition scopes, settlement, per-reaction pending flags, wavefront tracking through derived memos.
- **OptimisticTests.cs** (Phase 3): Optimistic projection, confirmation, rollback on fault/cancellation, overlapping actions.
- **BlazorIntegrationTests.cs** (Phase 4): Dispatcher routing, ReactionBinder apply/notify marshalling.
- **CoyoteTests.cs**: Added systematic exploration of `Invalidate()` racing Gets.

### Documentation
- **docs/adr/0007-transitions-pending-and-optimistic-state.md**: Full ADR with context, design rationale, and implementation details.
- **README.md**: Updated with transitions, pending indicators, and optimistic state examples.
- **docs/adr/README.md**: Added ADR 0007 to the index.
- **NUGET_BLAZOR_README.md**: Blazor package documentation.

## Implementation Details

- **Ambient tagging via AsyncLocal**: `TransitionFlow.Current` tags the writing flow; invalidation cascades inherit the tag

https://claude.ai/code/session_019FcJVUrrWsXMKY5TqUnYeM