### PR TITLE
Re-pin the Coyote feed to merged coyote main (1.8.0-net10.2)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,7 +57,7 @@ jobs:
         # assemblies and control System.Threading.Lock. No --add-source here: NuGet
         # rejects it when nuget.config declares package source mapping, and the mapping
         # already routes Microsoft.Coyote* to the local packages/coyote feed.
-        dotnet tool install --global Microsoft.Coyote.CLI --version 1.8.0-net10.1
+        dotnet tool install --global Microsoft.Coyote.CLI --version 1.8.0-net10.2
         echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
     - name: Coyote Rewrite
       run: |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Coyote.Actors" Version="1.8.0-net10.1" />
-    <PackageVersion Include="Microsoft.Coyote.Core" Version="1.8.0-net10.1" />
-    <PackageVersion Include="Microsoft.Coyote.Test" Version="1.8.0-net10.1" />
+    <PackageVersion Include="Microsoft.Coyote.Actors" Version="1.8.0-net10.2" />
+    <PackageVersion Include="Microsoft.Coyote.Core" Version="1.8.0-net10.2" />
+    <PackageVersion Include="Microsoft.Coyote.Test" Version="1.8.0-net10.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />

--- a/docs/Coyote.md
+++ b/docs/Coyote.md
@@ -39,7 +39,7 @@ The whole suite runs against normal assemblies; the systematic tests skip themse
 ### 1. Install the Coyote CLI (once)
 
 ```bash
-dotnet tool install --global Microsoft.Coyote.CLI --version 1.8.0-net10.1
+dotnet tool install --global Microsoft.Coyote.CLI --version 1.8.0-net10.2
 ```
 
 Run this from the repository root: the version comes from the local feed bootstrapped in

--- a/eng/build-coyote-packages.sh
+++ b/eng/build-coyote-packages.sh
@@ -9,9 +9,9 @@
 set -euo pipefail
 
 COYOTE_REPO="https://github.com/timonkrebs/coyote"
-COYOTE_COMMIT="7143589c54b1310d0fde0cb7dca208875a79df69"
+COYOTE_COMMIT="f00c3ce6b4235292d7c159bf0883980f1a2bfd10"
 COYOTE_VERSION_PREFIX="1.8.0"
-COYOTE_VERSION_SUFFIX="net10.1"
+COYOTE_VERSION_SUFFIX="net10.2"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FEED_DIR="$REPO_ROOT/packages/coyote"


### PR DESCRIPTION
Follow-up to #153, as announced there: timonkrebs/coyote#6 is merged, so the pack script now pins the merge commit on coyote main (`f00c3ce`) instead of a commit that lived on the (since deleted) PR branch.

## What changes

- `eng/build-coyote-packages.sh`: `COYOTE_COMMIT` → `f00c3ce` (coyote main), `COYOTE_VERSION_SUFFIX` → `net10.2`.
- `Directory.Packages.props`, workflow CLI install, `docs/Coyote.md`: `1.8.0-net10.1` → `1.8.0-net10.2`. The version bump matters: the package *content* changes with the new pin, so reusing the old version string could let a NuGet cache serve stale bits.

## Why the new pin is worth taking

The merged coyote main includes the review-hardened Lock model: it keys its synchronization on per-instance surrogates, so a modeled `System.Threading.Lock` and a `Monitor` lock on the same instance stay independent, exactly as at runtime — one less way for the systematic tests to falsely serialize.

(The old pin `7143589` stays permanently fetchable — coyote #6 merged with a merge commit — so main is not broken either way; this is provenance hygiene plus the model improvement.)

## Verified locally with a pristine package cache

Feed packs from the new pin, restore, build, 410 regular tests, CLI install at `1.8.0-net10.2`, rewrite of all five assemblies, and all 3 systematic Coyote tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b8vRgNLY6DH7AE5cx3YMp

---
_Generated by [Claude Code](https://claude.ai/code/session_011b8vRgNLY6DH7AE5cx3YMp)_