### PR TITLE
Add the optimistic-todo Blazor sample with bUnit component tests (ADR 0007 phase 4)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />

--- a/MemoizR.slnx
+++ b/MemoizR.slnx
@@ -6,6 +6,8 @@
   </Configurations>
   <Folder Name="/samples/">
     <Project Path="samples/DistributedGraphSample/DistributedGraphSample.csproj" />
+    <Project Path="samples/OptimisticTodoSample.Tests/OptimisticTodoSample.Tests.csproj" />
+    <Project Path="samples/OptimisticTodoSample/OptimisticTodoSample.csproj" />
   </Folder>
   <Project Path="MemoizR.Analyzers.Tests/MemoizR.Analyzers.Tests.csproj" />
   <Project Path="MemoizR.Analyzers/MemoizR.Analyzers.csproj" />

--- a/README.md
+++ b/README.md
@@ -282,7 +282,10 @@ protected override void OnInitialized()
 ```
 
 Reactions owned by services rather than components can target a renderer dispatcher directly
-with `f.AddBlazorDispatcher(dispatcher)`.
+with `f.AddBlazorDispatcher(dispatcher)`. A runnable end-to-end demo — optimistic todo list
+with instant projection, a pending-driven submit button, and live rollback on server rejection
+— lives in [samples/OptimisticTodoSample](samples/OptimisticTodoSample), with bUnit component
+tests covering the whole lifecycle.
 
 ### WPF / UI threads
 

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -1,7 +1,7 @@
 # ADR 0007 — Transitions, `IsPending`, and optimistic state with automatic rollback
 
-- Status: Proposed (phases 1–4 implemented on this branch — phase 4 without the sample app and
-  bUnit component tests; phase 5 open)
+- Status: Proposed (phases 1–4 implemented, including the optimistic-todo sample app with bUnit
+  component tests; phase 5 open)
 - Date: 2026-07-15
 - Deciders: MemoizR maintainers
 - Inspiration: Solid 2.0's async architecture (deferred stabilization, `isPending`,
@@ -280,7 +280,11 @@ Where the landed code deliberately deviates from the sketches above:
   `MemoizRComponentBase` gluing it to components, and `services.AddMemoizR()` for the
   scoped-per-circuit factory. Integration-tested against `Dispatcher.CreateDefault()` — the
   renderer dispatcher Blazor Server uses — so the thread-pool/renderer split is pinned without
-  a renderer; the optimistic-todo sample app and bUnit component tests remain open.
+  a renderer. The optimistic-todo sample app (`samples/OptimisticTodoSample`, Blazor Server)
+  demonstrates the whole stack — instant projection, pending-driven button, structural
+  rollback on rejection — and its bUnit tests (`samples/OptimisticTodoSample.Tests`) replay
+  the PDF's transition lifecycle table through Blazor's real test renderer against a gated
+  fake server, including the overlapping-actions case.
 
 ## Consequences
 

--- a/samples/OptimisticTodoSample.Tests/GatedTodoApi.cs
+++ b/samples/OptimisticTodoSample.Tests/GatedTodoApi.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using OptimisticTodoSample.Services;
+
+namespace OptimisticTodoSample.Tests;
+
+// The deterministic "server": every save parks on a gate keyed by its text until the test
+// confirms or rejects it, so the optimistic window is provably open at the assertion points.
+// Keyed, not queued: overlapping action bodies run concurrently, so arrival order is NOT
+// submission order -- and Confirm/Reject WAIT for the save to arrive, because a body applies
+// its optimistic patch (which the test observes) before it reaches the server.
+internal sealed class GatedTodoApi : ITodoApi
+{
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<string>> pending = new();
+
+    public Task<string> SaveAsync(string text, CancellationToken token)
+    {
+        var gate = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        pending[text] = gate;
+        return gate.Task;
+    }
+
+    public async Task Confirm(string text)
+    {
+        (await TakeAsync(text)).SetResult(text);
+    }
+
+    public async Task Reject(string text, string message)
+    {
+        (await TakeAsync(text)).SetException(new InvalidOperationException(message));
+    }
+
+    private async Task<TaskCompletionSource<string>> TakeAsync(string text)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            if (pending.TryRemove(text, out var gate))
+            {
+                return gate;
+            }
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"no save for \"{text}\" arrived at the server");
+    }
+}

--- a/samples/OptimisticTodoSample.Tests/OptimisticTodoSample.Tests.csproj
+++ b/samples/OptimisticTodoSample.Tests/OptimisticTodoSample.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OptimisticTodoSample\OptimisticTodoSample.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OptimisticTodoSample.Tests/TodoListTests.cs
+++ b/samples/OptimisticTodoSample.Tests/TodoListTests.cs
@@ -1,0 +1,107 @@
+using Bunit;
+using MemoizR;
+using Microsoft.Extensions.DependencyInjection;
+using OptimisticTodoSample.Components;
+using OptimisticTodoSample.Services;
+
+namespace OptimisticTodoSample.Tests;
+
+// The bUnit half of ADR 0007 phase 4: the optimistic-todo component driven through Blazor's
+// test renderer, against a gated fake server so every optimistic window is deterministic.
+// The assertions are Solid 2.0's transition lifecycle table, observed through rendered markup.
+public class TodoListTests : BunitContext
+{
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly GatedTodoApi api = new();
+
+    public TodoListTests()
+    {
+        Services.AddMemoizR();
+        Services.AddScoped<ITodoApi>(_ => api);
+        Services.AddScoped<TodoState>();
+    }
+
+    private IRenderedComponent<TodoList> RenderTodoList() => Render<TodoList>();
+
+    // Find-and-trigger runs as ONE dispatch on the renderer's context: the reactive bindings
+    // re-render from background flows, so an element found outside it can go stale before the
+    // event fires (bUnit's UnknownEventHandlerIdException).
+    private static Task Submit(IRenderedComponent<TodoList> cut, string text)
+    {
+        return cut.InvokeAsync(() =>
+        {
+            cut.Find("input").Input(text);
+            cut.Find("form").Submit();
+        });
+    }
+
+    [Fact]
+    public async Task Add_ProjectsOptimistically_DisablesTheButton_ThenConfirms()
+    {
+        var cut = RenderTodoList();
+
+        await Submit(cut, "write docs");
+
+        // 2. Action triggered: the todo renders instantly, muted, while the server is still
+        //    deciding; the action's reactive IsPending flag disables the button.
+        cut.WaitForAssertion(() =>
+        {
+            var item = cut.Find("li");
+            Assert.Contains("write docs", item.TextContent);
+            Assert.Contains("pending", item.ClassList);
+            Assert.True(cut.Find("button").HasAttribute("disabled"));
+        }, WaitTimeout);
+
+        // 4. Server commit: the confirmed item replaces the projection, the button re-enables.
+        await api.Confirm("write docs");
+        cut.WaitForAssertion(() =>
+        {
+            var items = cut.FindAll("li");
+            var item = Assert.Single(items);
+            Assert.Contains("write docs", item.TextContent);
+            Assert.Contains("settled", item.ClassList);
+            Assert.False(cut.Find("button").HasAttribute("disabled"));
+        }, WaitTimeout);
+    }
+
+    [Fact]
+    public async Task Add_RollsBackAndShowsTheError_WhenTheServerRejects()
+    {
+        var cut = RenderTodoList();
+
+        await Submit(cut, "deploy on friday");
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll("li")), WaitTimeout);
+
+        // 5. Rollback: the projection vanishes -- no manual recovery in the component beyond
+        //    showing the error the run's Completion carried.
+        await api.Reject("deploy on friday", "deploys are for mondays");
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Empty(cut.FindAll("li"));
+            Assert.Contains("deploys are for mondays", cut.Find(".error").TextContent);
+            Assert.False(cut.Find("button").HasAttribute("disabled"));
+        }, WaitTimeout);
+    }
+
+    [Fact]
+    public async Task OverlappingAdds_RollBackOnlyTheRejectedProjection()
+    {
+        var cut = RenderTodoList();
+
+        await Submit(cut, "first");
+        await Submit(cut, "second");
+        cut.WaitForAssertion(() => Assert.Equal(2, cut.FindAll("li").Count), WaitTimeout);
+
+        // The first save fails, the second succeeds: structural rollback removes only the
+        // rejected run's patch -- the surviving projection and its confirmation are untouched.
+        await api.Reject("first", "rejected");
+        await api.Confirm("second");
+        cut.WaitForAssertion(() =>
+        {
+            var item = Assert.Single(cut.FindAll("li"));
+            Assert.Contains("second", item.TextContent);
+            Assert.Contains("settled", item.ClassList);
+        }, WaitTimeout);
+    }
+}

--- a/samples/OptimisticTodoSample.Tests/Usings.cs
+++ b/samples/OptimisticTodoSample.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/samples/OptimisticTodoSample/Components/App.razor
+++ b/samples/OptimisticTodoSample/Components/App.razor
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link rel="stylesheet" href="app.css" />
+    <title>MemoizR optimistic todos</title>
+    <HeadOutlet @rendermode="InteractiveServer" />
+</head>
+
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src="_framework/blazor.web.js"></script>
+</body>
+
+</html>

--- a/samples/OptimisticTodoSample/Components/Pages/Home.razor
+++ b/samples/OptimisticTodoSample/Components/Pages/Home.razor
@@ -1,0 +1,13 @@
+@page "/"
+
+<main>
+    <h1>MemoizR optimistic todos</h1>
+    <p>
+        The list below is an <strong>optimistic view</strong> (ADR 0007): adding a todo projects
+        it instantly while the "server" (1.5&#160;s latency) decides. Include the word
+        <code>fail</code> and the server rejects it &mdash; the projection rolls back
+        structurally, the source of truth untouched. The button is driven by the action's
+        reactive <code>IsPending</code> flag.
+    </p>
+    <TodoList />
+</main>

--- a/samples/OptimisticTodoSample/Components/Routes.razor
+++ b/samples/OptimisticTodoSample/Components/Routes.razor
@@ -1,0 +1,5 @@
+<Router AppAssembly="typeof(Routes).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" />
+    </Found>
+</Router>

--- a/samples/OptimisticTodoSample/Components/TodoList.razor
+++ b/samples/OptimisticTodoSample/Components/TodoList.razor
@@ -1,0 +1,72 @@
+@inherits MemoizR.MemoizRComponentBase
+@inject TodoState State
+
+<div class="todo-container">
+    <form @onsubmit="Add">
+        <input placeholder="What needs doing? (include 'fail' to watch the rollback)"
+               @bind="draft" @bind:event="oninput" />
+        <button type="submit" disabled="@addPending">
+            @(addPending ? "Saving…" : "Add")
+        </button>
+    </form>
+
+    @if (error is not null)
+    {
+        <p class="error" role="alert">@error</p>
+    }
+
+    <ul>
+        @foreach (var todo in todos)
+        {
+            <li class="@(todo.Pending ? "pending" : "settled")">@todo.Text</li>
+        }
+    </ul>
+</div>
+
+@code {
+    // The render snapshot: renders are synchronous, the graph is async, so the bindings below
+    // project the nodes into these fields on the renderer's context and re-render on change.
+    private ImmutableList<TodoItem> todos = ImmutableList<TodoItem>.Empty;
+    private bool addPending;
+    private string draft = "";
+    private string? error;
+
+    protected override void OnInitialized()
+    {
+        Bind(State.Todos, value => todos = value);
+        Bind(State.AddTodo.IsPending, pending => addPending = pending);
+    }
+
+    private void Add()
+    {
+        var text = draft.Trim();
+        if (text.Length == 0)
+        {
+            return;
+        }
+        draft = "";
+        error = null;
+
+        // Fire the process-layer action; the optimistic projection appears via the Todos
+        // binding immediately, so the handler itself has nothing to render.
+        _ = ObserveAsync(State.AddTodo.Run(text), text);
+    }
+
+    // The run's Completion carries the body's outcome; the rollback has already happened by
+    // the time it faults, so the only UI concern left is telling the user.
+    private async Task ObserveAsync(MemoizR.Reactive.ActionRun run, string text)
+    {
+        try
+        {
+            await run.Completion;
+        }
+        catch (Exception ex)
+        {
+            await InvokeAsync(() =>
+            {
+                error = $"\"{text}\" was not saved: {ex.Message}";
+                StateHasChanged();
+            });
+        }
+    }
+}

--- a/samples/OptimisticTodoSample/Components/_Imports.razor
+++ b/samples/OptimisticTodoSample/Components/_Imports.razor
@@ -1,0 +1,6 @@
+@using System.Collections.Immutable
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using OptimisticTodoSample.Components
+@using OptimisticTodoSample.Services

--- a/samples/OptimisticTodoSample/OptimisticTodoSample.csproj
+++ b/samples/OptimisticTodoSample/OptimisticTodoSample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MemoizR.Blazor\MemoizR.Blazor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OptimisticTodoSample/Program.cs
+++ b/samples/OptimisticTodoSample/Program.cs
@@ -1,0 +1,20 @@
+using MemoizR;
+using OptimisticTodoSample.Components;
+using OptimisticTodoSample.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents().AddInteractiveServerComponents();
+
+// One reactive graph per circuit; the sample's state and backend hang off the same scope.
+builder.Services.AddMemoizR();
+builder.Services.AddScoped<ITodoApi, FlakyTodoApi>();
+builder.Services.AddScoped<TodoState>();
+
+var app = builder.Build();
+
+app.UseStaticFiles();
+app.UseAntiforgery();
+app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
+
+app.Run();

--- a/samples/OptimisticTodoSample/Services/ITodoApi.cs
+++ b/samples/OptimisticTodoSample/Services/ITodoApi.cs
@@ -1,0 +1,24 @@
+namespace OptimisticTodoSample.Services;
+
+/// <summary>The "server". Returns the confirmed text, or throws to reject the todo.</summary>
+public interface ITodoApi
+{
+    Task<string> SaveAsync(string text, CancellationToken token);
+}
+
+/// <summary>
+/// The sample backend: slow enough that the optimistic projection is visible, and it rejects
+/// any todo containing "fail" so the automatic rollback can be watched live.
+/// </summary>
+public sealed class FlakyTodoApi : ITodoApi
+{
+    public async Task<string> SaveAsync(string text, CancellationToken token)
+    {
+        await Task.Delay(TimeSpan.FromMilliseconds(1500), token);
+        if (text.Contains("fail", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("the server rejected this todo");
+        }
+        return text;
+    }
+}

--- a/samples/OptimisticTodoSample/Services/TodoItem.cs
+++ b/samples/OptimisticTodoSample/Services/TodoItem.cs
@@ -1,0 +1,5 @@
+namespace OptimisticTodoSample.Services;
+
+/// <summary>One todo row. <see cref="Pending"/> marks an optimistic projection that the
+/// server has not confirmed yet; the UI renders it muted.</summary>
+public sealed record TodoItem(string Text, bool Pending);

--- a/samples/OptimisticTodoSample/Services/TodoState.cs
+++ b/samples/OptimisticTodoSample/Services/TodoState.cs
@@ -1,0 +1,40 @@
+using System.Collections.Immutable;
+using MemoizR;
+using MemoizR.Reactive;
+
+namespace OptimisticTodoSample.Services;
+
+/// <summary>
+/// The reactive graph behind the todo UI (ADR 0007), one instance per circuit. The source of
+/// truth is an atomically updatable list; <see cref="Todos"/> is its optimistic view (source +
+/// in-flight patches), and <see cref="AddTodo"/> is the process-layer action: it instantly
+/// projects the new todo as pending, saves it on the server, confirms atomically, and rolls
+/// back structurally when the server rejects -- no manual recovery anywhere.
+/// </summary>
+public sealed class TodoState
+{
+    private readonly EagerRelativeSignal<ImmutableList<TodoItem>> source;
+
+    public TodoState(MemoFactory memo, ITodoApi api)
+    {
+        source = memo.CreateEagerRelativeSignal(ImmutableList<TodoItem>.Empty);
+        Todos = memo.CreateOptimistic<ImmutableList<TodoItem>>(source, "Todos");
+        AddTodo = memo.CreateAction<string>(async (text, ctx) =>
+        {
+            // 1. Instant projection: the UI shows the todo (muted) before the network moves.
+            await ctx.Apply(Todos, list => list.Add(new TodoItem(text, Pending: true)));
+
+            // 2. The process step: the real save, cancellable via the run's token.
+            var confirmed = await api.SaveAsync(text, ctx.Token);
+
+            // 3. Confirm atomically: overlapping runs compose instead of clobbering. When the
+            //    run ends its patch is dropped; on a fault the drop IS the rollback and the
+            //    source was never touched.
+            await source.Set(list => list.Add(new TodoItem(confirmed, Pending: false)));
+        }, "AddTodo");
+    }
+
+    public OptimisticState<ImmutableList<TodoItem>> Todos { get; }
+
+    public ReactiveAction<string> AddTodo { get; }
+}

--- a/samples/OptimisticTodoSample/wwwroot/app.css
+++ b/samples/OptimisticTodoSample/wwwroot/app.css
@@ -1,0 +1,41 @@
+body {
+    font-family: system-ui, sans-serif;
+    max-width: 40rem;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    line-height: 1.5;
+}
+
+.todo-container form {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.todo-container input {
+    flex: 1;
+    padding: 0.4rem 0.6rem;
+}
+
+.todo-container button {
+    padding: 0.4rem 1rem;
+}
+
+.todo-container ul {
+    list-style: none;
+    padding: 0;
+}
+
+.todo-container li {
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid #ddd;
+}
+
+/* The optimistic projection: visible immediately, muted until the server confirms. */
+.todo-container li.pending {
+    opacity: 0.5;
+    font-style: italic;
+}
+
+.error {
+    color: #b00020;
+}


### PR DESCRIPTION
Completes ADR 0007 phase 4 (follow-up to #152): the runnable end-to-end demo of the process layer, plus the bUnit component tests that were left open.

## `samples/OptimisticTodoSample` — Blazor Server demo

A minimal app exercising the whole stack:

- **`TodoState`** (scoped per circuit): an `EagerRelativeSignal` source of truth behind a `CreateOptimistic` view, and an `AddTodo` action that projects the new todo instantly (muted "pending" styling), saves it against a deliberately slow fake server (1.5 s latency; todos containing `fail` are rejected), confirms with an **atomic relative update** (overlapping runs compose), and rolls back structurally on rejection.
- **`TodoList.razor`** inherits `MemoizRComponentBase`: `Bind(State.Todos, …)` and `Bind(State.AddTodo.IsPending, …)` project the graph into render-snapshot fields — the submit button is driven by the action's reactive pending flag, and rejection errors surface from `run.Completion`.

## `samples/OptimisticTodoSample.Tests` — bUnit tests

Three tests (bUnit 2.7.2 on the repo's xUnit v3 stack) replay the Solid 2.0 transition lifecycle table through Blazor's real test renderer against a **gated fake server**, so every optimistic window is deterministic:

1. optimistic projection renders instantly + button disabled → server confirm → settled item, button re-enabled
2. server rejection → projection rolls back, error surfaced, nothing else touched
3. overlapping adds → only the rejected run's projection rolls back; the surviving one confirms

Two test-infrastructure subtleties are baked in as comments: find+trigger pairs dispatch as one unit on the renderer's context (background reactive re-renders stale found elements otherwise), and the fake server's gates are keyed by text because concurrent action bodies do not reach the server in submission order.

## Housekeeping

- Both projects registered in `MemoizR.slnx` (samples folder) so CI builds the app and runs the bUnit tests; `bunit` added to `Directory.Packages.props`.
- ADR 0007 status + phase-4 implementation note updated; README's Blazor section links the sample.

## Verification

- Full solution suite green: 349 + 59 + 5 + 3 tests.
- The sample tests passed 8/8 consecutive runs after the determinism fixes.
- The app was booted and serves the prerendered todo component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FcJVUrrWsXMKY5TqUnYeM

---
_Generated by [Claude Code](https://claude.ai/code/session_019FcJVUrrWsXMKY5TqUnYeM)_