### PR TITLE
Add MZR004: optimistic patches must not capture non-Sendable state (ADR 0007 phase 5)

### DIFF
--- a/MemoizR.Analyzers.Tests/AnalyzerTestHarness.cs
+++ b/MemoizR.Analyzers.Tests/AnalyzerTestHarness.cs
@@ -22,14 +22,15 @@ internal static class AnalyzerTestHarness
         return [.. paths.Distinct().Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))];
     }
 
-    public static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source, DiagnosticAnalyzer analyzer)
+    // ConsoleApplication is for top-level-statement snippets, which cannot compile in a library.
+    public static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source, DiagnosticAnalyzer analyzer, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
     {
         var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
         var compilation = CSharpCompilation.Create(
             "AnalyzerTestSnippet",
             [tree],
             References.Value,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+            new CSharpCompilationOptions(outputKind, nullableContextOptions: NullableContextOptions.Enable));
 
         var compileErrors = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
         Assert.True(compileErrors.Count == 0, $"snippet does not compile: {string.Join("; ", compileErrors)}");

--- a/MemoizR.Analyzers.Tests/AnalyzerTestHarness.cs
+++ b/MemoizR.Analyzers.Tests/AnalyzerTestHarness.cs
@@ -23,12 +23,17 @@ internal static class AnalyzerTestHarness
     }
 
     // ConsoleApplication is for top-level-statement snippets, which cannot compile in a library.
-    public static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source, DiagnosticAnalyzer analyzer, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
+    public static Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source, DiagnosticAnalyzer analyzer, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
+        => AnalyzeAsync([source], analyzer, outputKind);
+
+    // Multiple sources compile as separate syntax trees: for pinning the same-tree-only
+    // resolution boundaries (a method group whose body lives in another file).
+    public static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string[] sources, DiagnosticAnalyzer analyzer, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
     {
-        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var trees = sources.Select(source => CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest))).ToArray();
         var compilation = CSharpCompilation.Create(
             "AnalyzerTestSnippet",
-            [tree],
+            trees,
             References.Value,
             new CSharpCompilationOptions(outputKind, nullableContextOptions: NullableContextOptions.Enable));
 

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -812,6 +812,39 @@ public class CapturedMutationAnalyzerTests
     }
 
     [Fact]
+    public async Task OtherReceiverHelper_StaticWriteIsFlagged_MemberWriteIsNot()
+    {
+        // The helper runs on another object, but the STATIC it writes races regardless of
+        // receiver; the write to that object's own member stays MZR001's territory.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+                private int instanceCount;
+
+                public void Touch()
+                {
+                    hits++;
+                    instanceCount++;
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var other = new C();
+                    f.CreateMemoizR(async () => { other.Touch(); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("static field 'hits'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task ExtensionMethodOnAnotherReceiver_IsNotChasedForMutation()
     {
         // The same extension on some OTHER object mutates that object's state -- a

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -1259,4 +1259,154 @@ public class CapturedMutationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task InvokedDelegateArgument_BindsTheInstance()
+    {
+        // The patch invokes a delegate handing it the enclosing instance: the delegate's own
+        // parameter IS that instance for the walked body, so the write is the same race.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    Action<C> step = c => c.Counter++;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { step(this); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SecondThisArgument_IsTracked()
+    {
+        // The instance is handed to two parameters and written through the second: every
+        // proven binding counts, not just the first.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                private static void Mutate(C first, C second) => second.Counter++;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () => { Mutate(this, this); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ReboundThisParameter_IsNotTheInstance()
+    {
+        // The helper rebinds the parameter to a fresh object before writing: that storage is
+        // recreated per replay and shared with nobody.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                private static void Mutate(C c)
+                {
+                    c = new C();
+                    c.Counter++;
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () => { Mutate(this); return 0; });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DisposeWritingItsOwnField_IsNotFlagged()
+    {
+        // The using resource's Dispose writes the resource's own storage, which is fresh per
+        // evaluation -- only statics and captures inside it are shared.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public sealed class Writer : IDisposable
+            {
+                public int mine;
+
+                public void Dispose() => mine++;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () =>
+                    {
+                        using var w = new Writer();
+                        return 0;
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task InvokedFactoryInitializedDelegate_MutationIsFlagged()
+    {
+        // The invoked local was initialized from a same-tree factory: the returned lambda is
+        // what replays, and its captured-local write races.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    Func<int, int> Make() => x => { applied++; return x; };
+                    Func<int, int> d = Make();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => d(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -1006,4 +1006,94 @@ public class CapturedMutationAnalyzerTests
         Assert.Equal("MZR002", diagnostic.Id);
         Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task InvokedCapturedDelegate_MutationIsFlagged()
+    {
+        // The patch synchronously invokes a captured delegate: its body runs on the
+        // computation's flows, so the captured-local write races like inline code.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    Func<int, int> d = x => { applied++; return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => d(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OverwrittenStaleInitializer_IsNotCharged()
+    {
+        // The mutating initializer is definitely overwritten before Apply: only the safe
+        // overwrite can be stored, so the stale write must not be charged to this call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = x => { applied++; return x; };
+                        patch = static x => x;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OverwrittenAliasSource_SurvivingMutationIsFlagged()
+    {
+        // The alias copies a source whose initializer is definitely overwritten: the
+        // surviving mutating write is what the overlay stores and replays.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> src = static x => x;
+                        src = x => { applied++; return x; };
+                        Func<int, int> patch = src;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -572,6 +572,29 @@ public class CapturedMutationAnalyzerTests
         Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
     }
 
+    // nameof(Next) is a compile-time string: the local function is neither invoked nor stored,
+    // so its body must not be chased.
+    [Fact]
+    public async Task NameofALocalHelper_DoesNotChaseIt()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var applied = 0;
+                    int Next() { applied++; return applied; }
+                    f.CreateMemoizR(async () => nameof(Next).Length);
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
     // A captured mutable STRUCT invoked through a non-readonly method mutates the hoisted
     // closure field on every re-execution -- covered by the mutating-value-receiver rule, the
     // lambda-capture analog of MZR004's boxed method-group receiver verdict.

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -945,4 +945,35 @@ public class CapturedMutationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task AssembledPatchMutation_IsFlagged()
+    {
+        // The patch assembled by the out-helper replays on the state's flows exactly like an
+        // inline patch: its write to the captured local is the same data race.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    void Provide(out Func<int, int> d) => d = x => { applied++; return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -726,6 +726,92 @@ public class CapturedMutationAnalyzerTests
     }
 
     [Fact]
+    public async Task ExtensionOnThis_AfterAnotherReceiver_IsStillFlagged()
+    {
+        // The earlier call on another object walks the same helper with no `this` binding:
+        // it must not poison the chase for the later call that DOES hand it the enclosing
+        // instance.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public static class CExtensions
+            {
+                public static void Inc(this C c) => c.Counter++;
+            }
+
+            public class C
+            {
+                public int Counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var otherObject = new C();
+                    f.CreateMemoizR(async () => { otherObject.Inc(); this.Inc(); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task MutatingGetter_ReadInComputation_IsFlagged()
+    {
+        // Reading the property runs its getter on every evaluation: the hidden `counter++`
+        // races exactly like the inline form.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;
+
+                private int P { get { counter++; return 0; } }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () => { return P; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task StaticHelperWithExplicitThisArgument_IsFlagged()
+    {
+        // `Mutate(this)` hands the enclosing instance to the parameter: the write through
+        // it mutates the enclosing object exactly like `this.Counter++`.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                private static void Mutate(C c) => c.Counter++;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () => { Mutate(this); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task ExtensionMethodOnAnotherReceiver_IsNotChasedForMutation()
     {
         // The same extension on some OTHER object mutates that object's state -- a

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -845,6 +845,79 @@ public class CapturedMutationAnalyzerTests
     }
 
     [Fact]
+    public async Task ForeignSetterHiddenStaticWrite_IsFlagged()
+    {
+        // The assignment target itself is a computation-local object, but the setter body
+        // still mutates a static on every recomputation.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Box
+            {
+                public static int hits;
+
+                public int Value
+                {
+                    get => 0;
+                    set { hits++; }
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () =>
+                    {
+                        var box = new Box();
+                        box.Value = 1;
+                        return 0;
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("static field 'hits'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ThisAliasInsideHelper_KeepsTheBinding()
+    {
+        // The helper stores the received instance in a local before handing it on: the
+        // alias resolves to the this-bound parameter, so the nested write is still the
+        // enclosing object's.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                private static void Mutate(C c) => c.Counter++;
+
+                private static void Wrapper(C c)
+                {
+                    var alias = c;
+                    Mutate(alias);
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () => { Wrapper(this); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task ExtensionMethodOnAnotherReceiver_IsNotChasedForMutation()
     {
         // The same extension on some OTHER object mutates that object's state -- a

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -976,4 +976,34 @@ public class CapturedMutationAnalyzerTests
         Assert.Equal("MZR002", diagnostic.Id);
         Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task SurvivingRebindPatch_MutationIsFlagged()
+    {
+        // The declaration initializer is definitely overwritten before Apply: the surviving
+        // write's lambda is the stored patch, and its captured-local write races on replay.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        patch = x => { applied++; return x; };
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -1196,4 +1196,67 @@ public class CapturedMutationAnalyzerTests
         Assert.Equal("MZR002", diagnostic.Id);
         Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task OutAssignedFactoryCall_MutationIsFlagged()
+    {
+        // The out helper binds its parameter to a factory call: the overlay stores the
+        // factory's returned lambda, whose captured-local write races on every replay.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    Func<int, int> Make() => x => { applied++; return x; };
+                    void Provide(out Func<int, int> d) => d = Make();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OverwrittenAutoPropertyInitializer_IsNotCharged()
+    {
+        // The auto-property initializer is definitely overwritten before Apply: the stale
+        // mutating lambda can never be the stored patch, whatever declaration shape held it.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int applied;
+
+                private static Func<int, int> Patch { get; set; } = x => { applied++; return x; };
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    Patch = static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -534,4 +534,77 @@ public class CapturedMutationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+
+    // The write hides behind a local function declared outside the computation: its closure is
+    // the computation's environment, so the chased `applied++` is the same data race as the
+    // inline form (and MZR004 cannot carry it -- the int is Sendable; the WRITE is the race).
+    // The helper's OWN local stays exempt: it is recreated per call.
+    [Fact]
+    public async Task OptimisticPatch_WriteHiddenInALocalHelper_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    int Next()
+                    {
+                        var tmp = 0;
+                        tmp++;
+                        applied++;
+                        return applied + tmp;
+                    }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Next());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
+
+    // A captured mutable STRUCT invoked through a non-readonly method mutates the hoisted
+    // closure field on every re-execution -- covered by the mutating-value-receiver rule, the
+    // lambda-capture analog of MZR004's boxed method-group receiver verdict.
+    [Fact]
+    public async Task OptimisticPatch_MutatingCapturedStructReceiver_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public struct Counter
+            {
+                private int count;
+
+                public int Next(int x) => x + count++;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var counter = new Counter();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => counter.Next(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'counter'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -595,6 +595,69 @@ public class CapturedMutationAnalyzerTests
         Assert.Empty(diagnostics);
     }
 
+    // A method invoked on THIS writes the enclosing object's state exactly like the inline
+    // form; a method on some OTHER receiver mutates that object instead -- a captured-
+    // reference mutation, deliberately MZR001's territory.
+    [Fact]
+    public async Task OptimisticPatch_WriteHiddenInAThisMethod_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;
+
+                private void Inc() => counter++;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { Inc(); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OptimisticPatch_HelperOnAnotherReceiver_IsNotChased()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Helper
+            {
+                private int count;
+
+                public void Inc() => count++;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var helper = new Helper();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { helper.Inc(); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
     // A captured mutable STRUCT invoked through a non-readonly method mutates the hoisted
     // closure field on every re-execution -- covered by the mutating-value-receiver rule, the
     // lambda-capture analog of MZR004's boxed method-group receiver verdict.

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -693,4 +693,64 @@ public class CapturedMutationAnalyzerTests
         Assert.Equal("MZR002", diagnostic.Id);
         Assert.Contains("captured local 'counter'", diagnostic.GetMessage());
     }
+
+    [Fact]
+    public async Task ExtensionMethodOnThis_MutatingEnclosingState_IsFlagged()
+    {
+        // `this.Inc()` runs the extension body with `this` bound to the receiver parameter:
+        // the write through that parameter mutates the enclosing object exactly like
+        // `this.Counter++` would, and the extension syntax must not hide it.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public static class CExtensions
+            {
+                public static void Inc(this C c) => c.Counter++;
+            }
+
+            public class C
+            {
+                public int Counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    f.CreateMemoizR(async () => { this.Inc(); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ExtensionMethodOnAnotherReceiver_IsNotChasedForMutation()
+    {
+        // The same extension on some OTHER object mutates that object's state -- a
+        // captured-reference mutation that is deliberately MZR001's territory, not MZR002's.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public static class CExtensions
+            {
+                public static void Inc(this C c) => c.Counter++;
+            }
+
+            public class C
+            {
+                public int Counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var otherObject = new C();
+                    f.CreateMemoizR(async () => { otherObject.Inc(); return 0; });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -1096,4 +1096,104 @@ public class CapturedMutationAnalyzerTests
         Assert.Equal("MZR002", diagnostic.Id);
         Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task HelperInvokedDelegate_MutationIsFlagged()
+    {
+        // The helper executes the delegate the patch handed it: step's captured-local write
+        // replays on the computation's flows, reached through the helper's own binding.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    Func<int, int> step = x => { applied++; return x; };
+                    static int Run(Func<int, int> g, int x) => g(x);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => Run(step, x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ConstructorMutation_IsFlagged()
+    {
+        // The patch constructs a Writer on every replay: the ctor's static write races,
+        // while the fresh object's own field write is nobody's shared state.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class Writer
+            {
+                public static int count;
+                public int mine;
+
+                public Writer()
+                {
+                    mine = 1;
+                    count++;
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = new Writer(); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("static field 'count'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task FactoryReturnedInvokedDelegate_MutationIsFlagged()
+    {
+        // `Get()(x)` executes the factory-returned lambda on the computation's flows: its
+        // captured-local write races like inline code.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    Func<int, int> Get() => x => { applied++; return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => Get()(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -483,4 +483,55 @@ public class CapturedMutationAnalyzerTests
         var diagnostic = Assert.Single(diagnostics);
         Assert.Contains("captured local 'counter'", diagnostic.GetMessage());
     }
+
+    // Apply's patch is a computation host (ADR 0007): it re-runs inside the view's computation
+    // on arbitrary flows, so a captured-state write in one is exactly this rule's data race.
+    [Fact]
+    public async Task OptimisticPatch_WritingCapturedLocal_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    int applied = 0;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { applied++; return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OptimisticPatch_PureProjection_IsNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + p);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -1472,4 +1472,67 @@ public class CapturedMutationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task AssembledPatchFactoryBinding_IsFlagged()
+    {
+        // The factory was handed the enclosing instance: inside the returned patch `c` IS
+        // `this`, so the replayed write races on the computation's own object.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                private static Func<int, int> Make(C c) => x => { c.Counter++; return x; };
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Make(this));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ConditionalInitializerFactoryArm_MutationIsFlagged()
+    {
+        // The patch variable's initializer picks an arm: the factory-call arm can be stored,
+        // and its returned lambda mutates captured state on every replay.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var applied = 0;
+                    var flag = true;
+                    Func<int, int> Make() => x => { applied++; return x; };
+                    Func<int, int> patch = flag ? static x => x : Make();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/CapturedMutationAnalyzerTests.cs
@@ -1409,4 +1409,67 @@ public class CapturedMutationAnalyzerTests
         Assert.Equal("MZR002", diagnostic.Id);
         Assert.Contains("captured local 'applied'", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task SecondInvocationBinding_IsWalked()
+    {
+        // The same delegate body runs under two receivers: the first walk must not mark it
+        // visited for the second, which is the one that writes the computation's instance.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var other = new C();
+                    Action<C> step = c => c.Counter++;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { step(other); step(this); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR002", diagnostic.Id);
+        Assert.Contains("field 'Counter'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task MethodGroupDelegateOnOtherReceiver_IsNotFlagged()
+    {
+        // The delegate captured another object: its own field write belongs to that object,
+        // which is MZR001's territory, not a write to the computation's instance.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public int Counter;
+
+                private void Touch() => Counter++;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var other = new C();
+                    Action step = other.Touch;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { step(); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -616,6 +616,101 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Contains("reassigned", diagnostic.GetMessage());
     }
 
+    // nameof(shared) is a compile-time string: the built delegate neither captures nor reads
+    // the symbol, so nothing crosses flows.
+    [Fact]
+    public async Task NameofOperands_AreNotCaptures()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + nameof(shared).Length + nameof(hits).Length);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // A straight-line reassignment AFTER the call cannot change the delegate the overlay
+    // already stored; only assignments that can execute before it distrust the initializer.
+    [Fact]
+    public async Task ReassignmentAfterTheCall_KeepsTheInitializerTrusted()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        await ctx.Apply(state, patch);
+                        patch = x => x + shared.Count;
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task LoopCarriedReassignment_IsStillUnresolvable()
+    {
+        // Textually after the call, but the loop carries the reassigned delegate back into
+        // the next iteration's Apply.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        for (var i = 0; i < 2; i++)
+                        {
+                            await ctx.Apply(state, patch);
+                            patch = x => x + shared.Count;
+                        }
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("reassigned", diagnostic.GetMessage());
+    }
+
     [Fact]
     public async Task PatchInternalLocalFunction_UsingPatchLocals_IsNotFlagged()
     {

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -4527,4 +4527,66 @@ public class OptimisticPatchCaptureAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task GenericFactoryCapture_UsesTheCallSiteType()
+    {
+        // The returned patch captures the factory's parameter: what it actually stores is
+        // the call-site List, so the declared type parameter must not wave it through.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int, int> Make<T>(T p) => x => x + p!.GetHashCode();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Make(new List<int>()));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SurvivingComputedPropertyWrite_IsResolved()
+    {
+        // The unsafe initializer is definitely overwritten by a store of a computed
+        // property: the getter's returned patch is the only storable closure, and it is safe.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int, int> Safe => static x => x;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = x => x + shared.Count;
+                        patch = Safe;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1802,6 +1802,116 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task FutureWriteToAFieldDelegate_DoesNotCountAsInitializer()
+    {
+        // The sole write executes strictly after the Apply read: whatever the field holds at
+        // the call came from somewhere the analyzer cannot see, so the future write must not
+        // stand in as the initializer.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> patch;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                        patch = static x => x;
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    // A source-declared method group whose body lives in another file cannot be walked, so
+    // its statics go unchecked: unverifiable means flagged. Metadata targets stay trusted.
+    [Fact]
+    public async Task CrossFileMethodGroup_IsFlaggedAsUnverifiable_MetadataIsNot()
+    {
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class Other
+            {
+                private static int hits;
+
+                public static int Patch(int x) => x + hits;
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Other.Patch);
+                        await ctx.Apply(state, System.Math.Abs);
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Patch'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OutParameterAssembledDelegate_Invoked_IsChasedForStatics()
+    {
+        // The delegate is assembled inside the callee through its out parameter.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static void Provide(out Func<int> d) => d = () => hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            Provide(out later);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -2074,6 +2074,215 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task OutHelperDelegateParameter_SafeCallSiteLambda_IsNotFlagged()
+    {
+        // The helper hands its own delegate parameter back through the out parameter: the
+        // call-site argument is what the invoke executes, and it is a safe static lambda.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static void Provide(out Func<int> d, Func<int> source) => d = source;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            Provide(out later, static () => 0);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OutHelperDelegateParameter_ChasesTheCallSiteLambda()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static void Provide(out Func<int> d, Func<int> source) => d = source;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            Provide(out later, () => hits);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CrossFileComputedStaticGetter_FallsBackToTheTypeVerdict()
+    {
+        // The static getter is computed but declared in another file: what it returns cannot
+        // be walked, so the property TYPE's verdict must apply instead of silent trust.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            using System.Collections.Generic;
+
+            public static class Other
+            {
+                private static readonly List<int> stored = new();
+
+                public static List<int> Items => stored;
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Other.Items.Count);
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Items'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DeconstructionAssignment_StandsInAsInitializer()
+    {
+        // The sole write is a simple deconstruction: the variable's slot is fully determined
+        // by the matching tuple element, exactly like a plain `patch = ...` first assignment.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        (patch, _) = ((Func<int, int>)(static x => x), 0);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ReturnedDelegate_ImmediatelyInvoked_IsChased()
+    {
+        // `Get()()` executes whatever the same-tree helper returns, on every replay.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static Func<int> Get() => () => hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Get()());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CrossFileReturnedDelegate_ImmediatelyInvoked_IsUnverifiable()
+    {
+        // The delegate-returning helper lives in another file: the returned closure cannot
+        // be inspected, and unverifiable means flagged.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static System.Func<int> Get() => () => hits;
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + External.Get()());
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Get'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1333,6 +1333,42 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task AssignmentBuiltDelegate_Invoked_IsChasedForStatics()
+    {
+        // No declaration initializer: the delegate is assembled by assignment, so every
+        // same-tree assignment's right-hand side might be the invoked body.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            later = () => hits;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1598,6 +1598,39 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Contains("writable static state", diagnostic.GetMessage());
     }
 
+    // An assignment target runs the SETTER: a hidden static read in one replays with the
+    // patch just like a getter's.
+    [Fact]
+    public async Task StaticReadHiddenInAPropertySetter_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            [Sendable]
+            public class C
+            {
+                private static int hits;
+
+                private int P { get => 0; set { _ = hits; } }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { P = 1; return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
     [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -491,6 +491,128 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Empty(diagnostics);
     }
 
+    // An already-built delegate flowing in as data is the one shape Roslyn cannot see into --
+    // and this rule is the only check a patch ever gets, so unverifiable means flagged.
+    [Fact]
+    public async Task PrebuiltDelegateParameter_IsFlaggedAsUnverifiable()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(Func<int, int> patch)
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    // A local function has no receiver, so no receiver/this verdict covers its closure: moving
+    // the read behind one declared outside the patch must not evade the rule.
+    [Fact]
+    public async Task LocalFunctionHelper_CapturingNonSendableState_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    int Count() => shared.Count;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Count());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("shared", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task PatchInternalLocalFunction_UsingPatchLocals_IsNotFlagged()
+    {
+        // The local function lives INSIDE the patch: its reads of patch-locals are
+        // patch-internal state created fresh per execution, not cross-flow sharing.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            var list = new List<int> { x };
+                            int Count() => list.Count;
+                            return x + Count();
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // No setter, yet `ref int Counter => ref counter` hands out assignable live storage.
+    [Fact]
+    public async Task RefReturningProperty_IsFlaggedAsWritable()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;
+
+                public ref int Counter => ref counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Counter);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("Counter", diagnostic.GetMessage());
+        Assert.Contains("writable state", diagnostic.GetMessage());
+    }
+
     [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1073,6 +1073,135 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task NameofProperty_DoesNotChaseItsGetter()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int Hits => hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + nameof(Hits).Length);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NameofMention_DoesNotSuppressTheRealRead()
+    {
+        // The nameof mention comes first in the walk; it must not enter the visited set and
+        // swallow the chase of the real read that follows.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int Hits => hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + nameof(Hits).Length + Hits);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+    }
+
+    // `alias = ...` rebinds patch just as directly as `patch = ...`.
+    [Fact]
+    public async Task RefAliasReassignment_IsUnresolvable()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    Func<int, int> patch = static x => x;
+                    ref var alias = ref patch;
+                    alias = x => x + shared.Count;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("reassigned", diagnostic.GetMessage());
+    }
+
+    // A constructor and a user-defined operator run on every replay exactly like helper calls.
+    [Fact]
+    public async Task ConstructorAndOperator_HidingStaticReads_AreChased()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Meter
+            {
+                private static int hits;
+
+                public readonly int Sample;
+
+                public Meter() { Sample = hits; }
+
+                public static int operator +(Meter meter, int x) => x + hits;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => new Meter() + x);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -939,6 +939,139 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Contains("writable state", diagnostic.GetMessage());
     }
 
+    // The closure hoists the VARIABLE, not a copy: a mutable struct that is fine as a
+    // (copied) node value is writable shared storage as a capture.
+    [Fact]
+    public async Task CapturedMutableStruct_IsFlagged_ReadonlyStructIsNot()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public struct Counter
+            {
+                public int Value;
+            }
+
+            public readonly struct Snapshot
+            {
+                public readonly int Value;
+
+                public Snapshot(int value) { Value = value; }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var counter = new Counter();
+                    var snap = new Snapshot(1);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + counter.Value + snap.Value);
+                    });
+                    counter.Value++;
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'counter'", diagnostic.GetMessage());
+        Assert.Contains("mutable struct", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ForInitializerDelegate_CarriesItsReassignment()
+    {
+        // Declared in the for-INITIALIZER, the variable outlives each iteration: the trailing
+        // reassignment is what the next iteration's Apply stores.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        for (Func<int, int> patch = static x => x; ; )
+                        {
+                            await ctx.Apply(state, patch);
+                            patch = x => x + shared.Count;
+                        }
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("reassigned", diagnostic.GetMessage());
+    }
+
+    // A property read runs its getter exactly like a call: `static int Hits => hits;` is the
+    // helper-method evasion with property syntax.
+    [Fact]
+    public async Task GetOnlyStaticProperty_HidingAStaticRead_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int Hits => hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Hits);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    // Top-level statements put captured locals in a compiler-synthesized entry point with no
+    // declaration of its own -- the enclosing-function test must not lose them.
+    [Fact]
+    public async Task TopLevelStatementCaptures_AreShared()
+    {
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            var f = new MemoFactory();
+            var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+            var shared = new List<int>();
+            f.CreateAction<int>(async (p, ctx) =>
+            {
+                await ctx.Apply(state, x => x + shared.Count);
+            });
+            """, new OptimisticPatchCaptureAnalyzer(), OutputKind.ConsoleApplication);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("shared", diagnostic.GetMessage());
+    }
+
     [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -3827,6 +3827,86 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task CapturedMethodGroupDelegate_ReceiverIsChecked()
+    {
+        // The captured delegate already holds its method-group receiver: the stored patch
+        // shares that object across flows even though the target body is safe.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Helper
+            {
+                public List<int> Items = new();
+
+                public int Patch(int x) => x;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var helper = new Helper();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> d = helper.Patch;
+                        await ctx.Apply(state, x => d(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'helper'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CapturedConditionalDelegate_OpaqueArmKeepsTheTypeVerdict()
+    {
+        // One arm of the captured delegate's initializer is an opaque cross-file factory
+        // result: the safe arm cannot vouch for it, so the type verdict stands.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static System.Func<int> Get() => () => hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool external)
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int> d = external ? External.Get() : static () => 0;
+                        await ctx.Apply(state, x => { _ = d; return x; });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'d'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1916,7 +1916,8 @@ public class OptimisticPatchCaptureAnalyzerTests
     {
         // The helper assembling the delegate lives in another file: nothing can say what
         // closure `later` holds at the invoke, and this walk is the only check that closure
-        // will ever get -- unverifiable means flagged.
+        // will ever get -- unverifiable means flagged, both for the executed cross-file
+        // helper itself and for the delegate it leaves behind.
         var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
         {
             """
@@ -1951,10 +1952,10 @@ public class OptimisticPatchCaptureAnalyzerTests
             """,
         }, new OptimisticPatchCaptureAnalyzer());
 
-        var diagnostic = Assert.Single(diagnostics);
-        Assert.Equal("MZR004", diagnostic.Id);
-        Assert.Contains("'later'", diagnostic.GetMessage());
-        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'Provide'") && d.GetMessage().Contains("another file"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'later'") && d.GetMessage().Contains("cannot be resolved"));
     }
 
     [Fact]
@@ -2280,6 +2281,183 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Equal("MZR004", diagnostic.Id);
         Assert.Contains("'Get'", diagnostic.GetMessage());
         Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task NestedHelperCall_IsRewalkedPerOuterBinding()
+    {
+        // Both outer calls funnel into the SAME nested `Invoke(f)` call site with different
+        // delegates: the second binding must be chased even though the syntax was already
+        // visited under the first.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int Run(Func<int> f) => Invoke(f);
+
+                private static int Invoke(Func<int> g) => g();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => Run(static () => 0) + Run(() => hits) + x);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DelegateWriteInACallbackThePatchNeverInvokes_IsNotChased()
+    {
+        // The reassignment lives in a callback the patch builds and discards: it provably
+        // cannot run before the invoke, so the harmless initializer is the only body.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later = static () => 0;
+                            Action unused = () => later = () => hits;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CrossFileInvokedHelper_IsUnverifiable_MetadataIsNot()
+    {
+        // The patch EXECUTES a helper whose source body lives in another file: its statics
+        // go unchecked, so unverifiable means flagged -- while the metadata call stays a
+        // trusted external contract.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class Other
+            {
+                private static int hits;
+
+                public static int ReadHits() => hits;
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => System.Math.Abs(x) + Other.ReadHits());
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'ReadHits'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task RefAliasFirstAssignment_StandsInAsInitializer()
+    {
+        // The field's sole write goes through a ref alias: it is the initialization, not a
+        // rebind, and the assigned lambda is what the overlay stores.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> patch;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    ref var alias = ref patch;
+                    alias = static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OutHelperDeconstructionAssignment_IsChased()
+    {
+        // The helper assembles its out parameter through deconstruction: the parameter's
+        // tuple slot is the delegate the caller invokes.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static void Provide(out Func<int> d) => (d, _) = ((Func<int>)(() => hits), 0);
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            Provide(out later);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
     }
 
     [Fact]

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1201,6 +1201,137 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Contains("writable static state", diagnostic.GetMessage());
     }
 
+    // Every link of the alias chain gets the reassignment check, against the site where its
+    // value is READ: patch is never written again, but it copied p0 after p0's reassignment.
+    [Fact]
+    public async Task ReassignedAlias_IsUnresolvable()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    Func<int, int> p0 = static x => x;
+                    p0 = x => x + shared.Count;
+                    Func<int, int> patch = p0;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'p0'", diagnostic.GetMessage());
+        Assert.Contains("reassigned", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task AliasReassignedAfterTheCopy_KeepsTheInitializerTrusted()
+    {
+        // p0's reassignment happens AFTER patch copied it: the copied value is the harmless
+        // initializer, so nothing distrusts the chain.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    Func<int, int> p0 = static x => x;
+                    Func<int, int> patch = p0;
+                    p0 = x => x + shared.Count;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // An event's backing delegate is writable storage by construction: subscribers on other
+    // flows mutate what the patch reads.
+    [Fact]
+    public async Task StaticEventRead_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static event Action? Changed;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { Changed?.Invoke(); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("Changed", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    // A delegate the patch builds AND invokes runs on every replay -- only the
+    // built-but-deferred shape is pruned.
+    [Fact]
+    public async Task ImmediatelyInvokedBuiltDelegate_IsChasedForStatics()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later = () => hits;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
     [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -2943,6 +2943,221 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task OverwrittenInitializer_IsNotChased()
+    {
+        // The unsafe initializer is definitely overwritten on the straight-line path to the
+        // invoke: only the surviving safe assignment can be the delegate invoked.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later = () => hits;
+                            later = static () => 0;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ConditionalPatch_BothArmsWalked_SafeArmsAreSilent()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, p > 0 ? (Func<int, int>)(static x => x) : static x => x + 1);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ConditionalPatch_UnverifiableArmIsFlagged()
+    {
+        // One arm is a cross-file method group: the safe arm must not silence it.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class Other
+            {
+                private static int hits;
+
+                public static int Patch(int x) => x + hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, p > 0 ? (Func<int, int>)Other.Patch : static x => x);
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Patch'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ComputedDelegateProperty_ReturnsAreWalked()
+    {
+        // The get-only computed property's only possible return is a verifiable static
+        // lambda: nothing to flag.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int, int> Patch
+                {
+                    get
+                    {
+                        return static x => x;
+                    }
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ComputedDelegateProperty_ReturnedClosureIsInspected()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static Func<int, int> Patch
+                {
+                    get
+                    {
+                        return x => x + hits;
+                    }
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CrossFilePropertySetter_IsUnverifiable()
+    {
+        // The setter body lives in another file and runs on every replay: on a
+        // computation-local receiver no other verdict ever looks at it.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public struct Box
+            {
+                private static int hits;
+
+                public int P
+                {
+                    get => 0;
+                    set { _ = hits; }
+                }
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            var box = new Box();
+                            box.P = 1;
+                            return x;
+                        });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'P'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -4492,4 +4492,39 @@ public class OptimisticPatchCaptureAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task UnreachableOutWrite_IsNotACandidate()
+    {
+        // The second assignment sits after an unconditional return: the caller can never
+        // receive that delegate, so its capture must not be charged to this patch.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    void Provide(out Func<int, int> d)
+                    {
+                        d = static x => x;
+                        return;
+                        d = x => x + shared.Count;
+                    }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -2618,6 +2618,196 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task OutHelperAssembledPatchArgument_IsWalked()
+    {
+        // The patch is definitely assembled by a same-tree out-helper before Apply: the
+        // helper's assignment is the body the overlay stores, and it is safe.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static void Provide(out Func<int, int> d) => d = static x => x;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OutHelperAssembledPatchArgument_ChasesTheAssembledBody()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static void Provide(out Func<int, int> d) => d = x => x + hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ReboundDelegateParameter_ChasesTheRebind()
+    {
+        // The helper rebinds its delegate parameter before invoking it: the rebinding
+        // closure is what runs, and the safe call-site lambda must not stand in for it.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int Run(Func<int> f)
+                {
+                    f = () => hits;
+                    return f();
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Run(static () => 0));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task MixedDelegateWrites_UnresolvedBranchIsStillFlagged()
+    {
+        // One branch assembles a safe lambda, the other an unverifiable cross-file closure:
+        // either can be the one invoked, so the safe branch must not silence the other.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static System.Func<int> Get() => () => hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            if (p > 0)
+                            {
+                                later = External.Get();
+                            }
+                            else
+                            {
+                                later = static () => 0;
+                            }
+
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'Get'") && d.GetMessage().Contains("another file"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'later'") && d.GetMessage().Contains("cannot be resolved"));
+    }
+
+    [Fact]
+    public async Task ForeignInstanceDelegateWrite_IsNotChasedForTheInvoke()
+    {
+        // The write rebinds the field on a provably different instance: the delegate this
+        // patch invokes is still the initializer, so the foreign lambda's static read must
+        // not be charged to it. (The writable-field capture itself is still reported --
+        // that is the capture rule, not the write chase.)
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private Func<int, int> patch = static x => x;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var otherObject = new C();
+                    otherObject.patch = x => x + hits;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => patch(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.DoesNotContain("hits", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -712,6 +712,107 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task LoopLocalDelegate_TrailingReassignment_IsNotCarried()
+    {
+        // The delegate local is declared INSIDE the loop body: freshly initialized each
+        // iteration, so the trailing reassignment dies with its iteration and can never
+        // reach a call -- the initializer stays trustworthy.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        for (var i = 0; i < 2; i++)
+                        {
+                            Func<int, int> patch = static x => x;
+                            await ctx.Apply(state, patch);
+                            patch = x => x + shared.Count;
+                        }
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DeconstructionReassignment_IsUnresolvable()
+    {
+        // `(patch, _) = ...` writes `patch` just as much as `patch = ...`: the tuple
+        // left-hand side must be flattened before comparing symbols.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        (patch, _) = ((Func<int, int>)(x => x + shared.Count), 0);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("reassigned", diagnostic.GetMessage());
+    }
+
+    // A static read inside a callback the patch merely BUILDS runs later, off the overlay's
+    // re-execution, on whatever flow invokes it -- the same deferred-callback shape MZR003
+    // prunes. (Closure captures keep the full walk: a built callback still pins them.)
+    [Fact]
+    public async Task StaticReadInACallbackThePatchOnlyBuilds_IsNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later = () => hits;
+                            _ = later;
+                            return x;
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task PatchInternalLocalFunction_UsingPatchLocals_IsNotFlagged()
     {
         // The local function lives INSIDE the patch: its reads of patch-locals are

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -165,6 +165,42 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task MethodGroupPatch_StoredInADelegateVariable_FlagsTheReceiver()
+    {
+        // The receiver hides behind a variable: `Apply` sees only a local reference, so the
+        // method group must be resolved through the (same-tree) initializer.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class Helper
+            {
+                public int Count;
+
+                public int Patch(int x) => x + Count;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var helper = new Helper();
+                    Func<int, int> patch = helper.Patch;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'helper'") && d.GetMessage().Contains("not Sendable"));
+    }
+
+    [Fact]
     public async Task MethodGroupPatch_ImmutableOrStaticReceiver_IsNotFlagged()
     {
         var diagnostics = await AnalyzeAsync("""
@@ -194,6 +230,103 @@ public class OptimisticPatchCaptureAnalyzerTests
             """);
 
         Assert.Empty(diagnostics);
+    }
+
+    // Hiding the state read behind an instance helper still captures `this`; the enclosing
+    // OBJECT is what crosses flows, so it is held to its type's sendability.
+    [Fact]
+    public async Task HelperCallHidingTheRead_FlagsTheCapturedThis()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;
+
+                private int ReadCounter() => counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        // Two helper calls, one capture: `this` is deduplicated like any symbol.
+                        await ctx.Apply(state, x => x + ReadCounter() + ReadCounter());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'this'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task HelperCallOnASendableEnclosingType_IsNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private readonly int bias;
+
+                private int Bias() => bias;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Bias());
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // Static state is shared across every flow without any capture: the read baked into the
+    // stored delegate races with whoever mutates the static.
+    [Fact]
+    public async Task StaticState_WritableOrNonSendable_IsFlagged_ConstAndImmutableAreNot()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;                          // writable static: flagged
+                private static readonly List<int> Cache = new();  // readonly, but the List is shared: flagged
+                public static int Threshold { get; set; }         // settable static property: flagged
+                private const int Max = 5;                        // compile-time constant: fine
+                private static readonly string Name = "n";        // readonly + Sendable: fine
+                private static string Label => "l";               // get-only, Sendable: fine
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + hits + Cache.Count + Threshold + Max + Name.Length + Label.Length);
+                    });
+                }
+            }
+            """);
+
+        Assert.Equal(3, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("hits") && d.GetMessage().Contains("writable static state"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Cache") && d.GetMessage().Contains("not Sendable"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("Threshold") && d.GetMessage().Contains("writable static state"));
     }
 
     [Fact]

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -4062,4 +4062,176 @@ public class OptimisticPatchCaptureAnalyzerTests
 
         Assert.Single(diagnostics);
     }
+    [Fact]
+    public async Task PostReadLocalFunctionEscape_DoesNotCountAsRunnable()
+    {
+        // The local function that rebinds the patch is lifted into a delegate, but that
+        // delegate escapes only AFTER the Apply call on the straight-line path: nothing can
+        // have invoked the rebind before the read, so the declaration initializer stands.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    Func<int, int> patch = static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        void Rebind() => patch = static x => x + 1;
+                        Action a = Rebind;
+                        await ctx.Apply(state, patch);
+                        Consume(a);
+                    });
+                }
+
+                private static void Consume(Action a) { }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task FutureRebindOfTwoStepLocal_KeepsTheInitializingWrite()
+    {
+        // The two-step local is rebound only AFTER the Apply call: the later write makes the
+        // global sole-write scan ambiguous, but cannot change what this call stored, so the
+        // initializing write's lambda is what gets walked -- and the rebind's captured static
+        // must not be charged to it.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        patch = static x => x;
+                        await ctx.Apply(state, patch);
+                        patch = static x => x + hits;
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CrossFileGetterOnLocalReceiver_IsUnverifiable()
+    {
+        // The receiver is a patch-local struct the capture walk never verdicts, and the
+        // getter body lives in another file: nothing else checks the statics it re-reads on
+        // every replay, so unverifiable means flagged.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public struct Box
+            {
+                private static int hits;
+                public int P => hits++;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            var box = new Box();
+                            return x + box.P;
+                        });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'P'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CapturedFactoryDelegate_IsWalkedNotTypeRejected()
+    {
+        // The captured delegate was built by a same-tree factory: its returns ARE the stored
+        // closure, so they are walked like a factory-built patch argument instead of the
+        // capture being rejected wholesale for its delegate type.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    static Func<int> Safe() => static () => 0;
+                    var d = Safe();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + d());
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task UnrelatedMethodWrite_DoesNotStandInForAFieldPatch()
+    {
+        // The field's sole write lives in a method nothing here calls: at the Apply read the
+        // field may still hold its default or an externally supplied delegate, so the write
+        // must not stand in as the initializer -- unresolvable keeps the flag.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> patch;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+
+                private void Reset() => patch = static x => x;
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1632,6 +1632,102 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task FirstAssignedDelegate_ResolvesLikeAnInitializer()
+    {
+        // Declaration in two steps: the sole assignment IS the initialization, not a rebind.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    Func<int, int> patch;
+                    patch = static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task InvokeAfterReassignment_ChasesTheNewBody()
+    {
+        // The second call executes the reassigned closure: the per-site guard must not let
+        // the first (safe) invocation swallow it.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later = static () => 0;
+                            _ = later();
+                            later = () => hits;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    // A computed get-only property is a helper call in disguise: its getter re-reads the
+    // mutable field on every replay.
+    [Fact]
+    public async Task ComputedInstanceGetter_ReadingMutableField_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;
+
+                private int Counter => counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Counter);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("counter", diagnostic.GetMessage());
+        Assert.Contains("writable state", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1208,8 +1208,11 @@ public class OptimisticPatchCaptureAnalyzerTests
     // Every link of the alias chain gets the reassignment check, against the site where its
     // value is READ: patch is never written again, but it copied p0 after p0's reassignment.
     [Fact]
-    public async Task ReassignedAlias_IsUnresolvable()
+    public async Task ReassignedAlias_SurvivingWriteIsWalked()
     {
+        // p0's initializer is definitely overwritten before patch copies it: the surviving
+        // write is the only closure the copy can hold, so it is walked as the patch body --
+        // and its capture of `shared` is what gets flagged, not the alias wholesale.
         var diagnostics = await AnalyzeAsync("""
             using System;
             using System.Collections.Generic;
@@ -1235,8 +1238,8 @@ public class OptimisticPatchCaptureAnalyzerTests
 
         var diagnostic = Assert.Single(diagnostics);
         Assert.Equal("MZR004", diagnostic.Id);
-        Assert.Contains("'p0'", diagnostic.GetMessage());
-        Assert.Contains("reassigned", diagnostic.GetMessage());
+        Assert.Contains("'shared'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
     }
 
     [Fact]
@@ -4363,5 +4366,69 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Equal("MZR004", diagnostic.Id);
         Assert.Contains("'shared'", diagnostic.GetMessage());
         Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+    [Fact]
+    public async Task OverwrittenAliasSource_SurvivingSafeWriteResolves()
+    {
+        // The unsafe initializer is definitely overwritten before the alias copies the
+        // source: only the safe surviving write can be stored, so nothing is flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> src = x => x + shared.Count;
+                        src = static x => x;
+                        Func<int, int> patch = src;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ForeignReceiverMemberRead_DoesNotTrustOwnWrite()
+    {
+        // The write initializes `this.patch`, but the patch is read off ANOTHER instance,
+        // whose copy may still be null or externally supplied: the synthesis must not pair
+        // them, and the unresolvable read keeps the flag.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> patch;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var other = new C();
+                    patch = static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, other.patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
     }
 }

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -4431,4 +4431,33 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Contains("'patch'", diagnostic.GetMessage());
         Assert.Contains("cannot be resolved", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task CapturedComputedPropertyDelegate_IsWalkedNotTypeRejected()
+    {
+        // The captured delegate was read from a same-tree computed property: the getter's
+        // returns ARE the stored closure, walked instead of the capture being rejected
+        // wholesale for its delegate type.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int> Safe => static () => 0;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var d = Safe;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + d());
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -329,6 +329,168 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Contains(diagnostics, d => d.GetMessage().Contains("Threshold") && d.GetMessage().Contains("writable static state"));
     }
 
+    // [Sendable] is the trust escape hatch (the type asserts internal synchronization); the
+    // classifier vets the whole object, and re-walking its members would override that trust.
+    [Fact]
+    public async Task SendableAttributedReceiver_MethodGroupBody_IsNotReWalked()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            [Sendable]
+            public class Helper
+            {
+                public int Count;
+
+                public int Patch(int x) => x + Count;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var helper = new Helper();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, helper.Patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task SendableAttributedEnclosingType_DirectReads_AreNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            [Sendable]
+            public class C
+            {
+                private int counter;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + counter);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // The classifier deliberately ignores statics (they are not part of instance transfer), so
+    // a Sendable `this` must not silence a static read hidden behind helpers: same-tree helper
+    // bodies are chased, transitively.
+    [Fact]
+    public async Task StaticReadHiddenBehindHelpers_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private int ReadHits() => hits;
+
+                private int Indirect() => ReadHits();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Indirect());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    // A struct receiver is Sendable by copy semantics, but a method-group delegate stores ONE
+    // boxed copy that every re-execution shares -- a non-readonly method mutates that box.
+    [Fact]
+    public async Task MutableStructReceiver_NonReadonlyMethodGroup_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public struct Counter
+            {
+                private int count;
+
+                public int Patch(int x) => x + count++;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var counter = new Counter();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, counter.Patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'counter'", diagnostic.GetMessage());
+        Assert.Contains("boxed receiver", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task StructReceiver_ReadonlyMethodGroup_IsNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public struct Counter
+            {
+                private int count;
+
+                public readonly int Peek(int x) => x + count;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var counter = new Counter();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, counter.Peek);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
     [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -586,8 +586,10 @@ public class OptimisticPatchCaptureAnalyzerTests
     // The initializer proves nothing once the variable is reassigned: the overlay may store
     // the second closure, so the variable is held to the unresolvable-delegate verdict.
     [Fact]
-    public async Task ReassignedDelegateVariable_IsFlaggedAsUnverifiable()
+    public async Task ReassignedDelegateVariable_SurvivingWriteIsWalked()
     {
+        // The rebind definitely overwrites the initializer before Apply: the surviving
+        // write is the closure the overlay stores, and its shared capture is the flag.
         var diagnostics = await AnalyzeAsync("""
             using System;
             using System.Collections.Generic;
@@ -612,8 +614,8 @@ public class OptimisticPatchCaptureAnalyzerTests
 
         var diagnostic = Assert.Single(diagnostics);
         Assert.Equal("MZR004", diagnostic.Id);
-        Assert.Contains("'patch'", diagnostic.GetMessage());
-        Assert.Contains("reassigned", diagnostic.GetMessage());
+        Assert.Contains("shared", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
     }
 
     // nameof(shared) is a compile-time string: the built delegate neither captures nor reads
@@ -1132,8 +1134,10 @@ public class OptimisticPatchCaptureAnalyzerTests
 
     // `alias = ...` rebinds patch just as directly as `patch = ...`.
     [Fact]
-    public async Task RefAliasReassignment_IsUnresolvable()
+    public async Task RefAliasReassignment_SurvivingWriteIsWalked()
     {
+        // The alias write rebinds patch and definitely overwrites its initializer: the
+        // surviving closure is walked, and its shared capture is the flag.
         var diagnostics = await AnalyzeAsync("""
             using System;
             using System.Collections.Generic;
@@ -1159,8 +1163,8 @@ public class OptimisticPatchCaptureAnalyzerTests
 
         var diagnostic = Assert.Single(diagnostics);
         Assert.Equal("MZR004", diagnostic.Id);
-        Assert.Contains("'patch'", diagnostic.GetMessage());
-        Assert.Contains("reassigned", diagnostic.GetMessage());
+        Assert.Contains("shared", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
     }
 
     // A constructor and a user-defined operator run on every replay exactly like helper calls.
@@ -3155,6 +3159,288 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Equal("MZR004", diagnostic.Id);
         Assert.Contains("'P'", diagnostic.GetMessage());
         Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ConditionalInvokedDelegate_UnresolvedArmIsFlagged()
+    {
+        // The invoked callee is a ternary: the safe arm must not silence the cross-file
+        // factory result the other arm can execute.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static System.Func<int> Get() => () => hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + (p > 0 ? External.Get() : (Func<int>)(static () => 0))());
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Get'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CastedLocalFunctionLift_DoesNotCountAsRunnable()
+    {
+        // The rebinding local function is only lifted through a cast into a variable that is
+        // never invoked: the write inside it cannot precede the Apply.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        void Rebind() => patch = x => x + hits;
+                        Action unused = (Action)Rebind;
+                        _ = unused;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CrossFileEventAccessor_IsUnverifiable()
+    {
+        // The custom add accessor's body lives in another file and runs on every replay.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            using System;
+
+            public struct Emitter
+            {
+                private static int hits;
+
+                public event Action Changed
+                {
+                    add { _ = hits; }
+                    remove { }
+                }
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            var emitter = new Emitter();
+                            emitter.Changed += static () => { };
+                            return x;
+                        });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Changed'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CrossFileDispose_IsUnverifiable()
+    {
+        // Disposal runs on every replay; its cross-file source body cannot be walked.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public struct Writer : System.IDisposable
+            {
+                private static int hits;
+
+                public void Dispose() { _ = hits; }
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            using var w = new Writer();
+                            return x;
+                        });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Dispose'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OutHelperMethodGroup_ReceiverIsChecked()
+    {
+        // The out-helper hands back a method group: its receiver is stored in the overlay
+        // exactly like a direct method-group patch.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Helper
+            {
+                public List<int> Items = new();
+
+                public int Patch(int x) => x;
+            }
+
+            public class C
+            {
+                private static void Provide(Helper h, out Func<int, int> d) => d = h.Patch;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var helper = new Helper();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(helper, out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'h'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OverwrittenPatchInitializer_SurvivingWriteIsWalked()
+    {
+        // The unsafe initializer is definitely overwritten before Apply: the overlay stores
+        // only the safe surviving lambda.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    Func<int, int> patch = x => x + shared.Count;
+                    patch = static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ComputedDelegateProperty_MethodGroupReceiverIsChecked()
+    {
+        // The getter returns a method group: the receiver it stores is checked like a
+        // direct method-group patch even when the target body itself is safe.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class Helper
+            {
+                public List<int> Items = new();
+
+                public int Patch(int x) => x;
+            }
+
+            public class C
+            {
+                private readonly Helper helper = new();
+
+                private Func<int, int> Patch
+                {
+                    get
+                    {
+                        return helper.Patch;
+                    }
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'helper'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
     }
 
     [Fact]

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1369,6 +1369,42 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task DeconstructionBuiltDelegate_Invoked_IsChasedForStatics()
+    {
+        // `(later, _) = ...` assembles the delegate just like `later = ...`: the tuple's
+        // elements are the bodies that might be invoked.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            (later, _) = ((Func<int>)(() => hits), 0);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -2808,6 +2808,141 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task MixedReturnBranches_UnresolvedOneIsStillFlagged()
+    {
+        // The same-tree factory returns a safe lambda on one branch and an unverifiable
+        // cross-file closure on the other: either can be the delegate the patch invokes.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static System.Func<int> Get() => () => hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int> Get(int p)
+                {
+                    if (p > 0)
+                    {
+                        return External.Get();
+                    }
+
+                    return static () => 0;
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => Get(x)());
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Get'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task NameofMentionOfARebindingLocalFunction_DoesNotCountAsReassignment()
+    {
+        // The rebinding local function is only MENTIONED in nameof, never run: the write
+        // inside it cannot precede the Apply, so the safe initializer stays the delegate.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        void Rebind() => patch = x => x + hits;
+                        _ = nameof(Rebind);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OutHelperMixedBranches_UnresolvedOneIsStillFlagged()
+    {
+        // One helper branch assembles a safe lambda, the other an unverifiable cross-file
+        // closure: the safe branch must not silence the other.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static System.Func<int, int> Get() => x => x + hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static void Provide(out Func<int, int> d, int p)
+                {
+                    if (p > 0)
+                    {
+                        d = External.Get();
+                    }
+                    else
+                    {
+                        d = static x => x;
+                    }
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch, p);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'d'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -4234,4 +4234,134 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Contains("'patch'", diagnostic.GetMessage());
         Assert.Contains("cannot be resolved", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task AliasedComputedPropertyPatch_IsResolved()
+    {
+        // The patch is copied out of a computed delegate property first: the alias resolves
+        // to the property, whose getter returns are the stored closure -- fully walkable.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int, int> Patch => static x => x;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = Patch;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task GetterReturningFactoryCall_IsResolved()
+    {
+        // The computed patch property returns a same-tree factory call: the factory's own
+        // returns are the stored closure, chased one level deeper instead of reported opaque.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int, int> Make() => static x => x;
+                private static Func<int, int> Patch { get { return Make(); } }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task OverwrittenForwardedHandoff_IsNotWalked()
+    {
+        // The forwarded handoff's delegate is definitely overwritten before the helper
+        // returns: whatever Build assembled can never reach the caller, so its closure must
+        // not be charged to this patch.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    static void Build(out Func<int, int> d) => d = x => x + hits;
+                    void Provide(out Func<int, int> d)
+                    {
+                        Build(out d);
+                        d = static x => x;
+                    }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NestedComputationHostLambda_CapturesAreStillPatchCaptures()
+    {
+        // The patch builds a nested computation on every replay: the nested lambda lives in
+        // the patch's own display chain, so what it captures is stored patch state even
+        // though the nested computation's execution is analyzed separately.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            f.CreateMemoizR(async () => shared.Count);
+                            return x;
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'shared'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -552,6 +552,71 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task HelperLocalClosures_AreNotPatchCaptures()
+    {
+        // Inner captures tmp -- but tmp belongs to Count's INVOCATION, recreated on every
+        // patch execution: nothing of it is stored in the optimistic delegate.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    int Count()
+                    {
+                        var tmp = new List<int>();
+                        int Inner() => tmp.Count;
+                        return Inner();
+                    }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Count());
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // The initializer proves nothing once the variable is reassigned: the overlay may store
+    // the second closure, so the variable is held to the unresolvable-delegate verdict.
+    [Fact]
+    public async Task ReassignedDelegateVariable_IsFlaggedAsUnverifiable()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    Func<int, int> patch = static x => x;
+                    patch = x => x + shared.Count;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("reassigned", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task PatchInternalLocalFunction_UsingPatchLocals_IsNotFlagged()
     {
         // The local function lives INSIDE the patch: its reads of patch-locals are

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1912,6 +1912,138 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
+    {
+        // `??=` can leave an older, externally supplied value in place: it must not be
+        // trusted as the initializer.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int>? patch;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        patch ??= static x => x;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DelegateArgumentInvokedByAHelper_IsChasedForStatics()
+    {
+        // Run's body only invokes its parameter: the call-site lambda is what executes.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int Run(Func<int> f) => f();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Run(() => hits));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task NamedOutArgument_ResolvesTheSemanticParameter()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static void Provide(int first, out Func<int> second) => second = () => hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            Provide(second: out later, first: 0);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task AssignmentOverwrittenBeforeTheInvoke_IsNotChased()
+    {
+        // The second straight-line assignment replaces the first: only the value still held
+        // at the invoke executes.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            later = () => hits;
+                            later = static () => 0;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -101,7 +101,7 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
-    public async Task EnclosingProperties_SettableIsFlagged_GetOnlySendableIsNot()
+    public async Task EnclosingProperties_SettableIsFlagged_GetOnlyAndInitOnlySendableAreNot()
     {
         var diagnostics = await AnalyzeAsync("""
             using MemoizR;
@@ -109,6 +109,7 @@ public class OptimisticPatchCaptureAnalyzerTests
             public class C
             {
                 public int Threshold { get; set; }   // settable: flagged
+                public int Limit { get; init; }      // init-only is immutable state: held to its (Sendable) type
                 public string Tag => "t";            // computed get-only, Sendable type: fine
 
                 public void M()
@@ -117,7 +118,7 @@ public class OptimisticPatchCaptureAnalyzerTests
                     var state = f.CreateOptimistic<int>(f.CreateSignal(1));
                     f.CreateAction<int>(async (p, ctx) =>
                     {
-                        await ctx.Apply(state, x => x + Threshold + Tag.Length);
+                        await ctx.Apply(state, x => x + Threshold + Limit + Tag.Length);
                     });
                 }
             }
@@ -127,6 +128,72 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Equal("MZR004", diagnostic.Id);
         Assert.Contains("Threshold", diagnostic.GetMessage());
         Assert.Contains("writable state", diagnostic.GetMessage());
+    }
+
+    // A method-group patch captures its RECEIVER into the stored delegate; the receiver is
+    // shared across pull flows even when the method body cannot be walked.
+    [Fact]
+    public async Task MethodGroupPatch_MutableReceiver_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Helper
+            {
+                public int Count;
+
+                public int Patch(int x) => x + Count;
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var helper = new Helper();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, helper.Patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'helper'") && d.GetMessage().Contains("not Sendable"));
+    }
+
+    [Fact]
+    public async Task MethodGroupPatch_ImmutableOrStaticReceiver_IsNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public sealed record Calm(int Bias)
+            {
+                public int Patch(int x) => x + Bias;
+            }
+
+            public class C
+            {
+                private static int StaticPatch(int x) => x;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var calm = new Calm(1);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, calm.Patch);
+                        await ctx.Apply(state, StaticPatch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
     }
 
     [Fact]

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -2144,10 +2144,11 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
-    public async Task CrossFileComputedStaticGetter_FallsBackToTheTypeVerdict()
+    public async Task CrossFileComputedStaticGetter_IsUnverifiable()
     {
-        // The static getter is computed but declared in another file: what it returns cannot
-        // be walked, so the property TYPE's verdict must apply instead of silent trust.
+        // The static getter is computed but declared in another file: what its body re-reads
+        // cannot be walked, and a Sendable return type would prove nothing -- unverifiable
+        // means flagged, like a cross-file executed helper.
         var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
         {
             """
@@ -2181,7 +2182,163 @@ public class OptimisticPatchCaptureAnalyzerTests
         var diagnostic = Assert.Single(diagnostics);
         Assert.Equal("MZR004", diagnostic.Id);
         Assert.Contains("'Items'", diagnostic.GetMessage());
-        Assert.Contains("not Sendable", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CrossFilePartialInstanceGetter_IsUnverifiable()
+    {
+        // The partial type's other half holds the computed getter: the patch re-runs it on
+        // every replay, and the Sendable int return type must not hide the unverifiable
+        // mutable-field re-read.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public partial class C
+            {
+                private int counter;
+
+                public int Counter => counter;
+            }
+            """,
+            """
+            using MemoizR;
+
+            public partial class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Counter);
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'Counter'", diagnostic.GetMessage());
+        Assert.Contains("another file", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ForeignInstanceWrite_DoesNotStandInAsInitializer()
+    {
+        // The sole write targets ANOTHER instance's member: it says nothing about
+        // `this.patch`, so the delegate the overlay stores stays unresolvable.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> patch;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var otherObject = new C();
+                    otherObject.patch = static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ConditionalFirstAssignment_DoesNotStandInAsInitializer()
+    {
+        // The field's only write sits under an `if`: it may never run, and the member can
+        // still hold a delegate supplied somewhere the analyzer cannot see.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> patch;
+                private bool reset;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    if (reset)
+                    {
+                        patch = static x => x;
+                    }
+
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'patch'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task CrossFileConstructorAndOperator_AreUnverifiable()
+    {
+        // The patch executes a constructor and a user-defined operator whose bodies live in
+        // another file: both replay unverifiable code, exactly like a cross-file helper call.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public class Meter
+            {
+                private static int hits;
+
+                public Meter() { hits++; }
+
+                public static int operator +(Meter m, int x) => x + hits;
+            }
+            """,
+            """
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            var meter = new Meter();
+                            return meter + x;
+                        });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.All(diagnostics, d => Assert.Contains("another file", d.GetMessage()));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("'Meter'"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("op_Addition"));
     }
 
     [Fact]

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -812,6 +812,71 @@ public class OptimisticPatchCaptureAnalyzerTests
         Assert.Empty(diagnostics);
     }
 
+    // A method group the patch stores builds a delegate without running it -- the same
+    // deferred shape as a built lambda, so its statics must not count as patch reads.
+    [Fact]
+    public async Task MethodGroupStoredInACallback_IsNotExecutedForStatics()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int ReadHits() => hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later = ReadHits;
+                            _ = later;
+                            return x;
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // An `in` argument hands out a readonly reference: it cannot rebind the local, so it must
+    // not distrust the initializer.
+    [Fact]
+    public async Task InArgument_DoesNotDistrustTheInitializer()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static void Use(in Func<int, int> candidate) { }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        Use(in patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
     [Fact]
     public async Task PatchInternalLocalFunction_UsingPatchLocals_IsNotFlagged()
     {

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -3669,6 +3669,164 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task ComputedStateProperty_IsNotTreatedAsThePatch()
+    {
+        // Only the delegate-typed patch parameter is inspected: the computed state property
+        // must not run the delegate-shaped fallbacks.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+            using MemoizR.Reactive;
+
+            public class C
+            {
+                private readonly MemoFactory f = new();
+                private readonly OptimisticState<int> _state;
+
+                private OptimisticState<int> State => _state;
+
+                public C()
+                {
+                    _state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(State, static x => x);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task FactoryCallPatchArgument_ReturnsAreWalked()
+    {
+        // The patch comes from a same-tree factory -- inline and through a variable -- and
+        // its only return is a verified static lambda.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int, int> Safe()
+                {
+                    return static x => x;
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Safe());
+                        Func<int, int> stored = Safe();
+                        await ctx.Apply(state, stored);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CapturedSafeDelegate_IsWalkedInsteadOfTypeRejected()
+    {
+        // The captured delegate resolves to a same-tree static lambda: its body is the
+        // whole closure, and it is safe.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int> safe = static () => 0;
+                        await ctx.Apply(state, x => x + safe());
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CapturedUnsafeDelegate_FlagsItsRealCapture()
+    {
+        // The captured delegate's body itself captures shared state: walking it points at
+        // the actual problem instead of the delegate's type.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int> reader = () => shared.Count;
+                        await ctx.Apply(state, x => x + reader());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("shared", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SwitchBreakBetweenWrites_DoesNotBlockTheOverwrite()
+    {
+        // The break only exits its own switch, which ends before the safe overwrite:
+        // control still reaches it, so the stale initializer stays dead.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = x => x + shared.Count;
+                        switch (p)
+                        {
+                            case 0:
+                                break;
+                        }
+
+                        patch = static x => x;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -3444,6 +3444,231 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task ForwardedOutHelper_IsResolvedThroughTheChain()
+    {
+        // Provide forwards its out parameter to Build: the whole assignment chain is
+        // same-tree and the assembled lambda is safe.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static void Build(out Func<int, int> d) => d = static x => x;
+
+                private static void Provide(out Func<int, int> d)
+                {
+                    Build(out d);
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ForwardedOutHelper_ChasesTheAssembledBody()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static void Build(out Func<int, int> d) => d = x => x + hits;
+
+                private static void Provide(out Func<int, int> d)
+                {
+                    Build(out d);
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OutHelperOverwritesStaleInitializer()
+    {
+        // The dominating out handoff replaces the unsafe initializer: only the helper's
+        // safe assignment can be the stored patch.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static void Provide(out Func<int, int> d) => d = static x => x;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = x => x + shared.Count;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ConditionalDelegateInitializer_UnresolvedArmIsFlagged()
+    {
+        // The variable's initializer is a ternary: the safe arm must not silence the
+        // opaque cross-file factory result the other arm can store.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static System.Func<int, int> Get() => x => x + hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool external)
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    Func<int, int> patch = external ? External.Get() : static x => x;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("already-built", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OutHelperDeconstructionFromCall_IsUnverifiable()
+    {
+        // The helper binds its out parameter through a deconstruction whose right side is a
+        // call result: nothing can pair the delegate's slot, so the write is unverifiable.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static (System.Func<int, int>, int) Pair() => (x => x + hits, 0);
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static void Provide(out Func<int, int> d) => (d, _) = External.Pair();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'d'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SurvivingFactoryWrite_IsWalkedThroughItsReturns()
+    {
+        // The surviving write's value is a same-tree factory call whose only return is a
+        // verified static lambda.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static Func<int, int> GetSafe()
+                {
+                    return static x => x;
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = x => x + shared.Count;
+                        patch = GetSafe();
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1405,6 +1405,200 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task AssignmentAfterTheOnlyInvoke_IsNotChased()
+    {
+        // The second assignment executes after the only invocation: its callback is built but
+        // never run during the replay.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            later = static () => 0;
+                            var y = later();
+                            later = () => hits;
+                            _ = later;
+                            return x + y;
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DeconstructionElement_AssignedToAnotherVariable_IsNotChased()
+    {
+        // Positional pairing: the hits callback lands in `other`, which is never invoked.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> other;
+                            Func<int> later;
+                            (other, later) = ((Func<int>)(() => hits), static () => 0);
+                            _ = other;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task InstanceFieldPatch_WrittenOnAFreshOtherInstance_StaysTrusted()
+    {
+        // `other.patch = ...` on a freshly constructed instance cannot rebind `this.patch`.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> patch = static x => x;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    var other = new C();
+                    other.patch = x => x + shared.Count;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ComputedStaticGetter_ReturningFreshValues_IsNotFlagged_AutoPropertyIs()
+    {
+        // `Items` allocates per replay -- nothing shared; `Stored` is backing storage holding
+        // ONE List shared by every flow.
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private static List<int> Items => new();
+
+                private static List<int> Stored { get; } = new();
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Items.Count + Stored.Count);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("Stored", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DeconstructionDeclaredDelegate_ResolvesItsInitializer()
+    {
+        // `var (patch, _) = (...)` declares through a designation: the safe lambda is right
+        // there in the tuple, so the delegate must not be reported as unverifiable.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var (patch, _) = ((Func<int, int>)(static x => x), 0);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NullConditionalInvoke_IsChasedForStatics()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int>? later = () => hits;
+                            return x + (later?.Invoke() ?? 0);
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1728,6 +1728,80 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task RefAliasAssignedDelegate_Invoked_IsChasedForStatics()
+    {
+        // The assignment goes through a ref alias; it rebinds `later` all the same.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later = static () => 0;
+                            ref var alias = ref later;
+                            alias = () => hits;
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task GetterLocalCallback_NeverInvoked_IsNotFlagged()
+    {
+        // The getter allocates and discards the callback on each replay: nothing of it is
+        // stored or executed, so its captures must not count.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;
+
+                private int Counter
+                {
+                    get
+                    {
+                        Func<int> later = () => counter;
+                        _ = later;
+                        return 0;
+                    }
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Counter);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1912,6 +1912,168 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
+    public async Task UnwalkableOutHelper_MakesTheInvokedDelegateUnverifiable()
+    {
+        // The helper assembling the delegate lives in another file: nothing can say what
+        // closure `later` holds at the invoke, and this walk is the only check that closure
+        // will ever get -- unverifiable means flagged.
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(new[]
+        {
+            """
+            public static class External
+            {
+                private static int hits;
+
+                public static void Provide(out System.Func<int> d) => d = () => hits;
+            }
+            """,
+            """
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            External.Provide(out later);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """,
+        }, new OptimisticPatchCaptureAnalyzer());
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("'later'", diagnostic.GetMessage());
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DelegateArgumentAliasedInsideHelper_IsStillChased()
+    {
+        // The helper stores its delegate parameter in a local before invoking it: the chase
+        // hops the alias to the parameter and the parameter to the call-site lambda.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static int Run(Func<int> f)
+                {
+                    var g = f;
+                    return g();
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Run(() => hits));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("hits", diagnostic.GetMessage());
+        Assert.Contains("writable static state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task GetterLocalFunction_Invoked_ReadsMutableField_IsFlagged()
+    {
+        // The computed getter reads the field through a getter-local function it calls
+        // immediately: the indirection must not hide what the direct read would flag.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;
+
+                private int Counter
+                {
+                    get
+                    {
+                        int Read() => counter;
+                        return Read();
+                    }
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Counter);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("counter", diagnostic.GetMessage());
+        Assert.Contains("writable state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OutHelperOverwrite_ChasesOnlyTheFinalDelegate()
+    {
+        // The helper overwrites its out parameter on the straight-line path to its return:
+        // the caller can only ever receive the second delegate, so the first body -- and its
+        // static read -- must not be charged to the patch.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static int hits;
+
+                private static void Provide(out Func<int> d)
+                {
+                    d = () => hits;
+                    d = static () => 0;
+                }
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x =>
+                        {
+                            Func<int> later;
+                            Provide(out later);
+                            return x + later();
+                        });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task CoalesceAssignment_DoesNotStandInAsInitializer()
     {
         // `??=` can leave an older, externally supplied value in place: it must not be

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.CodeAnalysis;
+
+namespace MemoizR.Analyzers.Tests;
+
+// Contracts of MZR004: an optimistic patch's closure captures cross flows (the patch re-runs
+// inside the view's computation on whichever flow pulls), so non-Sendable-typed captures and
+// reads of writable enclosing-object state are flagged; Sendable snapshots -- the idiomatic
+// payload capture -- are not.
+public class OptimisticPatchCaptureAnalyzerTests
+{
+    private static Task<System.Collections.Immutable.ImmutableArray<Diagnostic>> AnalyzeAsync(string source)
+        => AnalyzerTestHarness.AnalyzeAsync(source, new OptimisticPatchCaptureAnalyzer());
+
+    [Fact]
+    public async Task NonSendableLocalCapture_IsFlagged_WithTheStructuralReason()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + shared.Count);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("shared", diagnostic.GetMessage());
+        Assert.Contains("List<int>", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SendableCaptures_AreNotFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public sealed record Item(string Name);
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var label = "x";
+                    var item = new Item("a");
+                    // The idiomatic shape: the payload and immutable snapshots are captured, and
+                    // the patch's own parameter is used freely.
+                    f.CreateAction<string>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + p.Length + label.Length + item.Name.Length);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task EnclosingObjectState_WritableOrNonSendable_IsFlagged_ReadonlyImmutableIsNot()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                private int counter;                        // writable field: flagged
+                private readonly List<int> cache = new();   // readonly, but the List is shared: flagged
+                private readonly string name = "n";         // readonly + Sendable: fine
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + counter + cache.Count + name.Length);
+                    });
+                }
+            }
+            """);
+
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal("MZR004", d.Id));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("counter") && d.GetMessage().Contains("writable state"));
+        Assert.Contains(diagnostics, d => d.GetMessage().Contains("cache") && d.GetMessage().Contains("not Sendable"));
+    }
+
+    [Fact]
+    public async Task EnclosingProperties_SettableIsFlagged_GetOnlySendableIsNot()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public int Threshold { get; set; }   // settable: flagged
+                public string Tag => "t";            // computed get-only, Sendable type: fine
+
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Threshold + Tag.Length);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR004", diagnostic.Id);
+        Assert.Contains("Threshold", diagnostic.GetMessage());
+        Assert.Contains("writable state", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task EachCapturedSymbol_IsReportedOnce_PerPatch()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + shared.Count + shared.Capacity);
+                    });
+                }
+            }
+            """);
+
+        Assert.Single(diagnostics);
+    }
+}

--- a/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/OptimisticPatchCaptureAnalyzerTests.cs
@@ -748,10 +748,11 @@ public class OptimisticPatchCaptureAnalyzerTests
     }
 
     [Fact]
-    public async Task DeconstructionReassignment_IsUnresolvable()
+    public async Task DeconstructionReassignment_SurvivingWriteIsWalked()
     {
-        // `(patch, _) = ...` writes `patch` just as much as `patch = ...`: the tuple
-        // left-hand side must be flattened before comparing symbols.
+        // `(patch, _) = ...` writes `patch` just as much as `patch = ...` -- and it also
+        // definitely OVERWRITES the initializer, so the paired surviving value is walked as
+        // the patch body and its capture of `shared` is what gets flagged.
         var diagnostics = await AnalyzeAsync("""
             using System;
             using System.Collections.Generic;
@@ -776,8 +777,8 @@ public class OptimisticPatchCaptureAnalyzerTests
 
         var diagnostic = Assert.Single(diagnostics);
         Assert.Equal("MZR004", diagnostic.Id);
-        Assert.Contains("'patch'", diagnostic.GetMessage());
-        Assert.Contains("reassigned", diagnostic.GetMessage());
+        Assert.Contains("'shared'", diagnostic.GetMessage());
+        Assert.Contains("not Sendable", diagnostic.GetMessage());
     }
 
     // A static read inside a callback the patch merely BUILDS runs later, off the overlay's
@@ -4453,6 +4454,37 @@ public class OptimisticPatchCaptureAnalyzerTests
                     f.CreateAction<int>(async (p, ctx) =>
                     {
                         await ctx.Apply(state, x => x + d());
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+    [Fact]
+    public async Task RefAliasOutHandoff_SurvivingWriteIsWalked()
+    {
+        // The out handoff rebinds the patch THROUGH a ref alias, definitely overwriting the
+        // unsafe initializer: the helper's safe assignment is the only storable closure.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Collections.Generic;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var state = f.CreateOptimistic<int>(f.CreateSignal(1));
+                    var shared = new List<int>();
+                    static void Provide(out Func<int, int> d) => d = static x => x;
+                    Func<int, int> patch = x => x + shared.Count;
+                    ref var alias = ref patch;
+                    Provide(out alias);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
                     });
                 }
             }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -1665,4 +1665,34 @@ public class SetInsideComputationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task AliasedReturnedPatch_IsResolved()
+    {
+        // The factory parks the patch in a local alias before returning it: the return
+        // resolves through the alias and the parameter back to the call-site lambda, whose
+        // Set runs under the evaluation lock like any inline patch's.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int, int> Make(Func<int, int> p) { var q = p; return q; }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Make(x => { _ = v.Set(2); return x; }));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -771,6 +771,65 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task SignalParameterRebound_ResolvesTheAssignedFactory()
+    {
+        // The helper unconditionally rebinds its parameter before the Set: the target is
+        // provably f2's signal regardless of what the caller passed.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var mine = f1.CreateSignal(1);
+                    void Write(Signal<int> s)
+                    {
+                        s = f2.CreateSignal(0);
+                        _ = s.Set(2);
+                    }
+                    f1.CreateMemoizR(async () => { Write(mine); return 0; });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task FactoryParameterProvenance_IsSubstituted()
+    {
+        // The helper CREATES the target through its factory parameter: the call-site factory
+        // argument is the provenance, so the disjoint-factory call is suppressed while the
+        // host factory's own call is still flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    void Write(MemoFactory f)
+                    {
+                        var s = f.CreateSignal(0);
+                        _ = s.Set(1);
+                    }
+                    f1.CreateMemoizR(async () => { Write(f2); return 0; });
+                    f1.CreateMemoizR(async () => { Write(f1); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task IndexerSetterArguments_KeepCallSiteProvenance()
     {
         // The Set target is the indexer's index parameter: the call-site index argument (a

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -647,6 +647,86 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task FirstAssignedState_ProvesTheHostFactory()
+    {
+        // Declaration in two steps: the sole assignment is the initialization, so the
+        // cross-factory suppression still applies.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+            using MemoizR.Reactive;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    OptimisticState<int> state;
+                    state = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DeadLocalFunctionRebind_KeepsTheSuppression()
+    {
+        // Rebind is declared but never referenced: dead code cannot execute, so the factory
+        // alias's initializer still proves provenance. The moment it IS invoked, execution
+        // order becomes unknowable and the diagnostic returns.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var host = f1;
+                    void Rebind() { host = f2; }
+                    var other = f2.CreateSignal(1);
+                    host.CreateMemoizR(async () => { await other.Set(2); return 0; });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task InvokedLocalFunctionRebind_KeepsTheDiagnostic()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var host = f1;
+                    void Rebind() { host = f2; }
+                    Rebind();
+                    var other = f2.CreateSignal(1);
+                    host.CreateMemoizR(async () => { await other.Set(2); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task ReassignedFactoryAlias_KeepsTheDiagnostic()
     {
         // `host` holds f2 at the creation, not its f1 initializer: the stale alias must not

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -903,6 +903,143 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task SetInsideAnIndexerPatch_KeepsCallSiteProvenance()
+    {
+        // The indexer's returned lambda writes through the index parameter: the call-site
+        // signal decides, exactly like a helper argument.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private Func<int, int> this[Signal<int> s]
+                {
+                    get
+                    {
+                        return x => { _ = s.Set(1); return x; };
+                    }
+                }
+
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var mine = f1.CreateSignal(1);
+                    var state = f1.CreateOptimistic<int>(mine);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, this[other]);
+                    });
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, this[mine]);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SetInsideAForwardedDelegateParameter_IsFlagged()
+    {
+        // The out-helper hands back its OTHER delegate parameter: the call-site lambda with
+        // the Set is what the overlay stores.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    void Provide(Func<int, int> source, out Func<int, int> p) => p = source;
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(x => { _ = v.Set(2); return x; }, out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SetInsideAFactoryReturnedPatch_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var mine = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(mine);
+                    Func<int, int> Make(Signal<int> s) => x => { _ = s.Set(1); return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Make(mine));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task OverwrittenOutHelperPatchBody_IsNotWalked()
+    {
+        // The helper's stale Set-lambda is definitely overwritten before it returns: only
+        // the safe second delegate can be the stored patch.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    void Provide(out Func<int, int> p)
+                    {
+                        p = x => { _ = v.Set(2); return x; };
+                        p = static x => x;
+                    }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task SetInsideAComputedPropertyPatch_IsFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -559,6 +559,96 @@ public class SetInsideComputationAnalyzerTests
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
 
+    // A constructor the patch executes Sets under the same evaluation lock: non-invocation
+    // syntax (new, getters, operators) must not evade the chase.
+    [Fact]
+    public async Task SetHiddenInAConstructor_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Writer
+            {
+                public Writer(Signal<int> target) { _ = target.Set(2); }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = new Writer(v); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DeconstructionReassignedState_KeepsTheDiagnostic()
+    {
+        // `(state, _) = ...` rebinds state to another factory's view before the call: the
+        // stale initializer must not prove provenance.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        var state = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                        (state, _) = (f2.CreateOptimistic<int>(f2.CreateSignal(2)), 0);
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task StateReassignedAfterTheCall_KeepsTheSuppression()
+    {
+        // The reassignment is straight-line AFTER the Apply read: the value already passed
+        // came from the f1 initializer, so the provably-disjoint suppression must hold.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        var state = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                        state = f1.CreateOptimistic<int>(f1.CreateSignal(2));
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
     [Fact]
     public async Task ReassignedStateAlias_KeepsTheDiagnostic()
     {

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -676,6 +676,94 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task HelperArgumentProvenance_IsSubstituted()
+    {
+        // The chased Set's target is the helper's parameter: the call-site argument `other`
+        // (a provably disjoint factory's signal) is what actually gets Set, exactly as the
+        // inline form -- the suppression must survive the helper boundary.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    void Write(Signal<int> s) { _ = s.Set(2); }
+                    f1.CreateMemoizR(async () => { Write(other); return 0; });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    // `using` runs Dispose before the evaluation exits, under the same lock.
+    [Fact]
+    public async Task SetHiddenInDispose_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class Writer : IDisposable
+            {
+                private readonly Signal<int> target;
+
+                public Writer(Signal<int> target) { this.target = target; }
+
+                public void Dispose() { _ = target.Set(2); }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    f.CreateMemoizR(async () =>
+                    {
+                        using var w = new Writer(v);
+                        return 0;
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task RebindCalledOnlyAfterTheCreation_KeepsTheSuppression()
+    {
+        // Rebind's only call site runs after the creation already used the initializer's
+        // factory: the write cannot precede the read.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var host = f1;
+                    void Rebind() { host = f2; }
+                    var other = f2.CreateSignal(1);
+                    host.CreateMemoizR(async () => { await other.Set(2); return 0; });
+                    Rebind();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task DeadLocalFunctionRebind_KeepsTheSuppression()
     {
         // Rebind is declared but never referenced: dead code cannot execute, so the factory

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -2339,4 +2339,73 @@ public class SetInsideComputationAnalyzerTests
         Assert.Equal("MZR003", diagnostic.Id);
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task ParameterAssignedPatch_SetIsFlagged()
+    {
+        // The patch lives in a PARAMETER slot assigned before Apply: the assignment
+        // dominates the read, so the factory-returned body is what replays.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private readonly MemoFactory f = new();
+
+                public void M(Func<int, int> patch)
+                {
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int, int> Make(Signal<int> s) => x => { _ = s.Set(2); return x; };
+                    patch = Make(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ConditionallyReboundInvokedParameter_KeepsTheCallerDelegate()
+    {
+        // The helper rebinds its delegate parameter only on one path: the caller's delegate
+        // still runs on the other, so its Set is a candidate.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    static int Run(Func<int> g, bool replace)
+                    {
+                        if (replace)
+                        {
+                            g = static () => 0;
+                        }
+
+                        return g();
+                    }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Run(() => { _ = v.Set(2); return 0; }, false));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -830,6 +830,34 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task SetInsideAConditionalComputationArm_IsFlagged()
+    {
+        // The conditional picks one of two computations at build time: either arm can be
+        // the body the factory stores, so a Set inside one must not hide behind the ternary.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using System.Threading.Tasks;
+            using MemoizR;
+
+            public class C
+            {
+                public void M(bool choose)
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    f.CreateMemoizR(choose
+                        ? (Func<Task<int>>)(async () => { _ = v.Set(2); return 1; })
+                        : async () => 2);
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task FactoryAliasInsideHelper_KeepsCallSiteProvenance()
     {
         // The helper aliases its factory parameter before creating the signal: the

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -1987,4 +1987,192 @@ public class SetInsideComputationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task SetInInvokedComputedPropertyDelegate_IsFlagged()
+    {
+        // The patch invokes the delegate a computed property hands back: the getter-returned
+        // lambda executes under the same evaluation lock, so its Set throws.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private readonly MemoFactory f = new();
+                private readonly Signal<int> v;
+
+                private Func<int> Step
+                {
+                    get
+                    {
+                        return () => { _ = v.Set(2); return 0; };
+                    }
+                }
+
+                public C()
+                {
+                    v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + Step());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ConditionalReturnFactoryArm_IsChased()
+    {
+        // The factory's return picks an arm at Apply time: the direct safe arm must not
+        // silence the factory-call arm, whose returned lambda Sets under the lock.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int, int> Make() => x => { _ = v.Set(1); return x; };
+                    Func<int, int> Get(bool flag) { return flag ? Make() : static x => x; }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Get(true));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ConditionalPatchFactoryArm_IsChased()
+    {
+        // The Apply argument itself is conditional: the factory-call arm can be the stored
+        // patch, so its returns are chased even though the other arm resolves directly.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int, int> Make() => x => { _ = v.Set(1); return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, p > 0 ? Make() : static x => x);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ComputedIndexerState_KeepsCrossFactoryProof()
+    {
+        // The Apply state comes from a computed indexer: the getter's return resolves with
+        // the call-site factory bound to the index parameter, proving the Set cross-context.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+            using MemoizR.Reactive;
+
+            public class C
+            {
+                private OptimisticState<int> this[MemoFactory f] => f.CreateOptimistic<int>(f.CreateSignal(1));
+
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(this[f1], x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ComputedSignalTargetProperty_KeepsCrossFactoryProof()
+    {
+        // The Set target is a computed signal property whose getter always builds on the
+        // disjoint unkeyed factory: the Set locks that other context and cannot throw here.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static readonly MemoFactory f2 = new MemoFactory();
+
+                private static Signal<int> Other => f2.CreateSignal(1);
+
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var state = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = Other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task SetInDeconstructionOverwrittenInitializer_IsNotFlagged()
+    {
+        // The deconstruction definitely overwrites the mutating initializer before Apply:
+        // only the paired safe value can be stored, so the stale Set is not charged.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = x => { _ = v.Set(2); return x; };
+                        (patch, _) = ((Func<int, int>)(static x => x), 0);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -830,6 +830,38 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task FactoryAliasInsideHelper_KeepsCallSiteProvenance()
+    {
+        // The helper aliases its factory parameter before creating the signal: the
+        // call-site factory is still the provenance, so the disjoint call is suppressed
+        // while the host factory's own call stays flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    void Write(MemoFactory f)
+                    {
+                        var host = f;
+                        var s = host.CreateSignal(0);
+                        _ = s.Set(1);
+                    }
+                    f1.CreateMemoizR(async () => { Write(f2); return 0; });
+                    f1.CreateMemoizR(async () => { Write(f1); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task IndexerSetterArguments_KeepCallSiteProvenance()
     {
         // The Set target is the indexer's index parameter: the call-site index argument (a

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -592,6 +592,63 @@ public class SetInsideComputationAnalyzerTests
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
 
+    // A property assignment executes the SETTER: a Set inside one throws under the same
+    // evaluation lock as an inline Set.
+    [Fact]
+    public async Task SetHiddenInAPropertySetter_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private static readonly MemoFactory F = new();
+                private static readonly Signal<int> V = F.CreateSignal(1);
+
+                private static int P { get => 0; set { _ = V.Set(2); } }
+
+                public void M()
+                {
+                    F.CreateMemoizR(async () => { P = 1; return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task RefAliasReboundState_KeepsTheDiagnostic()
+    {
+        // The state is rebound through a ref alias to another factory's view: the stale
+        // initializer must not prove provenance.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var state = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                    ref var alias = ref state;
+                    alias = f2.CreateOptimistic<int>(f2.CreateSignal(2));
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
     [Fact]
     public async Task DeconstructionReassignedState_KeepsTheDiagnostic()
     {

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -734,6 +734,70 @@ public class SetInsideComputationAnalyzerTests
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
 
+    [Fact]
+    public async Task ExtensionHelperReceiver_KeepsCallSiteProvenance()
+    {
+        // The Set target is the extension helper's `this` parameter: the receiver at the
+        // call site (a provably disjoint factory's signal) is what actually gets Set, while
+        // the same helper on the HOST factory's own signal is still flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public static class SignalExtensions
+            {
+                public static void Write(this Signal<int> s)
+                {
+                    _ = s.Set(2);
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var mine = f1.CreateSignal(1);
+                    f1.CreateMemoizR(async () => { other.Write(); return 0; });
+                    f1.CreateMemoizR(async () => { mine.Write(); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ZeroArgumentLocalFunction_KeepsTheArgumentMap()
+    {
+        // The helper's local function closes over the helper's signal parameter: the
+        // call-site provenance must survive the zero-argument inner call.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    void Write(Signal<int> s)
+                    {
+                        void Inner() { _ = s.Set(2); }
+                        Inner();
+                    }
+                    f1.CreateMemoizR(async () => { Write(other); return 0; });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
     // `using` runs Dispose before the evaluation exits, under the same lock.
     [Fact]
     public async Task SetHiddenInDispose_IsFlagged()

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -862,6 +862,47 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task SetInsideAnOutAssembledPatch_KeepsCallSiteProvenance()
+    {
+        // The assembled patch writes through the helper's signal parameter: the call-site
+        // argument decides -- a disjoint factory's signal is suppressed, the host factory's
+        // own is flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var mine = f1.CreateSignal(1);
+                    var state = f1.CreateOptimistic<int>(mine);
+                    void Provide(Signal<int> s, out Func<int, int> p) => p = x => { _ = s.Set(1); return x; };
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(other, out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(mine, out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task SetInsideAComputedPropertyPatch_IsFlagged()
     {
         var diagnostics = await AnalyzeAsync("""

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -531,6 +531,34 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task AliasedStateArgument_ProvesTheHostFactory()
+    {
+        // The state reaches Apply through a variable-to-variable alias: provenance must chase
+        // initializers until the creation, or disjoint factories would keep a false warning.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var s0 = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                    var state = s0;
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task ProvablyCrossFactorySetInsidePatch_IsNotFlagged()
     {
         // A patch's flow locks the context of the factory that created the OPTIMISTIC STATE

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -493,4 +493,33 @@ public class SetInsideComputationAnalyzerTests
         Assert.Equal("MZR003", diagnostic.Id);
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
+
+    [Fact]
+    public async Task ProvablyCrossFactorySetInsidePatch_IsNotFlagged()
+    {
+        // A patch's flow locks the context of the factory that created the OPTIMISTIC STATE
+        // (the Apply receiver is the action context, which belongs to no factory), so the
+        // cross-factory suppression must resolve the host from the state argument: the Set
+        // targets f2's context while the patch evaluates under f1's.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var state = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -1800,4 +1800,100 @@ public class SetInsideComputationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task SetInInvokedCapturedDelegate_IsFlagged()
+    {
+        // The patch synchronously invokes a captured delegate: its body executes under the
+        // same evaluation lock, so the Set throws exactly like an inline one.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int, int> d = x => { _ = v.Set(2); return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => d(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SetInOverwrittenStaleInitializer_IsNotFlagged()
+    {
+        // The mutating initializer is definitely overwritten before Apply: the overlay can
+        // only store the safe overwrite, so the stale Set must not be charged to this call.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = x => { _ = v.Set(2); return x; };
+                        patch = static x => x;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task NestedFactoryReturnedPatch_KeepsCallSiteProvenance()
+    {
+        // Make forwards its signal into Inner, whose returned patch writes it: the nested
+        // map proves the disjoint factory's signal safe, while the host factory's own stays
+        // flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var mine = f1.CreateSignal(1);
+                    var state = f1.CreateOptimistic<int>(mine);
+                    Func<int, int> Inner(Signal<int> t) => x => { _ = t.Set(1); return x; };
+                    Func<int, int> Make(Signal<int> s) { return Inner(s); }
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Make(other));
+                    });
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Make(mine));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -786,6 +786,38 @@ public class SetInsideComputationAnalyzerTests
         Assert.Equal("MZR003", diagnostic.Id);
     }
 
+    // `Changed += handler` executes the custom add accessor immediately, under the same
+    // evaluation lock as the computation itself.
+    [Fact]
+    public async Task SetHiddenInACustomEventAccessor_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private static readonly MemoFactory F = new();
+                private static readonly Signal<int> V = F.CreateSignal(1);
+
+                private static event Action Changed
+                {
+                    add { _ = V.Set(2); }
+                    remove { }
+                }
+
+                public void M()
+                {
+                    F.CreateMemoizR(async () => { Changed += () => { }; return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
     [Fact]
     public async Task DeconstructionReassignedState_KeepsTheDiagnostic()
     {

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -738,6 +738,121 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task InterfaceDeclaredUsingResource_ChasesTheConcreteDispose()
+    {
+        // The initializer's type beats the declared interface: Writer.Dispose is what runs.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class Writer : IDisposable
+            {
+                private readonly Signal<int> target;
+
+                public Writer(Signal<int> target) { this.target = target; }
+
+                public void Dispose() { _ = target.Set(2); }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    f.CreateMemoizR(async () =>
+                    {
+                        using IDisposable w = new Writer(v);
+                        return 0;
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task SetterValueParameter_SubstitutesTheAssignedSignal()
+    {
+        // `P = other` runs the setter with value = other, a provably disjoint factory's
+        // signal: the suppression must survive the accessor boundary.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                private static Signal<int> P { get => null!; set { _ = value.Set(2); } }
+
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    f1.CreateMemoizR(async () => { P = other; return 0; });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task HelperRewalkedPerCallSite_CatchesTheSameFactoryCall()
+    {
+        // The first (suppressed, cross-factory) call must not cache away the second call,
+        // whose same-factory Set throws.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var v = f1.CreateSignal(1);
+                    void Write(Signal<int> s) { _ = s.Set(2); }
+                    f1.CreateMemoizR(async () => { Write(other); Write(v); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task LiftedRebind_InvokedOnlyAfterTheCreation_KeepsTheSuppression()
+    {
+        // The method-group lift is not execution: the delegate's only invocation runs after
+        // the creation already used the initializer's factory.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var host = f1;
+                    void Rebind() { host = f2; }
+                    Action later = Rebind;
+                    var other = f2.CreateSignal(1);
+                    host.CreateMemoizR(async () => { await other.Set(2); return 0; });
+                    later();
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task RebindCalledOnlyAfterTheCreation_KeepsTheSuppression()
     {
         // Rebind's only call site runs after the creation already used the initializer's

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -700,6 +700,40 @@ public class SetInsideComputationAnalyzerTests
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public async Task SignalParameterAliasedInsideHelper_ResolvesThroughTheCallSite()
+    {
+        // The helper stores its parameter in a local before the Set: the alias resolves to
+        // the parameter and the parameter to the call-site argument, so the cross-factory
+        // suppression survives -- while the same helper called with the HOST factory's own
+        // signal is still flagged (per-call-site provenance, not per-helper).
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var mine = f1.CreateSignal(1);
+                    void Write(Signal<int> s)
+                    {
+                        var a = s;
+                        _ = a.Set(2);
+                    }
+                    f1.CreateMemoizR(async () => { Write(other); return 0; });
+                    f1.CreateMemoizR(async () => { Write(mine); return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
     // `using` runs Dispose before the evaluation exits, under the same lock.
     [Fact]
     public async Task SetHiddenInDispose_IsFlagged()

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -620,6 +620,63 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task DeconstructionDeclaredState_ProvesTheHostFactory()
+    {
+        // `var (state, _) = (f1.CreateOptimistic(...), 0)` declares through a designation: the
+        // creation is right there in the tuple, so cross-factory suppression must still apply.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var (state, _) = (f1.CreateOptimistic<int>(f1.CreateSignal(1)), 0);
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ReassignedFactoryAlias_KeepsTheDiagnostic()
+    {
+        // `host` holds f2 at the creation, not its f1 initializer: the stale alias must not
+        // prove cross-factory disjointness for a Set that throws on f2's context.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var host = f1;
+                    host = f2;
+                    var v = f2.CreateSignal(0);
+                    var state = host.CreateOptimistic<int>(v);
+                    f2.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = v.Set(1); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task RefAliasReboundState_KeepsTheDiagnostic()
     {
         // The state is rebound through a ref alias to another factory's view: the stale

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -1896,4 +1896,95 @@ public class SetInsideComputationAnalyzerTests
         Assert.Equal("MZR003", diagnostic.Id);
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task SetInNullConditionalInvokedDelegate_IsFlagged()
+    {
+        // `d?.Invoke()` still executes the delegate under the evaluation lock when non-null:
+        // the conditional-access placeholder resolves to the real delegate expression.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int> d = () => { _ = v.Set(1); return 0; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { d?.Invoke(); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SetInFactoryReturnedInvokedDelegate_IsFlagged()
+    {
+        // `Get()(x)` runs whatever the same-tree factory returned, immediately and under
+        // the same lock: the returned lambda's Set throws like an inline one.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int, int> Get() => x => { _ = v.Set(1); return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => Get()(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ComputedStateProperty_KeepsCrossFactoryProof()
+    {
+        // The Apply state comes from a computed property whose getter always builds on f1:
+        // the Set targets a disjoint unkeyed factory's signal, so it locks another context
+        // and cannot throw here.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+            using MemoizR.Reactive;
+
+            public class C
+            {
+                private static readonly MemoFactory f1 = new MemoFactory();
+
+                private static OptimisticState<int> State => f1.CreateOptimistic<int>(f1.CreateSignal(1));
+
+                public void M()
+                {
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(State, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -2276,4 +2276,67 @@ public class SetInsideComputationAnalyzerTests
         Assert.Equal("MZR003", diagnostic.Id);
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task ConditionalInvokedCalleeFactoryArm_IsChased()
+    {
+        // One callee arm resolves directly; the other is a factory call whose returned
+        // lambda Sets. The resolvable arm must not account for its sibling.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int> Make() => () => { _ = v.Set(2); return 0; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => x + (p > 0 ? static () => 0 : Make())());
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task NamedInvokeArguments_BindByParameter()
+    {
+        // The invoke names its arguments out of declaration order: `mine` must bind to the
+        // host factory's signal, which is what makes this Set throw.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public delegate void Step(Signal<int> mine, Signal<int> other);
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var remote = f2.CreateSignal(1);
+                    var local = f1.CreateSignal(1);
+                    var state = f1.CreateOptimistic<int>(local);
+                    Step step = (mine, other) => { _ = mine.Set(2); };
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { step(other: remote, mine: local); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -530,6 +530,65 @@ public class SetInsideComputationAnalyzerTests
         Assert.Equal("MZR003", diagnostic.Id);
     }
 
+    // A helper the computation CALLS executes its Set under the same evaluation lock: hiding
+    // the write behind a local function must not evade the diagnostic.
+    [Fact]
+    public async Task SetHiddenInALocalHelper_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    void Write() { _ = v.Set(2); }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { Write(); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task ReassignedStateAlias_KeepsTheDiagnostic()
+    {
+        // The state variable is reassigned from another factory before the call: the stale
+        // initializer must not prove provenance, or the suppression would drop a diagnostic
+        // the runtime contradicts.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var state = f1.CreateOptimistic<int>(f1.CreateSignal(1));
+                    state = f2.CreateOptimistic<int>(f2.CreateSignal(1));
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
     [Fact]
     public async Task AliasedStateArgument_ProvesTheHostFactory()
     {

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -2175,4 +2175,105 @@ public class SetInsideComputationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+    [Fact]
+    public async Task ConditionalComputedStateGetter_KeepsCrossFactoryProof()
+    {
+        // Every arm of the computed state getter builds on f1: the host context is provable
+        // even though the getter returns a conditional, so the disjoint Set cannot throw.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+            using MemoizR.Reactive;
+
+            public class C
+            {
+                private static readonly MemoFactory f1 = new MemoFactory();
+
+                private bool flag;
+
+                private OptimisticState<int> State => flag
+                    ? f1.CreateOptimistic<int>(f1.CreateSignal(1))
+                    : f1.CreateOptimistic<int>(f1.CreateSignal(2));
+
+                public void M()
+                {
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(State, x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task InvokedDelegateSignalArgument_KeepsCallSiteProvenance()
+    {
+        // The invoked delegate's parameter binds to the call's argument: the disjoint
+        // factory's signal is proven cross-context, while the host's own stays flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var mine = f1.CreateSignal(1);
+                    var state = f1.CreateOptimistic<int>(mine);
+                    Action<Signal<int>> step = s => { _ = s.Set(2); };
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { step(other); return x; });
+                    });
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { step(mine); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task InvokedFactoryInitializedDelegate_SetIsFlagged()
+    {
+        // The invoked local was initialized from a same-tree factory: the returned lambda
+        // executes under the evaluation lock, so its Set throws.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    Func<int, int> Make() => x => { _ = v.Set(2); return x; };
+                    Func<int, int> d = Make();
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => d(x));
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -495,6 +495,42 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task HelperReturnedState_DoesNotProveTheHostFactory()
+    {
+        // MakeState merely RETURNS a state: its receiver (f1) says nothing about which factory
+        // created it -- here it is really F2's, whose context the patch evaluates under, so the
+        // Set on F2's signal throws at runtime and the suppression must not trust the helper.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+            using MemoizR.Reactive;
+
+            public static class StateHelpers
+            {
+                public static readonly MemoFactory F2 = new MemoFactory();
+
+                public static OptimisticState<int> MakeState(this MemoFactory f)
+                    => F2.CreateOptimistic<int>(F2.CreateSignal(1));
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var other = StateHelpers.F2.CreateSignal(1);
+                    f1.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(f1.MakeState(), x => { _ = other.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task ProvablyCrossFactorySetInsidePatch_IsNotFlagged()
     {
         // A patch's flow locks the context of the factory that created the OPTIMISTIC STATE

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -771,6 +771,43 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task IndexerSetterArguments_KeepCallSiteProvenance()
+    {
+        // The Set target is the indexer's index parameter: the call-site index argument (a
+        // provably disjoint factory's signal) is what actually gets Set, while the same
+        // indexer fed the HOST factory's own signal is still flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class Wrapper
+            {
+                public int this[Signal<int> s]
+                {
+                    set { _ = s.Set(value); }
+                }
+            }
+
+            public class C
+            {
+                public void M()
+                {
+                    var f1 = new MemoFactory();
+                    var f2 = new MemoFactory();
+                    var other = f2.CreateSignal(1);
+                    var mine = f1.CreateSignal(1);
+                    var wrapper = new Wrapper();
+                    f1.CreateMemoizR(async () => { wrapper[other] = 1; return 0; });
+                    f1.CreateMemoizR(async () => { wrapper[mine] = 1; return 0; });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task ZeroArgumentLocalFunction_KeepsTheArgumentMap()
     {
         // The helper's local function closes over the helper's signal parameter: the

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -1695,4 +1695,109 @@ public class SetInsideComputationAnalyzerTests
         Assert.Equal("MZR003", diagnostic.Id);
         Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
     }
+    [Fact]
+    public async Task AliasedComputedPropertyPatch_SetIsFlagged()
+    {
+        // The patch is copied out of the computed property before Apply: the alias resolves
+        // to the getter's returned lambda, whose Set throws under the evaluation lock.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private readonly MemoFactory f = new();
+                private readonly Signal<int> v;
+
+                private Func<int, int> Patch
+                {
+                    get
+                    {
+                        return x => { _ = v.Set(2); return x; };
+                    }
+                }
+
+                public C()
+                {
+                    v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = Patch;
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SetInSurvivingRebindPatch_IsFlagged()
+    {
+        // The declaration initializer is definitely overwritten before Apply: the surviving
+        // write's lambda is the stored patch, and its Set throws exactly like an inline one.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch = static x => x;
+                        patch = x => { _ = v.Set(2); return x; };
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SetInsideOverwrittenForwardedHandoff_IsNotFlagged()
+    {
+        // Build's assembled delegate is definitely overwritten before Provide returns: its
+        // Set can never be the stored patch, so it must not be flagged.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    void Build(out Func<int, int> d) => d = x => { _ = v.Set(2); return x; };
+                    void Provide(out Func<int, int> d)
+                    {
+                        Build(out d);
+                        d = static x => x;
+                    }
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
 }

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -830,6 +830,75 @@ public class SetInsideComputationAnalyzerTests
     }
 
     [Fact]
+    public async Task SetInsideAnOutAssembledPatch_IsFlagged()
+    {
+        // The patch assembled by the out-helper runs inside the view's evaluation lock: its
+        // Set throws exactly like an inline patch's.
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    void Provide(out Func<int, int> d) => d = x => { _ = v.Set(2); return x; };
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        Func<int, int> patch;
+                        Provide(out patch);
+                        await ctx.Apply(state, patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task SetInsideAComputedPropertyPatch_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using System;
+            using MemoizR;
+
+            public class C
+            {
+                private readonly MemoFactory f = new();
+                private readonly Signal<int> v;
+
+                private Func<int, int> Patch
+                {
+                    get
+                    {
+                        return x => { _ = v.Set(2); return x; };
+                    }
+                }
+
+                public C()
+                {
+                    v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, Patch);
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
+
+    [Fact]
     public async Task SetInsideAConditionalComputationArm_IsFlagged()
     {
         // The conditional picks one of two computations at build time: either arm can be

--- a/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
+++ b/MemoizR.Analyzers.Tests/SetInsideComputationAnalyzerTests.cs
@@ -465,4 +465,32 @@ public class SetInsideComputationAnalyzerTests
 
         Assert.Empty(diagnostics);
     }
+
+    // A patch runs inside the view memo's recompute, whose flow holds the evaluation lock in
+    // upgradeable mode -- a Set in one throws exactly like a Set in the memo's own computation.
+    [Fact]
+    public async Task SetInsideOptimisticPatch_IsFlagged()
+    {
+        var diagnostics = await AnalyzeAsync("""
+            using MemoizR;
+
+            public class C
+            {
+                public void M()
+                {
+                    var f = new MemoFactory();
+                    var v = f.CreateSignal(1);
+                    var state = f.CreateOptimistic<int>(v);
+                    f.CreateAction<int>(async (p, ctx) =>
+                    {
+                        await ctx.Apply(state, x => { _ = v.Set(2); return x; });
+                    });
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MZR003", diagnostic.Id);
+        Assert.Contains("Signal<int>.Set", diagnostic.GetMessage());
+    }
 }

--- a/MemoizR.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/MemoizR.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 MZR001  | Concurrency | Warning | Value type shared by the reactive graph is not Sendable
 MZR002  | Concurrency | Warning | Reactive computation mutates state shared with code outside it
 MZR003  | Concurrency | Warning | Signal.Set inside a reactive computation throws at runtime
+MZR004  | Concurrency | Warning | Optimistic patch captures non-Sendable state

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -43,10 +43,10 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             {
                 foreach (var target in MutationTargets(operation))
                 {
-                    ReportIfShared(context, target, computation.Scope, computation.Scope);
+                    ReportIfShared(context, target, computation.Scope, computation.Scope, thisParameter: null);
                 }
 
-                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedLocalFunctions);
+                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedLocalFunctions, thisParameter: null);
             }
         }
     }
@@ -55,21 +55,26 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // FUNCTION's closure IS the computation's environment (`int Next() { applied++; ... }`),
     // and a method invoked on THIS or statically (`void Inc() => counter++;`) mutates the
     // enclosing object/static state on every run -- shapes MZR004 cannot carry (a Sendable
-    // type or int hides them; the WRITE is the race). A method on any OTHER receiver stays
-    // unchased: its writes mutate that object's state, a captured-reference mutation that is
-    // deliberately MZR001's territory. Bodies resolve same-tree, the visited set bounds call
-    // cycles, and the helper's own per-call locals stay exempt via the enclosing-function
-    // guard in ReportIfShared.
+    // type or int hides them; the WRITE is the race). An EXTENSION method whose receiver
+    // argument is `this` is the same helper in disguise: its receiver parameter IS the
+    // enclosing instance for the walked body (`this.Inc()` with `Inc(this C c) =>
+    // c.Counter++` mutates it like `this.Counter++`), so that parameter is carried as the
+    // body's `this`. A method (extension or not) on any OTHER receiver stays unchased: its
+    // writes mutate that object's state, a captured-reference mutation that is deliberately
+    // MZR001's territory. Bodies resolve same-tree, the visited set bounds call cycles, and
+    // the helper's own per-call locals stay exempt via the enclosing-function guard in
+    // ReportIfShared.
     private static void InspectCalledHelper(
         OperationAnalysisContext context,
         IOperation operation,
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
-        HashSet<IMethodSymbol> visited)
+        HashSet<IMethodSymbol> visited,
+        IParameterSymbol? thisParameter)
     {
         var method = operation switch
         {
-            IInvocationOperation call when IsChaseableReceiver(call) => call.TargetMethod,
+            IInvocationOperation call when IsChaseableReceiver(call, thisParameter) => call.TargetMethod,
             IMethodReferenceOperation { Method.MethodKind: MethodKind.LocalFunction } reference => reference.Method,
             _ => null,
         };
@@ -83,21 +88,51 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        var nestedThis = NestedThisParameter(operation, thisParameter);
         foreach (var inner in ComputationLambdas.Descend(helper.Body))
         {
             foreach (var target in MutationTargets(inner))
             {
-                ReportIfShared(context, target, helper.Scope, computationScope);
+                ReportIfShared(context, target, helper.Scope, computationScope, nestedThis);
             }
 
-            InspectCalledHelper(context, inner, computationScope, semanticModel, visited);
+            InspectCalledHelper(context, inner, computationScope, semanticModel, visited, nestedThis);
         }
     }
 
-    private static bool IsChaseableReceiver(IInvocationOperation call)
+    private static bool IsChaseableReceiver(IInvocationOperation call, IParameterSymbol? thisParameter)
     {
-        return call.Instance is null
-            || call.Instance is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance };
+        return call.Instance is null || IsEnclosingInstance(call.Instance, thisParameter);
+    }
+
+    // The `this` identity for a chased body. An extension invocation rebinds it: the
+    // receiver parameter when the receiver argument is the enclosing instance (directly, or
+    // through the current body's own receiver parameter), nothing otherwise -- an extension
+    // on another object must not have its receiver writes counted. Every other chase keeps
+    // the current binding: a local function nested in an extension body still closes over
+    // the extension's receiver parameter, while bodies that cannot name it are unaffected.
+    private static IParameterSymbol? NestedThisParameter(IOperation operation, IParameterSymbol? thisParameter)
+    {
+        if (operation is not IInvocationOperation { TargetMethod: { IsExtensionMethod: true } method } call)
+        {
+            return thisParameter;
+        }
+
+        var receiver = call.Arguments.FirstOrDefault(argument => argument.Parameter?.Ordinal == 0)?.Value;
+        while (receiver is IConversionOperation conversion)
+        {
+            receiver = conversion.Operand;
+        }
+
+        return IsEnclosingInstance(receiver, thisParameter) ? method.Parameters.FirstOrDefault() : null;
+    }
+
+    private static bool IsEnclosingInstance(IOperation? receiver, IParameterSymbol? thisParameter)
+    {
+        return receiver is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance }
+            || (receiver is IParameterReferenceOperation parameter
+                && thisParameter is not null
+                && SymbolEqualityComparer.Default.Equals(parameter.Parameter, thisParameter));
     }
 
     private static ImmutableArray<IOperation> MutationTargets(IOperation operation)
@@ -190,9 +225,9 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         return targets.ToImmutable();
     }
 
-    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope)
+    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope, IParameterSymbol? thisParameter)
     {
-        var (kind, symbol) = ResolveSharedRoot(target, scope);
+        var (kind, symbol) = ResolveSharedRoot(target, scope, thisParameter);
         if (kind is null || !SharesComputationEnvironment(symbol!, computationScope))
         {
             return;
@@ -221,7 +256,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // all resolve to the shared field/local being mutated. Returns (null, null) when the target is a
     // member of some OTHER reference object (mutation through a captured reference -- MZR001's
     // territory, the value type there should be Sendable).
-    private static (string? kind, ISymbol? symbol) ResolveSharedRoot(IOperation target, SyntaxNode scope)
+    private static (string? kind, ISymbol? symbol) ResolveSharedRoot(IOperation target, SyntaxNode scope, IParameterSymbol? thisParameter)
     {
         switch (target)
         {
@@ -232,38 +267,39 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             case IFieldReferenceOperation { Field.IsStatic: true } staticField:
                 return ("static field", staticField.Field);
             case IFieldReferenceOperation field:
-                return ResolveThroughReceiver(field.Instance, "field", field.Field, scope);
+                return ResolveThroughReceiver(field.Instance, "field", field.Field, scope, thisParameter);
             case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
                 return ("static property", staticProperty.Property);
             case IPropertyReferenceOperation property:
-                return ResolveThroughReceiver(property.Instance, "property", property.Property, scope);
+                return ResolveThroughReceiver(property.Instance, "property", property.Property, scope, thisParameter);
             case IEventReferenceOperation { Event.IsStatic: true } staticEvent:
                 return ("static event", staticEvent.Event);
             case IEventReferenceOperation @event:
-                return ResolveThroughReceiver(@event.Instance, "event", @event.Event, scope);
+                return ResolveThroughReceiver(@event.Instance, "event", @event.Event, scope, thisParameter);
             default:
                 return (null, null);
         }
     }
 
-    // A member on `this` is reported as the member. A member on a value-type receiver that is
-    // itself shared storage (a captured struct local/parameter, or a nested value-type
+    // A member on `this` -- or on an extension body's receiver parameter bound to `this` --
+    // is reported as the member. A member on a value-type receiver that is itself shared
+    // storage (a captured struct local/parameter, or a nested value-type
     // field/property/this) reports that RECEIVER -- mutating the member mutates the receiver's
     // storage. A member on any other (reference) receiver is left to MZR001.
-    private static (string? kind, ISymbol? symbol) ResolveThroughReceiver(IOperation? receiver, string memberKind, ISymbol member, SyntaxNode scope)
+    private static (string? kind, ISymbol? symbol) ResolveThroughReceiver(IOperation? receiver, string memberKind, ISymbol member, SyntaxNode scope, IParameterSymbol? thisParameter)
     {
         switch (receiver)
         {
-            case IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance }:
+            case var enclosing when IsEnclosingInstance(enclosing, thisParameter):
                 return (memberKind, member);
             case ILocalReferenceOperation { Local.Type.IsValueType: true } local when IsDeclaredOutside(local.Local, scope):
                 return ("captured local", local.Local);
             case IParameterReferenceOperation { Parameter.Type.IsValueType: true } parameter when IsDeclaredOutside(parameter.Parameter, scope):
                 return ("captured parameter", parameter.Parameter);
             case IFieldReferenceOperation { Type.IsValueType: true } outerField:
-                return ResolveSharedRoot(outerField, scope);
+                return ResolveSharedRoot(outerField, scope, thisParameter);
             case IPropertyReferenceOperation { Type.IsValueType: true } outerProperty:
-                return ResolveSharedRoot(outerProperty, scope);
+                return ResolveSharedRoot(outerProperty, scope, thisParameter);
             default:
                 return (null, null);
         }

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -63,9 +63,18 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
 
     private static void InspectComputationBody(OperationAnalysisContext context, ComputationLambdas.ComputationBody computation, SemanticModel? semanticModel)
     {
-        var visitedHelpers = new HashSet<(IMethodSymbol, IParameterSymbol?, bool)>(ChaseKeyComparer.Instance);
-        var visitedDelegates = new HashSet<SyntaxNode>();
-        InspectComputationOperations(context, computation, computation.Scope, semanticModel, visitedHelpers, visitedDelegates);
+        var walk = new ChaseState();
+        InspectComputationOperations(context, computation, computation.Scope, semanticModel, walk, argumentMap: null);
+    }
+
+    // Per-computation walk state: the visited sets bound helper/delegate cycles, and the
+    // reported set keeps a body re-walked under a DIFFERENT delegate binding from emitting
+    // the same mutation diagnostic twice.
+    private sealed class ChaseState
+    {
+        public readonly HashSet<(IMethodSymbol, IParameterSymbol?, bool, string)> VisitedHelpers = new(ChaseKeyComparer.Instance);
+        public readonly HashSet<SyntaxNode> VisitedDelegates = new();
+        public readonly HashSet<SyntaxNode> ReportedTargets = new();
     }
 
     private static void InspectComputationOperations(
@@ -73,18 +82,18 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         ComputationLambdas.ComputationBody body,
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
-        HashSet<(IMethodSymbol, IParameterSymbol?, bool)> visitedHelpers,
-        HashSet<SyntaxNode> visitedDelegates)
+        ChaseState walk,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         foreach (var operation in ComputationLambdas.Descend(body.Body))
         {
             foreach (var target in MutationTargets(operation))
             {
-                ReportIfShared(context, target, body.Scope, computationScope, thisParameter: null, foreignThis: false);
+                ReportIfShared(context, target, body.Scope, computationScope, thisParameter: null, foreignThis: false, walk.ReportedTargets);
             }
 
-            InspectCalledHelper(context, operation, computationScope, semanticModel, visitedHelpers, thisParameter: null, foreignThis: false);
-            InspectInvokedDelegate(context, operation, computationScope, semanticModel, visitedHelpers, visitedDelegates);
+            InspectCalledHelper(context, operation, computationScope, semanticModel, walk, thisParameter: null, foreignThis: false, argumentMap);
+            InspectInvokedDelegate(context, operation, computationScope, semanticModel, walk, argumentMap);
         }
     }
 
@@ -98,21 +107,66 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         IOperation operation,
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
-        HashSet<(IMethodSymbol, IParameterSymbol?, bool)> visitedHelpers,
-        HashSet<SyntaxNode> visitedDelegates)
+        ChaseState walk,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         if (operation is not IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
         {
             return;
         }
 
-        var resolved = ComputationLambdas.ResolveDelegateValue(callee, semanticModel, null);
+        var resolved = ComputationLambdas.ResolveDelegateValue(ComputationLambdas.ResolveConditionalReceiver(callee), semanticModel, argumentMap);
+        var found = false;
         foreach (var delegateBody in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
         {
-            if (!computationScope.Span.Contains(delegateBody.Scope.Span) && visitedDelegates.Add(delegateBody.Scope))
-            {
-                InspectComputationOperations(context, delegateBody, computationScope, semanticModel, visitedHelpers, visitedDelegates);
-            }
+            found = true;
+            InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, argumentMap);
+        }
+
+        if (!found)
+        {
+            InspectInvokedFactoryResult(context, resolved, computationScope, semanticModel, walk, argumentMap);
+        }
+    }
+
+    // `Get()(x)` executes whatever the same-tree factory returned, with the returns' own
+    // argument maps.
+    private static void InspectInvokedFactoryResult(
+        OperationAnalysisContext context,
+        IOperation resolved,
+        SyntaxNode computationScope,
+        SemanticModel? semanticModel,
+        ChaseState walk,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        while (resolved is IConversionOperation conversion)
+        {
+            resolved = conversion.Operand;
+        }
+
+        if (resolved is not IInvocationOperation call
+            || ComputationLambdas.ResolveMethodBody(call.TargetMethod, semanticModel) is not { } factory)
+        {
+            return;
+        }
+
+        foreach (var (delegateBody, map) in ComputationLambdas.ReturnedBodies(factory, semanticModel, ComputationLambdas.BuildArgumentMap(call, argumentMap)))
+        {
+            InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, map);
+        }
+    }
+
+    private static void InspectDelegateBody(
+        OperationAnalysisContext context,
+        ComputationLambdas.ComputationBody delegateBody,
+        SyntaxNode computationScope,
+        SemanticModel? semanticModel,
+        ChaseState walk,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        if (!computationScope.Span.Contains(delegateBody.Scope.Span) && walk.VisitedDelegates.Add(delegateBody.Scope))
+        {
+            InspectComputationOperations(context, delegateBody, computationScope, semanticModel, walk, argumentMap);
         }
     }
 
@@ -136,9 +190,10 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         IOperation operation,
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
-        HashSet<(IMethodSymbol, IParameterSymbol?, bool)> visited,
+        ChaseState walk,
         IParameterSymbol? thisParameter,
-        bool foreignThis)
+        bool foreignThis,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         foreach (var method in ChaseableMethods(operation, thisParameter, foreignThis))
         {
@@ -151,7 +206,14 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
 
             var nestedThis = NestedThisParameter(operation, thisParameter, foreignThis);
             var nestedForeign = ForeignReceiver(operation, thisParameter, foreignThis);
-            if (!visited.Add((method, nestedThis, nestedForeign)))
+
+            // The map lets a delegate handed INTO the helper resolve at its invocation
+            // (`Run(step)` with `Run(Func<int> f) => f()` executes step's body). Only the
+            // DELEGATE bindings key the visited set: they decide what an invoked parameter
+            // resolves to, while re-walking on ordinary arguments would only repeat the
+            // same reports (which the reported set deduplicates anyway).
+            var nestedMap = ComputationLambdas.BuildArgumentMap(operation, argumentMap);
+            if (!walk.VisitedHelpers.Add((method, nestedThis, nestedForeign, DelegateBindingsKey(nestedMap))))
             {
                 continue;
             }
@@ -160,21 +222,31 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             {
                 foreach (var target in MutationTargets(inner))
                 {
-                    ReportIfShared(context, target, helper.Scope, computationScope, nestedThis, nestedForeign);
+                    ReportIfShared(context, target, helper.Scope, computationScope, nestedThis, nestedForeign, walk.ReportedTargets);
                 }
 
-                InspectCalledHelper(context, inner, computationScope, semanticModel, visited, nestedThis, nestedForeign);
+                InspectCalledHelper(context, inner, computationScope, semanticModel, walk, nestedThis, nestedForeign, nestedMap);
+                InspectInvokedDelegate(context, inner, computationScope, semanticModel, walk, nestedMap);
             }
         }
+    }
+
+    private static string DelegateBindingsKey(Dictionary<IParameterSymbol, IOperation>? map)
+    {
+        if (map is null)
+        {
+            return "";
+        }
+
+        var delegates = map.Where(entry => entry.Key.Type.TypeKind == TypeKind.Delegate)
+            .ToDictionary(entry => entry.Key, entry => entry.Value);
+        return ComputationLambdas.ArgumentMapKey(delegates);
     }
 
     private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
     {
         switch (operation)
         {
-            case IInvocationOperation call:
-                yield return call.TargetMethod;
-                break;
             case IMethodReferenceOperation { Method.MethodKind: MethodKind.LocalFunction } reference:
                 yield return reference.Method;
                 break;
@@ -182,6 +254,19 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                 foreach (var accessor in ChaseableAccessors(property, thisParameter, foreignThis))
                 {
                     yield return accessor;
+                }
+
+                break;
+
+            // Every other executed shape runs like a call: a same-tree CONSTRUCTOR
+            // (`new Writer()` incrementing a static counter), a user-defined
+            // operator/conversion, a custom event accessor, using-driven Dispose.
+            // ForeignReceiver marks a constructor's fresh object so its own instance
+            // writes stay suppressed while statics and captured state still report.
+            default:
+                foreach (var method in ComputationLambdas.ExecutedMethods(operation))
+                {
+                    yield return method;
                 }
 
                 break;
@@ -215,6 +300,13 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // in a foreign body still belongs to that foreign object.
     private static bool ForeignReceiver(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
     {
+        // A constructor body's `this` is the FRESH object being built -- never the
+        // computation's instance, whichever flow reaches it.
+        if (operation is IObjectCreationOperation)
+        {
+            return true;
+        }
+
         var instance = operation switch
         {
             IInvocationOperation call => call.Instance,
@@ -294,18 +386,19 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, IParameterSymbol? This, bool Foreign)>
+    private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings)>
     {
         public static readonly ChaseKeyComparer Instance = new();
 
-        public bool Equals((IMethodSymbol Method, IParameterSymbol? This, bool Foreign) x, (IMethodSymbol Method, IParameterSymbol? This, bool Foreign) y)
+        public bool Equals((IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings) x, (IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings) y)
         {
             return SymbolEqualityComparer.Default.Equals(x.Method, y.Method)
                 && SymbolEqualityComparer.Default.Equals(x.This, y.This)
-                && x.Foreign == y.Foreign;
+                && x.Foreign == y.Foreign
+                && x.Bindings == y.Bindings;
         }
 
-        public int GetHashCode((IMethodSymbol Method, IParameterSymbol? This, bool Foreign) key)
+        public int GetHashCode((IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings) key)
         {
             return SymbolEqualityComparer.Default.GetHashCode(key.Method);
         }
@@ -401,10 +494,10 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         return targets.ToImmutable();
     }
 
-    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope, IParameterSymbol? thisParameter, bool foreignThis)
+    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope, IParameterSymbol? thisParameter, bool foreignThis, HashSet<SyntaxNode> reportedTargets)
     {
         var (kind, symbol) = ResolveSharedRoot(target, scope, thisParameter, foreignThis);
-        if (kind is null || !SharesComputationEnvironment(symbol!, computationScope))
+        if (kind is null || !SharesComputationEnvironment(symbol!, computationScope) || !reportedTargets.Add(target.Syntax))
         {
             return;
         }

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -205,21 +205,9 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // "Captured" = declared outside the computation's declaring syntax (the lambda expression,
-    // or the method/local-function declaration for a method-group computation). The span test
-    // (rather than comparing containing symbols) is what keeps nested non-computation lambdas
-    // correct: a local declared in a nested LINQ lambda belongs to the computation and must not
-    // be flagged, while a local of the enclosing method is shared and must be.
+    // Shared with MZR004; see ComputationLambdas.IsDeclaredOutside for the span-test rationale.
     private static bool IsDeclaredOutside(ISymbol symbol, SyntaxNode scope)
     {
-        var declaration = symbol.DeclaringSyntaxReferences.FirstOrDefault();
-        if (declaration is null)
-        {
-            // Compiler-generated (e.g. a setter's value parameter): nothing actionable to point at.
-            return false;
-        }
-
-        return declaration.SyntaxTree != scope.SyntaxTree
-            || !scope.Span.Contains(declaration.Span);
+        return ComputationLambdas.IsDeclaredOutside(symbol, scope);
     }
 }

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -37,13 +38,56 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
 
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
+            var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
             foreach (var operation in ComputationLambdas.Descend(computation.Body))
             {
                 foreach (var target in MutationTargets(operation))
                 {
-                    ReportIfShared(context, target, computation.Scope);
+                    ReportIfShared(context, target, computation.Scope, computation.Scope);
                 }
+
+                InspectCalledLocalFunction(context, operation, computation.Scope, invocation.SemanticModel, visitedLocalFunctions);
             }
+        }
+    }
+
+    // A LOCAL FUNCTION the computation invokes (or lifts into a delegate) has no receiver: its
+    // closure IS the computation's environment, so `int Next() { applied++; return applied; }`
+    // declared outside the computation writes state the computation shares exactly like an
+    // inline `applied++` -- and MZR004 cannot carry this shape (the int is Sendable; the WRITE
+    // is the race). Bodies resolve same-tree, the visited set bounds call cycles, and the
+    // helper's own per-call locals stay exempt via the enclosing-function guard in
+    // ReportIfShared.
+    private static void InspectCalledLocalFunction(
+        OperationAnalysisContext context,
+        IOperation operation,
+        SyntaxNode computationScope,
+        SemanticModel? semanticModel,
+        HashSet<IMethodSymbol> visited)
+    {
+        var method = operation switch
+        {
+            IInvocationOperation call => call.TargetMethod,
+            IMethodReferenceOperation reference => reference.Method,
+            _ => null,
+        };
+
+        if (method is not { MethodKind: MethodKind.LocalFunction }
+            || !ComputationLambdas.IsDeclaredOutside(method, computationScope)
+            || !visited.Add(method)
+            || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+        {
+            return;
+        }
+
+        foreach (var inner in ComputationLambdas.Descend(helper.Body))
+        {
+            foreach (var target in MutationTargets(inner))
+            {
+                ReportIfShared(context, target, helper.Scope, computationScope);
+            }
+
+            InspectCalledLocalFunction(context, inner, computationScope, semanticModel, visited);
         }
     }
 
@@ -137,10 +181,10 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         return targets.ToImmutable();
     }
 
-    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope)
+    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope)
     {
         var (kind, symbol) = ResolveSharedRoot(target, scope);
-        if (kind is null)
+        if (kind is null || !SharesComputationEnvironment(symbol!, computationScope))
         {
             return;
         }
@@ -150,6 +194,17 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             target.Syntax.GetLocation(),
             kind,
             symbol!.Name));
+    }
+
+    // A captured local/parameter is the computation's business only when it lives in a
+    // function ENCLOSING the computation -- a chased helper's own locals are recreated per
+    // call. Members of `this` and statics are shared storage wherever they are written from.
+    // (For the computation's own body, scope == computationScope and C# scoping makes this
+    // trivially true.)
+    private static bool SharesComputationEnvironment(ISymbol symbol, SyntaxNode computationScope)
+    {
+        return symbol is not (ILocalSymbol or IParameterSymbol)
+            || ComputationLambdas.DeclaredInFunctionEnclosing(symbol, computationScope);
     }
 
     // Resolves a mutation target to the shared storage it ultimately writes, walking up value-type

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -72,7 +72,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // the same mutation diagnostic twice.
     private sealed class ChaseState
     {
-        public readonly HashSet<(IMethodSymbol, IParameterSymbol?, bool, string)> VisitedHelpers = new(ChaseKeyComparer.Instance);
+        public readonly HashSet<(IMethodSymbol, ImmutableArray<IParameterSymbol>, bool, string)> VisitedHelpers = new(ChaseKeyComparer.Instance);
         public readonly HashSet<SyntaxNode> VisitedDelegates = new();
         public readonly HashSet<SyntaxNode> ReportedTargets = new();
     }
@@ -84,18 +84,18 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         ChaseState walk,
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
-        IParameterSymbol? thisParameter = null,
+        ImmutableArray<IParameterSymbol> thisParameters = default,
         bool foreignThis = false)
     {
         foreach (var operation in ComputationLambdas.Descend(body.Body))
         {
             foreach (var target in MutationTargets(operation))
             {
-                ReportIfShared(context, target, body.Scope, computationScope, thisParameter, foreignThis, walk.ReportedTargets);
+                ReportIfShared(context, target, body.Scope, computationScope, thisParameters, foreignThis, walk.ReportedTargets);
             }
 
-            InspectCalledHelper(context, operation, computationScope, semanticModel, walk, thisParameter, foreignThis, argumentMap);
-            InspectInvokedDelegate(context, operation, computationScope, semanticModel, walk, argumentMap);
+            InspectCalledHelper(context, operation, computationScope, semanticModel, walk, thisParameters, foreignThis, argumentMap);
+            InspectInvokedDelegate(context, operation, computationScope, semanticModel, walk, argumentMap, thisParameters, foreignThis);
         }
     }
 
@@ -108,17 +108,39 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
         ChaseState walk,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        ImmutableArray<IParameterSymbol> thisParameters,
+        bool foreignThis)
     {
-        if (operation is not IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
+        if (operation is not IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke } invoke)
         {
             return;
         }
 
-        foreach (var (delegateBody, map) in ComputationLambdas.InvokedDelegateBodies(callee, semanticModel, argumentMap))
+        foreach (var (delegateBody, map) in ComputationLambdas.InvokedDelegateBodies(invoke, semanticModel, argumentMap))
         {
-            InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, map);
+            // The invoke's arguments bind the delegate's parameters exactly like a helper
+            // call's: one handed the enclosing instance IS `this` for the walked body.
+            InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, map, BoundThisParameters(map, thisParameters, foreignThis), foreignThis);
         }
+    }
+
+    private static ImmutableArray<IParameterSymbol> BoundThisParameters(
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        ImmutableArray<IParameterSymbol> thisParameters,
+        bool foreignThis)
+    {
+        if (argumentMap is null)
+        {
+            return thisParameters;
+        }
+
+        var bound = argumentMap
+            .Where(entry => IsComputationInstance(ComputationLambdas.Unwrap(entry.Value), thisParameters, foreignThis))
+            .Select(entry => entry.Key)
+            .ToImmutableArray();
+
+        return bound.IsEmpty ? thisParameters : bound;
     }
 
     private static void InspectDelegateBody(
@@ -127,11 +149,13 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
         ChaseState walk,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        ImmutableArray<IParameterSymbol> thisParameters,
+        bool foreignThis)
     {
         if (!computationScope.Span.Contains(delegateBody.Scope.Span) && walk.VisitedDelegates.Add(delegateBody.Scope))
         {
-            InspectComputationOperations(context, delegateBody, computationScope, semanticModel, walk, argumentMap);
+            InspectComputationOperations(context, delegateBody, computationScope, semanticModel, walk, argumentMap, thisParameters, foreignThis);
         }
     }
 
@@ -156,11 +180,11 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
         ChaseState walk,
-        IParameterSymbol? thisParameter,
+        ImmutableArray<IParameterSymbol> thisParameters,
         bool foreignThis,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        foreach (var method in ChaseableMethods(operation, thisParameter, foreignThis))
+        foreach (var method in ChaseableMethods(operation, thisParameters, foreignThis))
         {
             if (ComputationLambdas.IsInsideNameOf(operation)
                 || (method.MethodKind == MethodKind.LocalFunction && !ComputationLambdas.IsDeclaredOutside(method, computationScope))
@@ -169,8 +193,8 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var nestedThis = NestedThisParameter(operation, thisParameter, foreignThis);
-            var nestedForeign = ForeignReceiver(operation, thisParameter, foreignThis);
+            var nestedThis = NestedThisParameter(operation, thisParameters, foreignThis);
+            var nestedForeign = ForeignReceiver(operation, thisParameters, foreignThis);
 
             // The map lets a delegate handed INTO the helper resolve at its invocation
             // (`Run(step)` with `Run(Func<int> f) => f()` executes step's body). Only the
@@ -199,7 +223,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         return ComputationLambdas.ArgumentMapKey(delegates);
     }
 
-    private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
+    private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis)
     {
         switch (operation)
         {
@@ -207,7 +231,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                 yield return reference.Method;
                 break;
             case IPropertyReferenceOperation property:
-                foreach (var accessor in ChaseableAccessors(property, thisParameter, foreignThis))
+                foreach (var accessor in ChaseableAccessors(property, thisParameters, foreignThis))
                 {
                     yield return accessor;
                 }
@@ -234,7 +258,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // the mutation target the direct walk reports -- but on a FOREIGN receiver nothing else
     // looks at the setter body, whose side effects (`set { hits++; }`) still run on every
     // replay.
-    private static IEnumerable<IMethodSymbol> ChaseableAccessors(IPropertyReferenceOperation property, IParameterSymbol? thisParameter, bool foreignThis)
+    private static IEnumerable<IMethodSymbol> ChaseableAccessors(IPropertyReferenceOperation property, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis)
     {
         var (reads, writes) = ComputationLambdas.PropertyUsage(property);
         if (reads && property.Property.GetMethod is { } getter)
@@ -243,7 +267,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         }
 
         if (writes && property.Property.SetMethod is { } setter
-            && property.Instance is { } instance && !IsComputationInstance(instance, thisParameter, foreignThis))
+            && property.Instance is { } instance && !IsComputationInstance(instance, thisParameters, foreignThis))
         {
             yield return setter;
         }
@@ -254,11 +278,13 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // parameter. A receiverless callee (static, extension, local function) has no `this` of
     // its own to rebind, so the current answer carries through -- a local function nested
     // in a foreign body still belongs to that foreign object.
-    private static bool ForeignReceiver(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
+    private static bool ForeignReceiver(IOperation operation, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis)
     {
-        // A constructor body's `this` is the FRESH object being built -- never the
-        // computation's instance, whichever flow reaches it.
-        if (operation is IObjectCreationOperation)
+        // A constructor body's `this` is the FRESH object being built, and a using
+        // resource's Dispose runs on that resource -- never on the computation's instance,
+        // whichever flow reaches them. Their own instance writes are per-evaluation
+        // storage, so only the statics and captures inside them are shared.
+        if (operation is IObjectCreationOperation or IUsingOperation or IUsingDeclarationOperation)
         {
             return true;
         }
@@ -270,7 +296,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             _ => null,
         };
 
-        return instance is null ? foreignThis : !IsComputationInstance(instance, thisParameter, foreignThis);
+        return instance is null ? foreignThis : !IsComputationInstance(instance, thisParameters, foreignThis);
     }
 
     // The `this` identity for a chased body: the parameter that RECEIVES the enclosing
@@ -280,24 +306,27 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // instance nowhere rebinds nothing: a chased local function keeps the current binding
     // (its closure can still name an extension body's receiver parameter), while any other
     // callee cannot reference it at all.
-    private static IParameterSymbol? NestedThisParameter(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
+    private static ImmutableArray<IParameterSymbol> NestedThisParameter(IOperation operation, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis)
     {
         if (operation is not IInvocationOperation call)
         {
-            return thisParameter;
+            return thisParameters;
         }
 
-        foreach (var argument in call.Arguments)
+        // EVERY parameter the instance was handed to: `Mutate(this, this)` binds both, and a
+        // write through either lands on the computation's object.
+        var bound = call.Arguments
+            .Where(argument => argument.Parameter is not null
+                && IsComputationInstance(ComputationLambdas.Unwrap(argument.Value), thisParameters, foreignThis))
+            .Select(argument => argument.Parameter!)
+            .ToImmutableArray();
+
+        if (!bound.IsEmpty)
         {
-            var value = ComputationLambdas.Unwrap(argument.Value);
-
-            if (IsComputationInstance(value, thisParameter, foreignThis) && argument.Parameter is { } parameter)
-            {
-                return parameter;
-            }
+            return bound;
         }
 
-        return call.TargetMethod.MethodKind == MethodKind.LocalFunction ? thisParameter : null;
+        return call.TargetMethod.MethodKind == MethodKind.LocalFunction ? thisParameters : default;
     }
 
     // The operation refers to the COMPUTATION's enclosing instance: a direct `this` -- only
@@ -305,7 +334,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // parameter, or a local ALIAS resolving to either through its same-tree initializer
     // chain (`var alias = c; Mutate(alias);` hands the instance on). An alias written
     // before its use no longer proves the binding and stays untrusted.
-    private static bool IsComputationInstance(IOperation? receiver, IParameterSymbol? thisParameter, bool foreignThis)
+    private static bool IsComputationInstance(IOperation? receiver, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis)
     {
         var current = receiver;
         HashSet<ISymbol>? visited = null;
@@ -318,9 +347,11 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                     continue;
                 case IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance }:
                     return !foreignThis;
-                case IParameterReferenceOperation parameter when thisParameter is not null
-                    && SymbolEqualityComparer.Default.Equals(parameter.Parameter, thisParameter):
-                    return true;
+                // ...unless the helper rebound it first (`c = new C(); c.Counter++`), in
+                // which case the write lands on whatever it was rebound to.
+                case IParameterReferenceOperation parameter when !thisParameters.IsDefaultOrEmpty
+                    && thisParameters.Contains<ISymbol>(parameter.Parameter, SymbolEqualityComparer.Default):
+                    return !ComputationLambdas.IsWrittenBefore(parameter.Parameter, current.Syntax, current.SemanticModel);
                 case ILocalReferenceOperation local:
                     visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                     if (!visited.Add(local.Local)
@@ -338,19 +369,20 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings)>
+    private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, ImmutableArray<IParameterSymbol> This, bool Foreign, string Bindings)>
     {
         public static readonly ChaseKeyComparer Instance = new();
 
-        public bool Equals((IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings) x, (IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings) y)
+        public bool Equals((IMethodSymbol Method, ImmutableArray<IParameterSymbol> This, bool Foreign, string Bindings) x, (IMethodSymbol Method, ImmutableArray<IParameterSymbol> This, bool Foreign, string Bindings) y)
         {
             return SymbolEqualityComparer.Default.Equals(x.Method, y.Method)
-                && SymbolEqualityComparer.Default.Equals(x.This, y.This)
+                && x.This.IsDefaultOrEmpty == y.This.IsDefaultOrEmpty
+                && (x.This.IsDefaultOrEmpty || Enumerable.SequenceEqual(x.This, y.This, SymbolEqualityComparer.Default))
                 && x.Foreign == y.Foreign
                 && x.Bindings == y.Bindings;
         }
 
-        public int GetHashCode((IMethodSymbol Method, IParameterSymbol? This, bool Foreign, string Bindings) key)
+        public int GetHashCode((IMethodSymbol Method, ImmutableArray<IParameterSymbol> This, bool Foreign, string Bindings) key)
         {
             return SymbolEqualityComparer.Default.GetHashCode(key.Method);
         }
@@ -446,9 +478,9 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         return targets.ToImmutable();
     }
 
-    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope, IParameterSymbol? thisParameter, bool foreignThis, HashSet<SyntaxNode> reportedTargets)
+    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis, HashSet<SyntaxNode> reportedTargets)
     {
-        var (kind, symbol) = ResolveSharedRoot(target, scope, thisParameter, foreignThis);
+        var (kind, symbol) = ResolveSharedRoot(target, scope, thisParameters, foreignThis);
         if (kind is null || !SharesComputationEnvironment(symbol!, computationScope) || !reportedTargets.Add(target.Syntax))
         {
             return;
@@ -477,7 +509,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // all resolve to the shared field/local being mutated. Returns (null, null) when the target is a
     // member of some OTHER reference object (mutation through a captured reference -- MZR001's
     // territory, the value type there should be Sendable).
-    private static (string? kind, ISymbol? symbol) ResolveSharedRoot(IOperation target, SyntaxNode scope, IParameterSymbol? thisParameter, bool foreignThis)
+    private static (string? kind, ISymbol? symbol) ResolveSharedRoot(IOperation target, SyntaxNode scope, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis)
     {
         switch (target)
         {
@@ -488,15 +520,15 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             case IFieldReferenceOperation { Field.IsStatic: true } staticField:
                 return ("static field", staticField.Field);
             case IFieldReferenceOperation field:
-                return ResolveThroughReceiver(field.Instance, "field", field.Field, scope, thisParameter, foreignThis);
+                return ResolveThroughReceiver(field.Instance, "field", field.Field, scope, thisParameters, foreignThis);
             case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
                 return ("static property", staticProperty.Property);
             case IPropertyReferenceOperation property:
-                return ResolveThroughReceiver(property.Instance, "property", property.Property, scope, thisParameter, foreignThis);
+                return ResolveThroughReceiver(property.Instance, "property", property.Property, scope, thisParameters, foreignThis);
             case IEventReferenceOperation { Event.IsStatic: true } staticEvent:
                 return ("static event", staticEvent.Event);
             case IEventReferenceOperation @event:
-                return ResolveThroughReceiver(@event.Instance, "event", @event.Event, scope, thisParameter, foreignThis);
+                return ResolveThroughReceiver(@event.Instance, "event", @event.Event, scope, thisParameters, foreignThis);
             default:
                 return (null, null);
         }
@@ -508,20 +540,20 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // nested value-type field/property/this) reports that RECEIVER -- mutating the member
     // mutates the receiver's storage. A member on any other receiver -- including a foreign
     // body's own `this` -- is left to MZR001.
-    private static (string? kind, ISymbol? symbol) ResolveThroughReceiver(IOperation? receiver, string memberKind, ISymbol member, SyntaxNode scope, IParameterSymbol? thisParameter, bool foreignThis)
+    private static (string? kind, ISymbol? symbol) ResolveThroughReceiver(IOperation? receiver, string memberKind, ISymbol member, SyntaxNode scope, ImmutableArray<IParameterSymbol> thisParameters, bool foreignThis)
     {
         switch (receiver)
         {
-            case var enclosing when IsComputationInstance(enclosing, thisParameter, foreignThis):
+            case var enclosing when IsComputationInstance(enclosing, thisParameters, foreignThis):
                 return (memberKind, member);
             case ILocalReferenceOperation { Local.Type.IsValueType: true } local when ComputationLambdas.IsDeclaredOutside(local.Local, scope):
                 return ("captured local", local.Local);
             case IParameterReferenceOperation { Parameter.Type.IsValueType: true } parameter when ComputationLambdas.IsDeclaredOutside(parameter.Parameter, scope):
                 return ("captured parameter", parameter.Parameter);
             case IFieldReferenceOperation { Type.IsValueType: true } outerField:
-                return ResolveSharedRoot(outerField, scope, thisParameter, foreignThis);
+                return ResolveSharedRoot(outerField, scope, thisParameters, foreignThis);
             case IPropertyReferenceOperation { Type.IsValueType: true } outerProperty:
-                return ResolveSharedRoot(outerProperty, scope, thisParameter, foreignThis);
+                return ResolveSharedRoot(outerProperty, scope, thisParameters, foreignThis);
             default:
                 return (null, null);
         }

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -38,15 +38,15 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
 
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
-            var visitedHelpers = new HashSet<(IMethodSymbol, IParameterSymbol?)>(ChaseKeyComparer.Instance);
+            var visitedHelpers = new HashSet<(IMethodSymbol, IParameterSymbol?, bool)>(ChaseKeyComparer.Instance);
             foreach (var operation in ComputationLambdas.Descend(computation.Body))
             {
                 foreach (var target in MutationTargets(operation))
                 {
-                    ReportIfShared(context, target, computation.Scope, computation.Scope, thisParameter: null);
+                    ReportIfShared(context, target, computation.Scope, computation.Scope, thisParameter: null, foreignThis: false);
                 }
 
-                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedHelpers, thisParameter: null);
+                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedHelpers, thisParameter: null, foreignThis: false);
             }
         }
     }
@@ -54,26 +54,28 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // A helper the computation runs writes the same state the inline form would: a LOCAL
     // FUNCTION's closure IS the computation's environment (`int Next() { applied++; ... }`),
     // a method invoked on THIS or statically (`void Inc() => counter++;`) mutates the
-    // enclosing object/static state on every run, and a GETTER read on the enclosing object
-    // executes the same way (`int P { get { counter++; ... } }`) -- shapes MZR004 cannot
-    // carry (a Sendable type or int hides them; the WRITE is the race). A helper handed the
-    // enclosing instance -- an extension's receiver argument, or an explicit `Mutate(this)`
-    // -- is the same in disguise: the receiving parameter IS `this` for the walked body, so
-    // it is carried as such. A member on any OTHER receiver stays unchased: its writes
-    // mutate that object's state, a captured-reference mutation that is deliberately
-    // MZR001's territory. Bodies resolve same-tree; the visited set -- keyed per RECEIVER
-    // BINDING, so `other.Inc()` before `this.Inc()` cannot poison the chase -- bounds call
-    // cycles, and the helper's own per-call locals stay exempt via the enclosing-function
-    // guard in ReportIfShared.
+    // enclosing object/static state on every run, and a GETTER read executes the same way
+    // (`int P { get { counter++; ... } }`) -- shapes MZR004 cannot carry (a Sendable type or
+    // int hides them; the WRITE is the race). A helper handed the enclosing instance -- an
+    // extension's receiver argument, or an explicit `Mutate(this)` -- is the same in
+    // disguise: the receiving parameter IS `this` for the walked body, so it is carried as
+    // such. A helper on some OTHER receiver is chased too -- a STATIC it writes races
+    // regardless of who the receiver is -- but with `foreignThis` set, so writes to that
+    // body's own object stay suppressed: those are a captured-reference mutation,
+    // deliberately MZR001's territory. Bodies resolve same-tree; the visited set -- keyed
+    // per RECEIVER BINDING, so `other.Inc()` before `this.Inc()` cannot poison the chase --
+    // bounds call cycles, and the helper's own per-call locals stay exempt via the
+    // enclosing-function guard in ReportIfShared.
     private static void InspectCalledHelper(
         OperationAnalysisContext context,
         IOperation operation,
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
-        HashSet<(IMethodSymbol, IParameterSymbol?)> visited,
-        IParameterSymbol? thisParameter)
+        HashSet<(IMethodSymbol, IParameterSymbol?, bool)> visited,
+        IParameterSymbol? thisParameter,
+        bool foreignThis)
     {
-        foreach (var method in ChaseableMethods(operation, thisParameter))
+        foreach (var method in ChaseableMethods(operation))
         {
             if (ComputationLambdas.IsInsideNameOf(operation)
                 || (method.MethodKind == MethodKind.LocalFunction && !ComputationLambdas.IsDeclaredOutside(method, computationScope))
@@ -82,8 +84,9 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var nestedThis = NestedThisParameter(operation, thisParameter);
-            if (!visited.Add((method, nestedThis)))
+            var nestedThis = NestedThisParameter(operation, thisParameter, foreignThis);
+            var nestedForeign = ForeignReceiver(operation, thisParameter, foreignThis);
+            if (!visited.Add((method, nestedThis, nestedForeign)))
             {
                 continue;
             }
@@ -92,35 +95,49 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             {
                 foreach (var target in MutationTargets(inner))
                 {
-                    ReportIfShared(context, target, helper.Scope, computationScope, nestedThis);
+                    ReportIfShared(context, target, helper.Scope, computationScope, nestedThis, nestedForeign);
                 }
 
-                InspectCalledHelper(context, inner, computationScope, semanticModel, visited, nestedThis);
+                InspectCalledHelper(context, inner, computationScope, semanticModel, visited, nestedThis, nestedForeign);
             }
         }
     }
 
-    private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation, IParameterSymbol? thisParameter)
+    private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation)
     {
         switch (operation)
         {
-            case IInvocationOperation call when call.Instance is null || IsEnclosingInstance(call.Instance, thisParameter):
+            case IInvocationOperation call:
                 yield return call.TargetMethod;
                 break;
             case IMethodReferenceOperation { Method.MethodKind: MethodKind.LocalFunction } reference:
                 yield return reference.Method;
                 break;
 
-            // A property READ on the enclosing object (or a static one) runs its getter like
-            // an invoked helper. Writes need no chase: the property itself is already the
-            // mutation target the direct walk reports.
+            // A property READ runs its getter like an invoked helper. Writes need no chase:
+            // the property itself is already the mutation target the direct walk reports.
             case IPropertyReferenceOperation property
-                when (property.Instance is null || IsEnclosingInstance(property.Instance, thisParameter))
-                    && ComputationLambdas.PropertyUsage(property).Reads
-                    && property.Property.GetMethod is { } getter:
+                when ComputationLambdas.PropertyUsage(property).Reads && property.Property.GetMethod is { } getter:
                 yield return getter;
                 break;
         }
+    }
+
+    // Whether the chased body's own `this` is some OTHER object than the computation's:
+    // true when the receiver is neither the enclosing instance nor the current this-bound
+    // parameter. A receiverless callee (static, extension, local function) has no `this` of
+    // its own to rebind, so the current answer carries through -- a local function nested
+    // in a foreign body still belongs to that foreign object.
+    private static bool ForeignReceiver(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
+    {
+        var instance = operation switch
+        {
+            IInvocationOperation call => call.Instance,
+            IPropertyReferenceOperation property => property.Instance,
+            _ => null,
+        };
+
+        return instance is null ? foreignThis : !IsComputationInstance(instance, thisParameter, foreignThis);
     }
 
     // The `this` identity for a chased body: the parameter that RECEIVES the enclosing
@@ -130,7 +147,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // instance nowhere rebinds nothing: a chased local function keeps the current binding
     // (its closure can still name an extension body's receiver parameter), while any other
     // callee cannot reference it at all.
-    private static IParameterSymbol? NestedThisParameter(IOperation operation, IParameterSymbol? thisParameter)
+    private static IParameterSymbol? NestedThisParameter(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
     {
         if (operation is not IInvocationOperation call)
         {
@@ -145,7 +162,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                 value = conversion.Operand;
             }
 
-            if (IsEnclosingInstance(value, thisParameter) && argument.Parameter is { } parameter)
+            if (IsComputationInstance(value, thisParameter, foreignThis) && argument.Parameter is { } parameter)
             {
                 return parameter;
             }
@@ -154,25 +171,29 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         return call.TargetMethod.MethodKind == MethodKind.LocalFunction ? thisParameter : null;
     }
 
-    private static bool IsEnclosingInstance(IOperation? receiver, IParameterSymbol? thisParameter)
+    // The operation refers to the COMPUTATION's enclosing instance: a direct `this` -- only
+    // while walking code whose `this` IS that instance -- or the current body's this-bound
+    // parameter.
+    private static bool IsComputationInstance(IOperation? receiver, IParameterSymbol? thisParameter, bool foreignThis)
     {
-        return receiver is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance }
+        return (receiver is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } && !foreignThis)
             || (receiver is IParameterReferenceOperation parameter
                 && thisParameter is not null
                 && SymbolEqualityComparer.Default.Equals(parameter.Parameter, thisParameter));
     }
 
-    private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, IParameterSymbol? This)>
+    private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, IParameterSymbol? This, bool Foreign)>
     {
         public static readonly ChaseKeyComparer Instance = new();
 
-        public bool Equals((IMethodSymbol Method, IParameterSymbol? This) x, (IMethodSymbol Method, IParameterSymbol? This) y)
+        public bool Equals((IMethodSymbol Method, IParameterSymbol? This, bool Foreign) x, (IMethodSymbol Method, IParameterSymbol? This, bool Foreign) y)
         {
             return SymbolEqualityComparer.Default.Equals(x.Method, y.Method)
-                && SymbolEqualityComparer.Default.Equals(x.This, y.This);
+                && SymbolEqualityComparer.Default.Equals(x.This, y.This)
+                && x.Foreign == y.Foreign;
         }
 
-        public int GetHashCode((IMethodSymbol Method, IParameterSymbol? This) key)
+        public int GetHashCode((IMethodSymbol Method, IParameterSymbol? This, bool Foreign) key)
         {
             return SymbolEqualityComparer.Default.GetHashCode(key.Method);
         }
@@ -268,9 +289,9 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         return targets.ToImmutable();
     }
 
-    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope, IParameterSymbol? thisParameter)
+    private static void ReportIfShared(OperationAnalysisContext context, IOperation target, SyntaxNode scope, SyntaxNode computationScope, IParameterSymbol? thisParameter, bool foreignThis)
     {
-        var (kind, symbol) = ResolveSharedRoot(target, scope, thisParameter);
+        var (kind, symbol) = ResolveSharedRoot(target, scope, thisParameter, foreignThis);
         if (kind is null || !SharesComputationEnvironment(symbol!, computationScope))
         {
             return;
@@ -299,7 +320,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     // all resolve to the shared field/local being mutated. Returns (null, null) when the target is a
     // member of some OTHER reference object (mutation through a captured reference -- MZR001's
     // territory, the value type there should be Sendable).
-    private static (string? kind, ISymbol? symbol) ResolveSharedRoot(IOperation target, SyntaxNode scope, IParameterSymbol? thisParameter)
+    private static (string? kind, ISymbol? symbol) ResolveSharedRoot(IOperation target, SyntaxNode scope, IParameterSymbol? thisParameter, bool foreignThis)
     {
         switch (target)
         {
@@ -310,39 +331,40 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             case IFieldReferenceOperation { Field.IsStatic: true } staticField:
                 return ("static field", staticField.Field);
             case IFieldReferenceOperation field:
-                return ResolveThroughReceiver(field.Instance, "field", field.Field, scope, thisParameter);
+                return ResolveThroughReceiver(field.Instance, "field", field.Field, scope, thisParameter, foreignThis);
             case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
                 return ("static property", staticProperty.Property);
             case IPropertyReferenceOperation property:
-                return ResolveThroughReceiver(property.Instance, "property", property.Property, scope, thisParameter);
+                return ResolveThroughReceiver(property.Instance, "property", property.Property, scope, thisParameter, foreignThis);
             case IEventReferenceOperation { Event.IsStatic: true } staticEvent:
                 return ("static event", staticEvent.Event);
             case IEventReferenceOperation @event:
-                return ResolveThroughReceiver(@event.Instance, "event", @event.Event, scope, thisParameter);
+                return ResolveThroughReceiver(@event.Instance, "event", @event.Event, scope, thisParameter, foreignThis);
             default:
                 return (null, null);
         }
     }
 
-    // A member on `this` -- or on an extension body's receiver parameter bound to `this` --
-    // is reported as the member. A member on a value-type receiver that is itself shared
-    // storage (a captured struct local/parameter, or a nested value-type
-    // field/property/this) reports that RECEIVER -- mutating the member mutates the receiver's
-    // storage. A member on any other (reference) receiver is left to MZR001.
-    private static (string? kind, ISymbol? symbol) ResolveThroughReceiver(IOperation? receiver, string memberKind, ISymbol member, SyntaxNode scope, IParameterSymbol? thisParameter)
+    // A member on the COMPUTATION's instance -- direct `this` in a non-foreign body, or a
+    // this-bound receiver parameter -- is reported as the member. A member on a value-type
+    // receiver that is itself shared storage (a captured struct local/parameter, or a
+    // nested value-type field/property/this) reports that RECEIVER -- mutating the member
+    // mutates the receiver's storage. A member on any other receiver -- including a foreign
+    // body's own `this` -- is left to MZR001.
+    private static (string? kind, ISymbol? symbol) ResolveThroughReceiver(IOperation? receiver, string memberKind, ISymbol member, SyntaxNode scope, IParameterSymbol? thisParameter, bool foreignThis)
     {
         switch (receiver)
         {
-            case var enclosing when IsEnclosingInstance(enclosing, thisParameter):
+            case var enclosing when IsComputationInstance(enclosing, thisParameter, foreignThis):
                 return (memberKind, member);
             case ILocalReferenceOperation { Local.Type.IsValueType: true } local when IsDeclaredOutside(local.Local, scope):
                 return ("captured local", local.Local);
             case IParameterReferenceOperation { Parameter.Type.IsValueType: true } parameter when IsDeclaredOutside(parameter.Parameter, scope):
                 return ("captured parameter", parameter.Parameter);
             case IFieldReferenceOperation { Type.IsValueType: true } outerField:
-                return ResolveSharedRoot(outerField, scope, thisParameter);
+                return ResolveSharedRoot(outerField, scope, thisParameter, foreignThis);
             case IPropertyReferenceOperation { Type.IsValueType: true } outerProperty:
-                return ResolveSharedRoot(outerProperty, scope, thisParameter);
+                return ResolveSharedRoot(outerProperty, scope, thisParameter, foreignThis);
             default:
                 return (null, null);
         }

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -75,7 +75,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         IParameterSymbol? thisParameter,
         bool foreignThis)
     {
-        foreach (var method in ChaseableMethods(operation))
+        foreach (var method in ChaseableMethods(operation, thisParameter, foreignThis))
         {
             if (ComputationLambdas.IsInsideNameOf(operation)
                 || (method.MethodKind == MethodKind.LocalFunction && !ComputationLambdas.IsDeclaredOutside(method, computationScope))
@@ -103,7 +103,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation)
+    private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation, IParameterSymbol? thisParameter, bool foreignThis)
     {
         switch (operation)
         {
@@ -113,13 +113,33 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             case IMethodReferenceOperation { Method.MethodKind: MethodKind.LocalFunction } reference:
                 yield return reference.Method;
                 break;
+            case IPropertyReferenceOperation property:
+                foreach (var accessor in ChaseableAccessors(property, thisParameter, foreignThis))
+                {
+                    yield return accessor;
+                }
 
-            // A property READ runs its getter like an invoked helper. Writes need no chase:
-            // the property itself is already the mutation target the direct walk reports.
-            case IPropertyReferenceOperation property
-                when ComputationLambdas.PropertyUsage(property).Reads && property.Property.GetMethod is { } getter:
-                yield return getter;
                 break;
+        }
+    }
+
+    // A property READ runs its getter like an invoked helper, on any receiver. A WRITE on
+    // the computation's own instance (or a static) needs no chase -- the property itself is
+    // the mutation target the direct walk reports -- but on a FOREIGN receiver nothing else
+    // looks at the setter body, whose side effects (`set { hits++; }`) still run on every
+    // replay.
+    private static IEnumerable<IMethodSymbol> ChaseableAccessors(IPropertyReferenceOperation property, IParameterSymbol? thisParameter, bool foreignThis)
+    {
+        var (reads, writes) = ComputationLambdas.PropertyUsage(property);
+        if (reads && property.Property.GetMethod is { } getter)
+        {
+            yield return getter;
+        }
+
+        if (writes && property.Property.SetMethod is { } setter
+            && property.Instance is { } instance && !IsComputationInstance(instance, thisParameter, foreignThis))
+        {
+            yield return setter;
         }
     }
 
@@ -172,14 +192,41 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     }
 
     // The operation refers to the COMPUTATION's enclosing instance: a direct `this` -- only
-    // while walking code whose `this` IS that instance -- or the current body's this-bound
-    // parameter.
+    // while walking code whose `this` IS that instance -- the current body's this-bound
+    // parameter, or a local ALIAS resolving to either through its same-tree initializer
+    // chain (`var alias = c; Mutate(alias);` hands the instance on). An alias written
+    // before its use no longer proves the binding and stays untrusted.
     private static bool IsComputationInstance(IOperation? receiver, IParameterSymbol? thisParameter, bool foreignThis)
     {
-        return (receiver is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } && !foreignThis)
-            || (receiver is IParameterReferenceOperation parameter
-                && thisParameter is not null
-                && SymbolEqualityComparer.Default.Equals(parameter.Parameter, thisParameter));
+        var current = receiver;
+        HashSet<ISymbol>? visited = null;
+        while (true)
+        {
+            switch (current)
+            {
+                case IConversionOperation conversion:
+                    current = conversion.Operand;
+                    continue;
+                case IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance }:
+                    return !foreignThis;
+                case IParameterReferenceOperation parameter when thisParameter is not null
+                    && SymbolEqualityComparer.Default.Equals(parameter.Parameter, thisParameter):
+                    return true;
+                case ILocalReferenceOperation local:
+                    visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                    if (!visited.Add(local.Local)
+                        || ComputationLambdas.IsWrittenBefore(local.Local, current.Syntax, current.SemanticModel)
+                        || ComputationLambdas.SameTreeInitializerOperation(local.Local, current.SemanticModel) is not { } initializer)
+                    {
+                        return false;
+                    }
+
+                    current = initializer;
+                    continue;
+                default:
+                    return false;
+            }
+        }
     }
 
     private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, IParameterSymbol? This, bool Foreign)>

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -129,8 +129,8 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // `Get()(x)` executes whatever the same-tree factory returned, with the returns' own
-    // argument maps.
+    // `Get()(x)` executes whatever the same-tree factory returned -- and `Step()` whatever
+    // the computed property's getter returned -- with the returns' own argument maps.
     private static void InspectInvokedFactoryResult(
         OperationAnalysisContext context,
         IOperation resolved,
@@ -144,13 +144,29 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             resolved = conversion.Operand;
         }
 
-        if (resolved is not IInvocationOperation call
-            || ComputationLambdas.ResolveMethodBody(call.TargetMethod, semanticModel) is not { } factory)
+        if (resolved is IInvocationOperation call
+            && ComputationLambdas.ResolveMethodBody(call.TargetMethod, semanticModel) is { } factory)
         {
+            InspectReturnedDelegateBodies(context, factory, ComputationLambdas.BuildArgumentMap(call, argumentMap), computationScope, semanticModel, walk);
             return;
         }
 
-        foreach (var (delegateBody, map) in ComputationLambdas.ReturnedBodies(factory, semanticModel, ComputationLambdas.BuildArgumentMap(call, argumentMap)))
+        if (ComputationLambdas.ReferencedVariable(resolved) is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
+            && ComputationLambdas.ResolveMethodBody(getter, semanticModel) is { } getterBody)
+        {
+            InspectReturnedDelegateBodies(context, getterBody, ComputationLambdas.BuildArgumentMap(resolved, argumentMap), computationScope, semanticModel, walk);
+        }
+    }
+
+    private static void InspectReturnedDelegateBodies(
+        OperationAnalysisContext context,
+        ComputationLambdas.ComputationBody source,
+        Dictionary<IParameterSymbol, IOperation>? sourceMap,
+        SyntaxNode computationScope,
+        SemanticModel? semanticModel,
+        ChaseState walk)
+    {
+        foreach (var (delegateBody, map) in ComputationLambdas.ReturnedBodies(source, semanticModel, sourceMap))
         {
             InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, map);
         }

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -53,18 +53,32 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                foreach (var (body, _) in ComputationLambdas.AssembledPatchBodies(argument.Value, invocation.SemanticModel))
+                foreach (var (body, map) in ComputationLambdas.AssembledPatchBodies(argument.Value, invocation.SemanticModel))
                 {
-                    InspectComputationBody(context, body, invocation.SemanticModel);
+                    InspectComputationBody(context, body, invocation.SemanticModel, map);
                 }
             }
         }
     }
 
-    private static void InspectComputationBody(OperationAnalysisContext context, ComputationLambdas.ComputationBody computation, SemanticModel? semanticModel)
+    // The assembled body carries the map that RESOLVED it: a factory parameter bound to the
+    // enclosing instance (`Make(this)`) is `this` for the walked patch, exactly as at a
+    // helper call.
+    private static void InspectComputationBody(
+        OperationAnalysisContext context,
+        ComputationLambdas.ComputationBody computation,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
         var walk = new ChaseState();
-        InspectComputationOperations(context, computation, computation.Scope, semanticModel, walk, argumentMap: null);
+        InspectComputationOperations(
+            context,
+            computation,
+            computation.Scope,
+            semanticModel,
+            walk,
+            argumentMap,
+            BoundThisParameters(argumentMap, default, foreignThis: false));
     }
 
     // Per-computation walk state: the visited sets bound helper/delegate cycles, and the

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -46,19 +46,21 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                     ReportIfShared(context, target, computation.Scope, computation.Scope);
                 }
 
-                InspectCalledLocalFunction(context, operation, computation.Scope, invocation.SemanticModel, visitedLocalFunctions);
+                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedLocalFunctions);
             }
         }
     }
 
-    // A LOCAL FUNCTION the computation invokes (or lifts into a delegate) has no receiver: its
-    // closure IS the computation's environment, so `int Next() { applied++; return applied; }`
-    // declared outside the computation writes state the computation shares exactly like an
-    // inline `applied++` -- and MZR004 cannot carry this shape (the int is Sendable; the WRITE
-    // is the race). Bodies resolve same-tree, the visited set bounds call cycles, and the
-    // helper's own per-call locals stay exempt via the enclosing-function guard in
-    // ReportIfShared.
-    private static void InspectCalledLocalFunction(
+    // A helper the computation runs writes the same state the inline form would: a LOCAL
+    // FUNCTION's closure IS the computation's environment (`int Next() { applied++; ... }`),
+    // and a method invoked on THIS or statically (`void Inc() => counter++;`) mutates the
+    // enclosing object/static state on every run -- shapes MZR004 cannot carry (a Sendable
+    // type or int hides them; the WRITE is the race). A method on any OTHER receiver stays
+    // unchased: its writes mutate that object's state, a captured-reference mutation that is
+    // deliberately MZR001's territory. Bodies resolve same-tree, the visited set bounds call
+    // cycles, and the helper's own per-call locals stay exempt via the enclosing-function
+    // guard in ReportIfShared.
+    private static void InspectCalledHelper(
         OperationAnalysisContext context,
         IOperation operation,
         SyntaxNode computationScope,
@@ -67,14 +69,14 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     {
         var method = operation switch
         {
-            IInvocationOperation call => call.TargetMethod,
-            IMethodReferenceOperation reference => reference.Method,
+            IInvocationOperation call when IsChaseableReceiver(call) => call.TargetMethod,
+            IMethodReferenceOperation { Method.MethodKind: MethodKind.LocalFunction } reference => reference.Method,
             _ => null,
         };
 
-        if (method is not { MethodKind: MethodKind.LocalFunction }
+        if (method is null
             || ComputationLambdas.IsInsideNameOf(operation)
-            || !ComputationLambdas.IsDeclaredOutside(method, computationScope)
+            || (method.MethodKind == MethodKind.LocalFunction && !ComputationLambdas.IsDeclaredOutside(method, computationScope))
             || !visited.Add(method)
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
@@ -88,8 +90,14 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                 ReportIfShared(context, target, helper.Scope, computationScope);
             }
 
-            InspectCalledLocalFunction(context, inner, computationScope, semanticModel, visited);
+            InspectCalledHelper(context, inner, computationScope, semanticModel, visited);
         }
+    }
+
+    private static bool IsChaseableReceiver(IInvocationOperation call)
+    {
+        return call.Instance is null
+            || call.Instance is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance };
     }
 
     private static ImmutableArray<IOperation> MutationTargets(IOperation operation)

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -73,6 +73,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         };
 
         if (method is not { MethodKind: MethodKind.LocalFunction }
+            || ComputationLambdas.IsInsideNameOf(operation)
             || !ComputationLambdas.IsDeclaredOutside(method, computationScope)
             || !visited.Add(method)
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -64,14 +64,55 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     private static void InspectComputationBody(OperationAnalysisContext context, ComputationLambdas.ComputationBody computation, SemanticModel? semanticModel)
     {
         var visitedHelpers = new HashSet<(IMethodSymbol, IParameterSymbol?, bool)>(ChaseKeyComparer.Instance);
-        foreach (var operation in ComputationLambdas.Descend(computation.Body))
+        var visitedDelegates = new HashSet<SyntaxNode>();
+        InspectComputationOperations(context, computation, computation.Scope, semanticModel, visitedHelpers, visitedDelegates);
+    }
+
+    private static void InspectComputationOperations(
+        OperationAnalysisContext context,
+        ComputationLambdas.ComputationBody body,
+        SyntaxNode computationScope,
+        SemanticModel? semanticModel,
+        HashSet<(IMethodSymbol, IParameterSymbol?, bool)> visitedHelpers,
+        HashSet<SyntaxNode> visitedDelegates)
+    {
+        foreach (var operation in ComputationLambdas.Descend(body.Body))
         {
             foreach (var target in MutationTargets(operation))
             {
-                ReportIfShared(context, target, computation.Scope, computation.Scope, thisParameter: null, foreignThis: false);
+                ReportIfShared(context, target, body.Scope, computationScope, thisParameter: null, foreignThis: false);
             }
 
-            InspectCalledHelper(context, operation, computation.Scope, semanticModel, visitedHelpers, thisParameter: null, foreignThis: false);
+            InspectCalledHelper(context, operation, computationScope, semanticModel, visitedHelpers, thisParameter: null, foreignThis: false);
+            InspectInvokedDelegate(context, operation, computationScope, semanticModel, visitedHelpers, visitedDelegates);
+        }
+    }
+
+    // A delegate the computation synchronously INVOKES runs its body on the computation's
+    // flows: a captured lambda's write (`Func<int,int> d = x => { applied++; ... }` invoked
+    // by the body) races exactly like inline code. Only bodies declared OUTSIDE the
+    // computation need this chase -- one declared inside is already covered by the full
+    // walk above; the visited set bounds self-invoking delegates.
+    private static void InspectInvokedDelegate(
+        OperationAnalysisContext context,
+        IOperation operation,
+        SyntaxNode computationScope,
+        SemanticModel? semanticModel,
+        HashSet<(IMethodSymbol, IParameterSymbol?, bool)> visitedHelpers,
+        HashSet<SyntaxNode> visitedDelegates)
+    {
+        if (operation is not IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
+        {
+            return;
+        }
+
+        var resolved = ComputationLambdas.ResolveDelegateValue(callee, semanticModel, null);
+        foreach (var delegateBody in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
+        {
+            if (!computationScope.Span.Contains(delegateBody.Scope.Span) && visitedDelegates.Add(delegateBody.Scope))
+            {
+                InspectComputationOperations(context, delegateBody, computationScope, semanticModel, visitedHelpers, visitedDelegates);
+            }
         }
     }
 

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -38,16 +38,40 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
 
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
-            var visitedHelpers = new HashSet<(IMethodSymbol, IParameterSymbol?, bool)>(ChaseKeyComparer.Instance);
-            foreach (var operation in ComputationLambdas.Descend(computation.Body))
+            InspectComputationBody(context, computation, invocation.SemanticModel);
+        }
+
+        // Patch shapes resolved beyond plain arguments -- assembled by an out-helper,
+        // returned by a computed delegate property or a same-tree factory -- replay on the
+        // state's flows exactly like an inline patch, so their writes race identically.
+        if (FactoryMethods.IsOptimisticPatchHost(invocation.TargetMethod))
+        {
+            foreach (var argument in invocation.Arguments)
             {
-                foreach (var target in MutationTargets(operation))
+                if (argument.Parameter?.Type is not { TypeKind: TypeKind.Delegate })
                 {
-                    ReportIfShared(context, target, computation.Scope, computation.Scope, thisParameter: null, foreignThis: false);
+                    continue;
                 }
 
-                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedHelpers, thisParameter: null, foreignThis: false);
+                foreach (var (body, _) in ComputationLambdas.AssembledPatchBodies(argument.Value, invocation.SemanticModel))
+                {
+                    InspectComputationBody(context, body, invocation.SemanticModel);
+                }
             }
+        }
+    }
+
+    private static void InspectComputationBody(OperationAnalysisContext context, ComputationLambdas.ComputationBody computation, SemanticModel? semanticModel)
+    {
+        var visitedHelpers = new HashSet<(IMethodSymbol, IParameterSymbol?, bool)>(ChaseKeyComparer.Instance);
+        foreach (var operation in ComputationLambdas.Descend(computation.Body))
+        {
+            foreach (var target in MutationTargets(operation))
+            {
+                ReportIfShared(context, target, computation.Scope, computation.Scope, thisParameter: null, foreignThis: false);
+            }
+
+            InspectCalledHelper(context, operation, computation.Scope, semanticModel, visitedHelpers, thisParameter: null, foreignThis: false);
         }
     }
 

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -73,7 +73,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     private sealed class ChaseState
     {
         public readonly HashSet<(IMethodSymbol, ImmutableArray<IParameterSymbol>, bool, string)> VisitedHelpers = new(ChaseKeyComparer.Instance);
-        public readonly HashSet<SyntaxNode> VisitedDelegates = new();
+        public readonly HashSet<(SyntaxNode, string, bool)> VisitedDelegates = new();
         public readonly HashSet<SyntaxNode> ReportedTargets = new();
     }
 
@@ -117,11 +117,19 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // A method group's body runs on the RECEIVER the delegate captured
+        // (`Action step = other.Touch;`), never on the computation's instance unless that
+        // receiver provably is it -- its own field writes are then MZR001's territory.
+        var receiver = ComputationLambdas.InvokedDelegateReceiver(invoke, semanticModel, argumentMap);
+        var calleeForeign = receiver is null
+            ? foreignThis
+            : !IsComputationInstance(ComputationLambdas.Unwrap(receiver), thisParameters, foreignThis);
+
         foreach (var (delegateBody, map) in ComputationLambdas.InvokedDelegateBodies(invoke, semanticModel, argumentMap))
         {
             // The invoke's arguments bind the delegate's parameters exactly like a helper
             // call's: one handed the enclosing instance IS `this` for the walked body.
-            InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, map, BoundThisParameters(map, thisParameters, foreignThis), foreignThis);
+            InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, map, BoundThisParameters(map, thisParameters, calleeForeign), calleeForeign);
         }
     }
 
@@ -153,7 +161,8 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         ImmutableArray<IParameterSymbol> thisParameters,
         bool foreignThis)
     {
-        if (!computationScope.Span.Contains(delegateBody.Scope.Span) && walk.VisitedDelegates.Add(delegateBody.Scope))
+        var key = (delegateBody.Scope, ComputationLambdas.ArgumentMapKey(argumentMap), foreignThis);
+        if (!computationScope.Span.Contains(delegateBody.Scope.Span) && walk.VisitedDelegates.Add(key))
         {
             InspectComputationOperations(context, delegateBody, computationScope, semanticModel, walk, argumentMap, thisParameters, foreignThis);
         }

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -38,7 +38,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
 
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
-            var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            var visitedHelpers = new HashSet<(IMethodSymbol, IParameterSymbol?)>(ChaseKeyComparer.Instance);
             foreach (var operation in ComputationLambdas.Descend(computation.Body))
             {
                 foreach (var target in MutationTargets(operation))
@@ -46,85 +46,112 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                     ReportIfShared(context, target, computation.Scope, computation.Scope, thisParameter: null);
                 }
 
-                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedLocalFunctions, thisParameter: null);
+                InspectCalledHelper(context, operation, computation.Scope, invocation.SemanticModel, visitedHelpers, thisParameter: null);
             }
         }
     }
 
     // A helper the computation runs writes the same state the inline form would: a LOCAL
     // FUNCTION's closure IS the computation's environment (`int Next() { applied++; ... }`),
-    // and a method invoked on THIS or statically (`void Inc() => counter++;`) mutates the
-    // enclosing object/static state on every run -- shapes MZR004 cannot carry (a Sendable
-    // type or int hides them; the WRITE is the race). An EXTENSION method whose receiver
-    // argument is `this` is the same helper in disguise: its receiver parameter IS the
-    // enclosing instance for the walked body (`this.Inc()` with `Inc(this C c) =>
-    // c.Counter++` mutates it like `this.Counter++`), so that parameter is carried as the
-    // body's `this`. A method (extension or not) on any OTHER receiver stays unchased: its
-    // writes mutate that object's state, a captured-reference mutation that is deliberately
-    // MZR001's territory. Bodies resolve same-tree, the visited set bounds call cycles, and
-    // the helper's own per-call locals stay exempt via the enclosing-function guard in
-    // ReportIfShared.
+    // a method invoked on THIS or statically (`void Inc() => counter++;`) mutates the
+    // enclosing object/static state on every run, and a GETTER read on the enclosing object
+    // executes the same way (`int P { get { counter++; ... } }`) -- shapes MZR004 cannot
+    // carry (a Sendable type or int hides them; the WRITE is the race). A helper handed the
+    // enclosing instance -- an extension's receiver argument, or an explicit `Mutate(this)`
+    // -- is the same in disguise: the receiving parameter IS `this` for the walked body, so
+    // it is carried as such. A member on any OTHER receiver stays unchased: its writes
+    // mutate that object's state, a captured-reference mutation that is deliberately
+    // MZR001's territory. Bodies resolve same-tree; the visited set -- keyed per RECEIVER
+    // BINDING, so `other.Inc()` before `this.Inc()` cannot poison the chase -- bounds call
+    // cycles, and the helper's own per-call locals stay exempt via the enclosing-function
+    // guard in ReportIfShared.
     private static void InspectCalledHelper(
         OperationAnalysisContext context,
         IOperation operation,
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
-        HashSet<IMethodSymbol> visited,
+        HashSet<(IMethodSymbol, IParameterSymbol?)> visited,
         IParameterSymbol? thisParameter)
     {
-        var method = operation switch
+        foreach (var method in ChaseableMethods(operation, thisParameter))
         {
-            IInvocationOperation call when IsChaseableReceiver(call, thisParameter) => call.TargetMethod,
-            IMethodReferenceOperation { Method.MethodKind: MethodKind.LocalFunction } reference => reference.Method,
-            _ => null,
-        };
-
-        if (method is null
-            || ComputationLambdas.IsInsideNameOf(operation)
-            || (method.MethodKind == MethodKind.LocalFunction && !ComputationLambdas.IsDeclaredOutside(method, computationScope))
-            || !visited.Add(method)
-            || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
-        {
-            return;
-        }
-
-        var nestedThis = NestedThisParameter(operation, thisParameter);
-        foreach (var inner in ComputationLambdas.Descend(helper.Body))
-        {
-            foreach (var target in MutationTargets(inner))
+            if (ComputationLambdas.IsInsideNameOf(operation)
+                || (method.MethodKind == MethodKind.LocalFunction && !ComputationLambdas.IsDeclaredOutside(method, computationScope))
+                || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
             {
-                ReportIfShared(context, target, helper.Scope, computationScope, nestedThis);
+                continue;
             }
 
-            InspectCalledHelper(context, inner, computationScope, semanticModel, visited, nestedThis);
+            var nestedThis = NestedThisParameter(operation, thisParameter);
+            if (!visited.Add((method, nestedThis)))
+            {
+                continue;
+            }
+
+            foreach (var inner in ComputationLambdas.Descend(helper.Body))
+            {
+                foreach (var target in MutationTargets(inner))
+                {
+                    ReportIfShared(context, target, helper.Scope, computationScope, nestedThis);
+                }
+
+                InspectCalledHelper(context, inner, computationScope, semanticModel, visited, nestedThis);
+            }
         }
     }
 
-    private static bool IsChaseableReceiver(IInvocationOperation call, IParameterSymbol? thisParameter)
+    private static IEnumerable<IMethodSymbol> ChaseableMethods(IOperation operation, IParameterSymbol? thisParameter)
     {
-        return call.Instance is null || IsEnclosingInstance(call.Instance, thisParameter);
+        switch (operation)
+        {
+            case IInvocationOperation call when call.Instance is null || IsEnclosingInstance(call.Instance, thisParameter):
+                yield return call.TargetMethod;
+                break;
+            case IMethodReferenceOperation { Method.MethodKind: MethodKind.LocalFunction } reference:
+                yield return reference.Method;
+                break;
+
+            // A property READ on the enclosing object (or a static one) runs its getter like
+            // an invoked helper. Writes need no chase: the property itself is already the
+            // mutation target the direct walk reports.
+            case IPropertyReferenceOperation property
+                when (property.Instance is null || IsEnclosingInstance(property.Instance, thisParameter))
+                    && ComputationLambdas.PropertyUsage(property).Reads
+                    && property.Property.GetMethod is { } getter:
+                yield return getter;
+                break;
+        }
     }
 
-    // The `this` identity for a chased body. An extension invocation rebinds it: the
-    // receiver parameter when the receiver argument is the enclosing instance (directly, or
-    // through the current body's own receiver parameter), nothing otherwise -- an extension
-    // on another object must not have its receiver writes counted. Every other chase keeps
-    // the current binding: a local function nested in an extension body still closes over
-    // the extension's receiver parameter, while bodies that cannot name it are unaffected.
+    // The `this` identity for a chased body: the parameter that RECEIVES the enclosing
+    // instance at this call -- an extension's receiver argument (`this.Inc()` with
+    // `Inc(this C c)`) or an explicit ordinary argument (`Mutate(this)`) -- resolved
+    // through the current body's own binding so chains keep it. A call handing the
+    // instance nowhere rebinds nothing: a chased local function keeps the current binding
+    // (its closure can still name an extension body's receiver parameter), while any other
+    // callee cannot reference it at all.
     private static IParameterSymbol? NestedThisParameter(IOperation operation, IParameterSymbol? thisParameter)
     {
-        if (operation is not IInvocationOperation { TargetMethod: { IsExtensionMethod: true } method } call)
+        if (operation is not IInvocationOperation call)
         {
             return thisParameter;
         }
 
-        var receiver = call.Arguments.FirstOrDefault(argument => argument.Parameter?.Ordinal == 0)?.Value;
-        while (receiver is IConversionOperation conversion)
+        foreach (var argument in call.Arguments)
         {
-            receiver = conversion.Operand;
+            var value = argument.Value;
+            while (value is IConversionOperation conversion)
+            {
+                value = conversion.Operand;
+            }
+
+            if (IsEnclosingInstance(value, thisParameter) && argument.Parameter is { } parameter)
+            {
+                return parameter;
+            }
         }
 
-        return IsEnclosingInstance(receiver, thisParameter) ? method.Parameters.FirstOrDefault() : null;
+        return call.TargetMethod.MethodKind == MethodKind.LocalFunction ? thisParameter : null;
     }
 
     private static bool IsEnclosingInstance(IOperation? receiver, IParameterSymbol? thisParameter)
@@ -133,6 +160,22 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             || (receiver is IParameterReferenceOperation parameter
                 && thisParameter is not null
                 && SymbolEqualityComparer.Default.Equals(parameter.Parameter, thisParameter));
+    }
+
+    private sealed class ChaseKeyComparer : IEqualityComparer<(IMethodSymbol Method, IParameterSymbol? This)>
+    {
+        public static readonly ChaseKeyComparer Instance = new();
+
+        public bool Equals((IMethodSymbol Method, IParameterSymbol? This) x, (IMethodSymbol Method, IParameterSymbol? This) y)
+        {
+            return SymbolEqualityComparer.Default.Equals(x.Method, y.Method)
+                && SymbolEqualityComparer.Default.Equals(x.This, y.This);
+        }
+
+        public int GetHashCode((IMethodSymbol Method, IParameterSymbol? This) key)
+        {
+            return SymbolEqualityComparer.Default.GetHashCode(key.Method);
+        }
     }
 
     private static ImmutableArray<IOperation> MutationTargets(IOperation operation)

--- a/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
+++ b/MemoizR.Analyzers/CapturedMutationAnalyzer.cs
@@ -83,25 +83,25 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         SyntaxNode computationScope,
         SemanticModel? semanticModel,
         ChaseState walk,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        IParameterSymbol? thisParameter = null,
+        bool foreignThis = false)
     {
         foreach (var operation in ComputationLambdas.Descend(body.Body))
         {
             foreach (var target in MutationTargets(operation))
             {
-                ReportIfShared(context, target, body.Scope, computationScope, thisParameter: null, foreignThis: false, walk.ReportedTargets);
+                ReportIfShared(context, target, body.Scope, computationScope, thisParameter, foreignThis, walk.ReportedTargets);
             }
 
-            InspectCalledHelper(context, operation, computationScope, semanticModel, walk, thisParameter: null, foreignThis: false, argumentMap);
+            InspectCalledHelper(context, operation, computationScope, semanticModel, walk, thisParameter, foreignThis, argumentMap);
             InspectInvokedDelegate(context, operation, computationScope, semanticModel, walk, argumentMap);
         }
     }
 
     // A delegate the computation synchronously INVOKES runs its body on the computation's
-    // flows: a captured lambda's write (`Func<int,int> d = x => { applied++; ... }` invoked
-    // by the body) races exactly like inline code. Only bodies declared OUTSIDE the
-    // computation need this chase -- one declared inside is already covered by the full
-    // walk above; the visited set bounds self-invoking delegates.
+    // flows: a captured lambda's write (`Func<int,int> d = x => { applied++; return x; }`
+    // invoked by the body) races exactly like inline code.
     private static void InspectInvokedDelegate(
         OperationAnalysisContext context,
         IOperation operation,
@@ -115,58 +115,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var resolved = ComputationLambdas.ResolveDelegateValue(ComputationLambdas.ResolveConditionalReceiver(callee), semanticModel, argumentMap);
-        var found = false;
-        foreach (var delegateBody in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
-        {
-            found = true;
-            InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, argumentMap);
-        }
-
-        if (!found)
-        {
-            InspectInvokedFactoryResult(context, resolved, computationScope, semanticModel, walk, argumentMap);
-        }
-    }
-
-    // `Get()(x)` executes whatever the same-tree factory returned -- and `Step()` whatever
-    // the computed property's getter returned -- with the returns' own argument maps.
-    private static void InspectInvokedFactoryResult(
-        OperationAnalysisContext context,
-        IOperation resolved,
-        SyntaxNode computationScope,
-        SemanticModel? semanticModel,
-        ChaseState walk,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
-    {
-        while (resolved is IConversionOperation conversion)
-        {
-            resolved = conversion.Operand;
-        }
-
-        if (resolved is IInvocationOperation call
-            && ComputationLambdas.ResolveMethodBody(call.TargetMethod, semanticModel) is { } factory)
-        {
-            InspectReturnedDelegateBodies(context, factory, ComputationLambdas.BuildArgumentMap(call, argumentMap), computationScope, semanticModel, walk);
-            return;
-        }
-
-        if (ComputationLambdas.ReferencedVariable(resolved) is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
-            && ComputationLambdas.ResolveMethodBody(getter, semanticModel) is { } getterBody)
-        {
-            InspectReturnedDelegateBodies(context, getterBody, ComputationLambdas.BuildArgumentMap(resolved, argumentMap), computationScope, semanticModel, walk);
-        }
-    }
-
-    private static void InspectReturnedDelegateBodies(
-        OperationAnalysisContext context,
-        ComputationLambdas.ComputationBody source,
-        Dictionary<IParameterSymbol, IOperation>? sourceMap,
-        SyntaxNode computationScope,
-        SemanticModel? semanticModel,
-        ChaseState walk)
-    {
-        foreach (var (delegateBody, map) in ComputationLambdas.ReturnedBodies(source, semanticModel, sourceMap))
+        foreach (var (delegateBody, map) in ComputationLambdas.InvokedDelegateBodies(callee, semanticModel, argumentMap))
         {
             InspectDelegateBody(context, delegateBody, computationScope, semanticModel, walk, map);
         }
@@ -234,16 +183,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var inner in ComputationLambdas.Descend(helper.Body))
-            {
-                foreach (var target in MutationTargets(inner))
-                {
-                    ReportIfShared(context, target, helper.Scope, computationScope, nestedThis, nestedForeign, walk.ReportedTargets);
-                }
-
-                InspectCalledHelper(context, inner, computationScope, semanticModel, walk, nestedThis, nestedForeign, nestedMap);
-                InspectInvokedDelegate(context, inner, computationScope, semanticModel, walk, nestedMap);
-            }
+            InspectComputationOperations(context, helper, computationScope, semanticModel, walk, nestedMap, nestedThis, nestedForeign);
         }
     }
 
@@ -349,11 +289,7 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
 
         foreach (var argument in call.Arguments)
         {
-            var value = argument.Value;
-            while (value is IConversionOperation conversion)
-            {
-                value = conversion.Operand;
-            }
+            var value = ComputationLambdas.Unwrap(argument.Value);
 
             if (IsComputationInstance(value, thisParameter, foreignThis) && argument.Parameter is { } parameter)
             {
@@ -545,9 +481,9 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
     {
         switch (target)
         {
-            case ILocalReferenceOperation local when IsDeclaredOutside(local.Local, scope):
+            case ILocalReferenceOperation local when ComputationLambdas.IsDeclaredOutside(local.Local, scope):
                 return ("captured local", local.Local);
-            case IParameterReferenceOperation parameter when IsDeclaredOutside(parameter.Parameter, scope):
+            case IParameterReferenceOperation parameter when ComputationLambdas.IsDeclaredOutside(parameter.Parameter, scope):
                 return ("captured parameter", parameter.Parameter);
             case IFieldReferenceOperation { Field.IsStatic: true } staticField:
                 return ("static field", staticField.Field);
@@ -578,9 +514,9 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         {
             case var enclosing when IsComputationInstance(enclosing, thisParameter, foreignThis):
                 return (memberKind, member);
-            case ILocalReferenceOperation { Local.Type.IsValueType: true } local when IsDeclaredOutside(local.Local, scope):
+            case ILocalReferenceOperation { Local.Type.IsValueType: true } local when ComputationLambdas.IsDeclaredOutside(local.Local, scope):
                 return ("captured local", local.Local);
-            case IParameterReferenceOperation { Parameter.Type.IsValueType: true } parameter when IsDeclaredOutside(parameter.Parameter, scope):
+            case IParameterReferenceOperation { Parameter.Type.IsValueType: true } parameter when ComputationLambdas.IsDeclaredOutside(parameter.Parameter, scope):
                 return ("captured parameter", parameter.Parameter);
             case IFieldReferenceOperation { Type.IsValueType: true } outerField:
                 return ResolveSharedRoot(outerField, scope, thisParameter, foreignThis);
@@ -591,9 +527,4 @@ public sealed class CapturedMutationAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // Shared with MZR004; see ComputationLambdas.IsDeclaredOutside for the span-test rationale.
-    private static bool IsDeclaredOutside(ISymbol symbol, SyntaxNode scope)
-    {
-        return ComputationLambdas.IsDeclaredOutside(symbol, scope);
-    }
 }

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -53,29 +53,23 @@ internal static class ComputationLambdas
 
     private static IEnumerable<ComputationBody> BodiesIn(IOperation value, SemanticModel? semanticModel, HashSet<ISymbol>? visitedVariables)
     {
+        // GetOperation on a variable initializer's lambda/method-group syntax yields the
+        // operation WITHOUT the enclosing delegate-creation wrapper: unwrapping here makes
+        // the wrapped and bare forms one case each.
+        if (value is IDelegateCreationOperation creation)
+        {
+            value = creation.Target;
+        }
+
         switch (value)
         {
-            case IDelegateCreationOperation { Target: IAnonymousFunctionOperation lambda }:
+            case IAnonymousFunctionOperation lambda:
                 yield return new ComputationBody(lambda.Body, lambda.Syntax);
                 break;
-            case IAnonymousFunctionOperation bareLambda:
-                // GetOperation on a variable initializer's lambda syntax yields the function
-                // operation itself, without the enclosing delegate-creation wrapper.
-                yield return new ComputationBody(bareLambda.Body, bareLambda.Syntax);
-                break;
-            case IDelegateCreationOperation { Target: IMethodReferenceOperation methodReference }:
+            case IMethodReferenceOperation methodReference:
                 if (ResolveMethodBody(methodReference.Method, semanticModel) is { } resolved)
                 {
                     yield return resolved;
-                }
-
-                break;
-            case IMethodReferenceOperation bareMethodReference:
-                // Like the bare-lambda case: GetOperation on a variable initializer's method
-                // group yields the reference without the delegate-creation wrapper.
-                if (ResolveMethodBody(bareMethodReference.Method, semanticModel) is { } resolvedBare)
-                {
-                    yield return resolvedBare;
                 }
 
                 break;
@@ -100,6 +94,46 @@ internal static class ComputationLambdas
                 }
 
                 break;
+
+            // A conditional (or null-coalescing) computation stores whichever arm the flow
+            // picks: both are possible bodies, so both are walked.
+            case IConditionalOperation or ICoalesceOperation:
+                foreach (var body in BranchBodies(value, semanticModel, visitedVariables))
+                {
+                    yield return body;
+                }
+
+                break;
+        }
+    }
+
+    private static IEnumerable<ComputationBody> BranchBodies(IOperation value, SemanticModel? semanticModel, HashSet<ISymbol>? visitedVariables)
+    {
+        var arms = value switch
+        {
+            IConditionalOperation conditional => (First: (IOperation?)conditional.WhenTrue, Second: conditional.WhenFalse),
+            ICoalesceOperation coalesce => (First: (IOperation?)coalesce.Value, Second: coalesce.WhenNull),
+            _ => (First: null, Second: null),
+        };
+
+        if (arms.First is null)
+        {
+            yield break;
+        }
+
+        foreach (var body in BodiesIn(arms.First, semanticModel, visitedVariables))
+        {
+            yield return body;
+        }
+
+        if (arms.Second is null)
+        {
+            yield break;
+        }
+
+        foreach (var body in BodiesIn(arms.Second, semanticModel, visitedVariables))
+        {
+            yield return body;
         }
     }
 

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -622,12 +622,42 @@ internal static class ComputationLambdas
             }
         }
 
+        // A declaration initializer definitely OVERWRITTEN before this read leaves the
+        // surviving writes as the only closures the call can store: their values are patch
+        // bodies too (resolution-only, like everything here -- MZR004 owns the accounting).
+        if (variable is not null)
+        {
+            foreach (var body in SurvivingWriteBodies(variable, reference, semanticModel))
+            {
+                yield return body;
+            }
+        }
+
+        // An ALIAS resolves to its assembled source first: `Func<int,int> p = Patch;`
+        // stores whatever the computed property's getter (or the stored factory call)
+        // returned.
+        var source = ResolveDelegateValue(reference, semanticModel, null);
+        while (source is IConversionOperation sourceConversion)
+        {
+            source = sourceConversion.Operand;
+        }
+
+        foreach (var body in AssembledSourceBodies(source, semanticModel))
+        {
+            yield return body;
+        }
+    }
+
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssembledSourceBodies(IOperation source, SemanticModel? semanticModel)
+    {
+        var resolvedVariable = ReferencedVariable(source);
+
         // The INDEXER's argument map keeps the returned lambda's index-parameter references
         // resolvable (`this[Signal<int> s] { get { return x => { s.Set(1); ... }; } }`).
-        if (variable is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
+        if (resolvedVariable is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
             && ResolveMethodBody(getter, semanticModel) is { } getterBody)
         {
-            var propertyMap = BuildArgumentMap(reference, null);
+            var propertyMap = BuildArgumentMap(source, null);
             foreach (var body in ReturnedBodies(getterBody, semanticModel, propertyMap))
             {
                 yield return (body, propertyMap);
@@ -637,8 +667,8 @@ internal static class ComputationLambdas
         // A patch produced by a same-tree delegate FACTORY -- called inline, or stored
         // through the variable's initializer -- resolves through the factory's returns,
         // with the call's own argument map.
-        var call = reference as IInvocationOperation
-            ?? UnwrappedInitializerCall(variable, semanticModel);
+        var call = source as IInvocationOperation
+            ?? UnwrappedInitializerCall(resolvedVariable, semanticModel);
         if (call is not null && ResolveMethodBody(call.TargetMethod, semanticModel) is { } factoryBody)
         {
             var callMap = BuildArgumentMap(call, null);
@@ -647,6 +677,60 @@ internal static class ComputationLambdas
                 yield return (body, callMap);
             }
         }
+    }
+
+    // The reassignment carve-out, resolution-only: when the declaration initializer is
+    // definitely overwritten on the straight-line path to this read, only the surviving
+    // writes can be the stored closure -- each write that no other candidate definitely
+    // kills resolves like an out-helper's assignment (values through aliases, forwarded
+    // handoffs recursively). MZR002/MZR003 walk these; MZR004's own carve-out accounts.
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> SurvivingWriteBodies(
+        ISymbol variable,
+        IOperation reference,
+        SemanticModel? semanticModel)
+    {
+        if (semanticModel is null || !InitializerDefinitelyOverwritten(variable, reference, semanticModel))
+        {
+            yield break;
+        }
+
+        var writes = new List<SyntaxNode>();
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (IsVariableWriteNode(node, variable, semanticModel)
+                && CanExecuteBefore(node, reference.Syntax, variable, semanticModel))
+            {
+                writes.Add(node);
+            }
+        }
+
+        foreach (var write in writes)
+        {
+            if (writes.Any(other => other != write && DefinitelyOverwrites(other, write, reference.Syntax, variable, semanticModel)))
+            {
+                continue;
+            }
+
+            foreach (var body in OutHandoffNodeBodies(write, variable, semanticModel, new HashSet<SyntaxNode>(), callMap: null))
+            {
+                yield return body;
+            }
+        }
+    }
+
+    private static bool InitializerDefinitelyOverwritten(ISymbol variable, IOperation reference, SemanticModel semanticModel)
+    {
+        if (variable.DeclaringSyntaxReferences.FirstOrDefault() is not { } declaration
+            || declaration.SyntaxTree != semanticModel.SyntaxTree
+            || declaration.GetSyntax() is not VariableDeclaratorSyntax { Initializer: not null } declarator)
+        {
+            return false;
+        }
+
+        return semanticModel.SyntaxTree.GetRoot().DescendantNodes().Any(node =>
+            IsVariableWriteNode(node, variable, semanticModel)
+            && CanExecuteBefore(node, reference.Syntax, variable, semanticModel)
+            && DefinitelyOverwrites(node, declarator, reference.Syntax, variable, semanticModel));
     }
 
     // A delegate VALUE collapsed through variable-alias initializers and parameter-to-
@@ -717,7 +801,7 @@ internal static class ComputationLambdas
         return initializer as IInvocationOperation;
     }
 
-    public static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
+    public static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null, HashSet<(IMethodSymbol, string)>? visitedFactories = null)
     {
         foreach (var inner in DescendDirectExecution(methodBody.Body))
         {
@@ -727,10 +811,55 @@ internal static class ComputationLambdas
             }
 
             // Aliases resolve too: `var q = p; return q;` hands back the call-site value.
-            foreach (var body in OfArgumentValue(ResolveDelegateValue(returned, semanticModel, argumentMap), semanticModel))
+            var resolved = ResolveDelegateValue(returned, semanticModel, argumentMap);
+            var resolvedAny = false;
+            foreach (var body in OfArgumentValue(resolved, semanticModel))
+            {
+                resolvedAny = true;
+                yield return body;
+            }
+
+            if (resolvedAny)
+            {
+                continue;
+            }
+
+            visitedFactories ??= new HashSet<(IMethodSymbol, string)>();
+            foreach (var body in NestedFactoryReturnedBodies(resolved, semanticModel, argumentMap, visitedFactories))
             {
                 yield return body;
             }
+        }
+    }
+
+    // `return Make();` assembles one factory deeper: chased through the nested call's
+    // returns with its own map, the visited set bounding recursive factories.
+    private static IEnumerable<ComputationBody> NestedFactoryReturnedBodies(
+        IOperation resolved,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<(IMethodSymbol, string)> visitedFactories)
+    {
+        while (resolved is IConversionOperation conversion)
+        {
+            resolved = conversion.Operand;
+        }
+
+        if (resolved is not IInvocationOperation call
+            || ResolveMethodBody(call.TargetMethod, semanticModel) is not { } nested)
+        {
+            yield break;
+        }
+
+        var nestedMap = BuildArgumentMap(call, argumentMap);
+        if (!visitedFactories.Add((call.TargetMethod, ArgumentMapKey(nestedMap))))
+        {
+            yield break;
+        }
+
+        foreach (var body in ReturnedBodies(nested, semanticModel, nestedMap, visitedFactories))
+        {
+            yield return body;
         }
     }
 
@@ -757,24 +886,21 @@ internal static class ComputationLambdas
             ? BuildArgumentMap(call, outerMap)
             : outerMap;
 
-        // The kill filter mirrors MZR004's accounting chase: an assignment definitely
-        // overwritten on the straight-line path to the helper's return can never be the
-        // delegate the caller receives.
+        // The kill filter mirrors MZR004's accounting chase: a write -- assignment or
+        // forwarded handoff -- definitely overwritten on the straight-line path to the
+        // helper's return can never be the delegate the caller receives.
         var writes = new List<SyntaxNode>();
         foreach (var node in helper.Scope.DescendantNodes())
         {
-            if (node is AssignmentExpressionSyntax candidate
-                && ReassignmentTargets(candidate) is { } targets
-                && targets.Any(target => WritesVariable(target, parameter, semanticModel)))
+            if (IsVariableWriteNode(node, parameter, semanticModel))
             {
-                writes.Add(candidate);
+                writes.Add(node);
             }
         }
 
-        foreach (var node in helper.Scope.DescendantNodes())
+        foreach (var node in writes)
         {
-            if (node is AssignmentExpressionSyntax victim
-                && writes.Any(other => other != victim && DefinitelyOverwrites(other, victim, helper.Scope, parameter, semanticModel)))
+            if (writes.Any(other => other != node && DefinitelyOverwrites(other, node, helper.Scope, parameter, semanticModel)))
             {
                 continue;
             }
@@ -786,9 +912,24 @@ internal static class ComputationLambdas
         }
     }
 
+    // A node that can BIND the variable: a (possibly deconstructing) assignment whose target
+    // writes it, or an out-argument handoff naming it (ref aliases included on both). Shared
+    // by the out-helper kill filter and the surviving-write resolution.
+    private static bool IsVariableWriteNode(SyntaxNode node, ISymbol variable, SemanticModel semanticModel)
+    {
+        return node switch
+        {
+            AssignmentExpressionSyntax assignment => ReassignmentTargets(assignment) is { } targets
+                && targets.Any(target => WritesVariable(target, variable, semanticModel)),
+            ArgumentSyntax argument => argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
+                && WritesVariable(argument.Expression, variable, semanticModel),
+            _ => false,
+        };
+    }
+
     private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> OutHandoffNodeBodies(
         SyntaxNode node,
-        IParameterSymbol parameter,
+        ISymbol variable,
         SemanticModel semanticModel,
         HashSet<SyntaxNode> visited,
         Dictionary<IParameterSymbol, IOperation>? callMap)
@@ -797,8 +938,8 @@ internal static class ComputationLambdas
         {
             case AssignmentExpressionSyntax assignment
                 when ReassignmentTargets(assignment) is { } targets
-                    && targets.Any(target => WritesVariable(target, parameter, semanticModel)):
-                foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
+                    && targets.Any(target => WritesVariable(target, variable, semanticModel)):
+                foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
                 {
                     // The call-site map resolves a value forwarded from ANOTHER delegate
                     // parameter (`Provide(source, out patch)` with `p = source`), aliases
@@ -812,7 +953,7 @@ internal static class ComputationLambdas
                 break;
             case ArgumentSyntax forwarded
                 when forwarded.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
-                    && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(forwarded.Expression).Symbol, parameter):
+                    && WritesVariable(forwarded.Expression, variable, semanticModel):
                 foreach (var body in OutHandoffBodies(forwarded, semanticModel, visited, callMap))
                 {
                     yield return body;
@@ -997,6 +1138,34 @@ internal static class ComputationLambdas
             }
 
             foreach (var descendant in Descend(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    // The unpruned walk for STORED-closure facts (MZR004's capture verdicts): a nested
+    // computation host's delegate is still BUILT by this body, so what it captures is pinned
+    // in this body's display chain even though the nested invocation's own analysis covers it
+    // for the mutation/Set rules. Only a nested OPTIMISTIC PATCH is skipped -- its own Apply
+    // analysis repeats exactly this capture walk on the same operations.
+    public static IEnumerable<IOperation> DescendStoredClosure(IOperation root)
+    {
+        foreach (var child in root.ChildOperations)
+        {
+            yield return child;
+
+            if (child is IInvocationOperation invocation && FactoryMethods.IsOptimisticPatchHost(invocation.TargetMethod))
+            {
+                foreach (var descendant in DescendNestedHostArguments(invocation, DescendStoredClosure))
+                {
+                    yield return descendant;
+                }
+
+                continue;
+            }
+
+            foreach (var descendant in DescendStoredClosure(child))
             {
                 yield return descendant;
             }

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -318,6 +318,18 @@ internal static class ComputationLambdas
             || !scope.Span.Contains(declaration.Span);
     }
 
+    // Whether the symbol's DECLARING FUNCTION (method, local function, lambda, accessor)
+    // lexically encloses the scope -- i.e. the symbol lives in an environment the scope's
+    // closure shares, rather than in some helper invocation that is recreated per call.
+    // Shared by MZR002's and MZR004's local-function chasing.
+    public static bool DeclaredInFunctionEnclosing(ISymbol symbol, SyntaxNode scope)
+    {
+        var declaration = symbol.ContainingSymbol?.DeclaringSyntaxReferences.FirstOrDefault();
+        return declaration is not null
+            && declaration.SyntaxTree == scope.SyntaxTree
+            && declaration.Span.Contains(scope.Span);
+    }
+
     // The tightest useful squiggle for an invocation: the member name, not the whole call with
     // its (possibly multi-line lambda) arguments.
     public static Location NameLocation(IInvocationOperation invocation)

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -88,7 +88,7 @@ internal static class ComputationLambdas
 
                 break;
             case ILocalReferenceOperation or IFieldReferenceOperation or IPropertyReferenceOperation:
-                foreach (var body in BodiesFromVariableInitializer(ReferencedVariable(value), semanticModel, visitedVariables))
+                foreach (var body in BodiesFromVariableInitializer(ReferencedVariable(value), value, semanticModel, visitedVariables))
                 {
                     yield return body;
                 }
@@ -167,7 +167,7 @@ internal static class ComputationLambdas
     // chase -- the runtime checks cover what this cannot see, like the method-group rule
     // above). The visited set breaks initializer reference cycles (two fields initialized from
     // each other).
-    private static IEnumerable<ComputationBody> BodiesFromVariableInitializer(ISymbol? variable, SemanticModel? semanticModel, HashSet<ISymbol>? visitedVariables)
+    private static IEnumerable<ComputationBody> BodiesFromVariableInitializer(ISymbol? variable, IOperation reference, SemanticModel? semanticModel, HashSet<ISymbol>? visitedVariables)
     {
         visitedVariables ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         if (variable is null || !visitedVariables.Add(variable))
@@ -175,8 +175,13 @@ internal static class ComputationLambdas
             yield break;
         }
 
+        // A definitely-overwritten initializer can never be the stored value at THIS read:
+        // walking it would charge (or excuse) a closure the overwrite provably replaced --
+        // the surviving-write resolution owns that case. May-be-overwritten initializers
+        // keep the best-effort trust below.
         var operation = SameTreeInitializerOperation(variable, semanticModel);
-        if (operation is null)
+        if (operation is null
+            || (semanticModel is not null && InitializerDefinitelyOverwritten(variable, reference, semanticModel)))
         {
             yield break;
         }
@@ -324,7 +329,7 @@ internal static class ComputationLambdas
             return true;
         }
 
-        if (readSite is null)
+        if (readSite is null || !ReadsThroughOwnReceiver(readSite, variable))
         {
             return false;
         }
@@ -332,6 +337,16 @@ internal static class ComputationLambdas
         var function = EnclosingFunction(write);
         return function is not null
             && (ReferenceEquals(function, EnclosingFunction(readSite)) || function.Span.Contains(readSite.Span));
+    }
+
+    // The synthesis pairs a write through the member's OWN object with a read through it
+    // too: `other.Patch` reads some other instance, which the `this`-receiver write says
+    // nothing about -- that instance's copy may still be null or externally supplied.
+    // Statics have no receiver to mismatch.
+    private static bool ReadsThroughOwnReceiver(SyntaxNode readSite, ISymbol variable)
+    {
+        return variable.IsStatic
+            || readSite is IdentifierNameSyntax or MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax };
     }
 
     // Only a write that fully DETERMINES the value qualifies: `x ??= ...` / `x += ...` can
@@ -622,15 +637,14 @@ internal static class ComputationLambdas
             }
         }
 
-        // A declaration initializer definitely OVERWRITTEN before this read leaves the
-        // surviving writes as the only closures the call can store: their values are patch
-        // bodies too (resolution-only, like everything here -- MZR004 owns the accounting).
-        if (variable is not null)
+        // A declaration initializer definitely OVERWRITTEN before its read leaves the
+        // surviving writes as the only closures the call can store -- at EVERY alias link:
+        // `src = safe; src = other; var patch = src;` stores src's surviving write even
+        // though the patch variable itself is never rebound. (Resolution-only, like
+        // everything here -- MZR004 owns the accounting.)
+        foreach (var body in AliasChainSurvivingBodies(reference, semanticModel))
         {
-            foreach (var body in SurvivingWriteBodies(variable, reference, semanticModel))
-            {
-                yield return body;
-            }
+            yield return body;
         }
 
         // An ALIAS resolves to its assembled source first: `Func<int,int> p = Patch;`
@@ -657,10 +671,9 @@ internal static class ComputationLambdas
         if (resolvedVariable is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
             && ResolveMethodBody(getter, semanticModel) is { } getterBody)
         {
-            var propertyMap = BuildArgumentMap(source, null);
-            foreach (var body in ReturnedBodies(getterBody, semanticModel, propertyMap))
+            foreach (var entry in ReturnedBodies(getterBody, semanticModel, BuildArgumentMap(source, null)))
             {
-                yield return (body, propertyMap);
+                yield return entry;
             }
         }
 
@@ -671,10 +684,44 @@ internal static class ComputationLambdas
             ?? UnwrappedInitializerCall(resolvedVariable, semanticModel);
         if (call is not null && ResolveMethodBody(call.TargetMethod, semanticModel) is { } factoryBody)
         {
-            var callMap = BuildArgumentMap(call, null);
-            foreach (var body in ReturnedBodies(factoryBody, semanticModel, callMap))
+            foreach (var entry in ReturnedBodies(factoryBody, semanticModel, BuildArgumentMap(call, null)))
             {
-                yield return (body, callMap);
+                yield return entry;
+            }
+        }
+    }
+
+    // The surviving-write carve-out at every ALIAS LINK's read site, mirroring
+    // ResolveDelegateValue's hops: a link that was written owns its value (the chase below
+    // covers its definite-overwrite case), so the chain stops there.
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AliasChainSurvivingBodies(IOperation reference, SemanticModel? semanticModel)
+    {
+        var link = reference;
+        HashSet<ISymbol>? visited = null;
+        while (ReferencedVariable(link) is { } variable)
+        {
+            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visited.Add(variable))
+            {
+                yield break;
+            }
+
+            foreach (var body in SurvivingWriteBodies(variable, link, semanticModel))
+            {
+                yield return body;
+            }
+
+            if (SameTreeInitializerOperation(variable, semanticModel) is not { } next
+                || IsWrittenBefore(variable, link.Syntax, semanticModel)
+                || !IsReferenceShape(next))
+            {
+                yield break;
+            }
+
+            link = next;
+            while (link is IConversionOperation conversion)
+            {
+                link = conversion.Operand;
             }
         }
     }
@@ -720,7 +767,10 @@ internal static class ComputationLambdas
 
     private static bool InitializerDefinitelyOverwritten(ISymbol variable, IOperation reference, SemanticModel semanticModel)
     {
-        if (variable.DeclaringSyntaxReferences.FirstOrDefault() is not { } declaration
+        // A member read through some OTHER receiver observes that instance's storage: the
+        // own-receiver writes this scan counts say nothing definite about it.
+        if (!ReadsThroughOwnReceiver(reference.Syntax, variable)
+            || variable.DeclaringSyntaxReferences.FirstOrDefault() is not { } declaration
             || declaration.SyntaxTree != semanticModel.SyntaxTree
             || declaration.GetSyntax() is not VariableDeclaratorSyntax { Initializer: not null } declarator)
         {
@@ -801,7 +851,9 @@ internal static class ComputationLambdas
         return initializer as IInvocationOperation;
     }
 
-    public static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null, HashSet<(IMethodSymbol, string)>? visitedFactories = null)
+    // Each body carries the ARGUMENT MAP that resolved it: a nested factory's returns bind
+    // that factory's own parameters, which the caller's map knows nothing about.
+    public static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null, HashSet<(IMethodSymbol, string)>? visitedFactories = null)
     {
         foreach (var inner in DescendDirectExecution(methodBody.Body))
         {
@@ -816,7 +868,7 @@ internal static class ComputationLambdas
             foreach (var body in OfArgumentValue(resolved, semanticModel))
             {
                 resolvedAny = true;
-                yield return body;
+                yield return (body, argumentMap);
             }
 
             if (resolvedAny)
@@ -825,16 +877,16 @@ internal static class ComputationLambdas
             }
 
             visitedFactories ??= new HashSet<(IMethodSymbol, string)>();
-            foreach (var body in NestedFactoryReturnedBodies(resolved, semanticModel, argumentMap, visitedFactories))
+            foreach (var entry in NestedFactoryReturnedBodies(resolved, semanticModel, argumentMap, visitedFactories))
             {
-                yield return body;
+                yield return entry;
             }
         }
     }
 
     // `return Make();` assembles one factory deeper: chased through the nested call's
     // returns with its own map, the visited set bounding recursive factories.
-    private static IEnumerable<ComputationBody> NestedFactoryReturnedBodies(
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> NestedFactoryReturnedBodies(
         IOperation resolved,
         SemanticModel? semanticModel,
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
@@ -857,9 +909,9 @@ internal static class ComputationLambdas
             yield break;
         }
 
-        foreach (var body in ReturnedBodies(nested, semanticModel, nestedMap, visitedFactories))
+        foreach (var entry in ReturnedBodies(nested, semanticModel, nestedMap, visitedFactories))
         {
-            yield return body;
+            yield return entry;
         }
     }
 
@@ -914,15 +966,18 @@ internal static class ComputationLambdas
 
     // A node that can BIND the variable: a (possibly deconstructing) assignment whose target
     // writes it, or an out-argument handoff naming it (ref aliases included on both). Shared
-    // by the out-helper kill filter and the surviving-write resolution.
+    // by the out-helper kill filter and the surviving-write resolution. Member writes count
+    // only through the member's OWN receiver -- `other.patch = safe;` on some other instance
+    // neither kills nor stands in for what a `this.patch` read observes.
     private static bool IsVariableWriteNode(SyntaxNode node, ISymbol variable, SemanticModel semanticModel)
     {
         return node switch
         {
             AssignmentExpressionSyntax assignment => ReassignmentTargets(assignment) is { } targets
-                && targets.Any(target => WritesVariable(target, variable, semanticModel)),
+                && targets.Any(target => WritesVariable(target, variable, semanticModel) && WritesThroughOwnReceiver(target, variable)),
             ArgumentSyntax argument => argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
-                && WritesVariable(argument.Expression, variable, semanticModel),
+                && WritesVariable(argument.Expression, variable, semanticModel)
+                && WritesThroughOwnReceiver(argument.Expression, variable),
             _ => false,
         };
     }

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -318,6 +318,22 @@ internal static class ComputationLambdas
             || !scope.Span.Contains(declaration.Span);
     }
 
+    // A symbol or member referenced only inside nameof() is a compile-time string -- nothing
+    // is captured, read, invoked, or stored. Shared guard for MZR002's and MZR004's reporting
+    // and helper chasing.
+    public static bool IsInsideNameOf(IOperation operation)
+    {
+        for (var current = operation.Parent; current is not null; current = current.Parent)
+        {
+            if (current is INameOfOperation)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // Whether the symbol's DECLARING FUNCTION (method, local function, lambda, accessor)
     // lexically encloses the scope -- i.e. the symbol lives in an environment the scope's
     // closure shares, rather than in some helper invocation that is recreated per call.

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -181,7 +181,45 @@ internal static class ComputationLambdas
             _ => null,
         };
 
+        // `Func<int,int> patch; patch = static x => x;` initializes by assignment: when the
+        // SOLE same-tree write is a simple assignment, its right-hand side is the initializer.
+        initializer ??= EffectiveInitializerAssignment(variable, semanticModel)?.Right;
+
         return initializer is null ? null : semanticModel.GetOperation(initializer);
+    }
+
+    // The single same-tree assignment standing in for a missing declaration initializer, or
+    // null when the declaration has one, there are several writes (ambiguous), or the one
+    // write is not a plain `x = value`. Reassignment scans EXCLUDE this node: it is the
+    // initialization, not a rebind.
+    public static AssignmentExpressionSyntax? EffectiveInitializerAssignment(ISymbol variable, SemanticModel? semanticModel)
+    {
+        if (semanticModel is null || variable.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                is VariableDeclaratorSyntax { Initializer: not null }
+                or PropertyDeclarationSyntax { Initializer: not null }
+                or SingleVariableDesignationSyntax)
+        {
+            return null;
+        }
+
+        AssignmentExpressionSyntax? sole = null;
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (ReassignmentTargets(node) is not { } targets
+                || !targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable)))
+            {
+                continue;
+            }
+
+            if (sole is not null || node is not AssignmentExpressionSyntax { Left: not TupleExpressionSyntax } assignment)
+            {
+                return null;
+            }
+
+            sole = assignment;
+        }
+
+        return sole;
     }
 
     private static ExpressionSyntax? DeconstructionInitializer(SingleVariableDesignationSyntax designation)
@@ -466,15 +504,18 @@ internal static class ComputationLambdas
 
     // Execution-order reasoning without dataflow: an assignment in a DIFFERENT function body
     // (a helper, a lambda, another method) runs whenever that function does -- unknowable, so
-    // it counts. In the same function, one textually before the reference obviously precedes
-    // it, and one textually after still reaches it when a loop encloses both AND the variable
-    // outlives the iteration (a loop-body local is freshly initialized each pass). Shared by
-    // MZR004's delegate-reassignment scan and the provenance checks in ReceiverChains.
-    public static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference, ISymbol variable)
+    // it counts, UNLESS that function is a local function never referenced in the tree (dead
+    // code cannot execute). In the same function, one textually before the reference obviously
+    // precedes it, and one textually after still reaches it when a loop encloses both AND the
+    // variable outlives the iteration (a loop-body local is freshly initialized each pass).
+    // Shared by MZR004's delegate-reassignment scan and the provenance checks in
+    // ReceiverChains.
+    public static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference, ISymbol variable, SemanticModel? semanticModel)
     {
-        if (!ReferenceEquals(EnclosingFunction(assignment), EnclosingFunction(reference)))
+        var assignmentFunction = EnclosingFunction(assignment);
+        if (!ReferenceEquals(assignmentFunction, EnclosingFunction(reference)))
         {
-            return true;
+            return CouldExecute(assignmentFunction, semanticModel);
         }
 
         if (assignment.SpanStart < reference.SpanStart)
@@ -507,6 +548,30 @@ internal static class ComputationLambdas
         }
 
         return null;
+    }
+
+    // A LOCAL FUNCTION with no reference outside its own body is dead code: its writes cannot
+    // execute. Anything else -- a method, accessor, or lambda, all reachable from outside this
+    // tree or through stored values -- stays unknowable and counts.
+    private static bool CouldExecute(SyntaxNode? function, SemanticModel? semanticModel)
+    {
+        if (function is not LocalFunctionStatementSyntax local || semanticModel is null
+            || semanticModel.GetDeclaredSymbol(local) is not { } symbol)
+        {
+            return true;
+        }
+
+        foreach (var identifier in semanticModel.SyntaxTree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText == symbol.Name
+                && !local.Span.Contains(identifier.Span)
+                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier).Symbol, symbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Only the loop BODY re-declares per iteration: a variable in a for-INITIALIZER is

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -79,12 +79,9 @@ internal static class ComputationLambdas
 
                 break;
             case IArrayCreationOperation { Initializer: { } initializer }:
-                foreach (var element in initializer.ElementValues)
+                foreach (var body in BodiesInArrayElements(initializer, semanticModel, visitedVariables))
                 {
-                    foreach (var body in BodiesIn(element, semanticModel, visitedVariables))
-                    {
-                        yield return body;
-                    }
+                    yield return body;
                 }
 
                 break;
@@ -95,6 +92,18 @@ internal static class ComputationLambdas
                 }
 
                 break;
+        }
+    }
+
+    // The params array of computations the structured-concurrency factories take.
+    private static IEnumerable<ComputationBody> BodiesInArrayElements(IArrayInitializerOperation initializer, SemanticModel? semanticModel, HashSet<ISymbol>? visitedVariables)
+    {
+        foreach (var element in initializer.ElementValues)
+        {
+            foreach (var body in BodiesIn(element, semanticModel, visitedVariables))
+            {
+                yield return body;
+            }
         }
     }
 

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -942,6 +942,25 @@ internal static class ComputationLambdas
         }
 
         var resolved = ResolveDelegateValue(ResolveConditionalReceiver(callee), semanticModel, argumentMap);
+
+        // A conditional callee runs whichever arm the flow picked: each is resolved on its
+        // own, so a directly-resolvable arm cannot stop the assembled chase for a sibling.
+        foreach (var arm in ValueArms(resolved))
+        {
+            foreach (var entry in InvokedArmBodies(arm, invoke, semanticModel, argumentMap))
+            {
+                yield return entry;
+            }
+        }
+    }
+
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> InvokedArmBodies(
+        IOperation arm,
+        IInvocationOperation invoke,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        var resolved = ResolveDelegateValue(arm, semanticModel, argumentMap);
         var found = false;
         foreach (var body in OfArgumentValue(resolved, semanticModel))
         {
@@ -963,6 +982,49 @@ internal static class ComputationLambdas
         }
     }
 
+    // The RECEIVER a method-group callee captured (`Action step = other.Touch;`), or null
+    // when the callee is a lambda or a static target. MZR002 needs it: that body's `this`
+    // is the captured object, not the computation's.
+    public static IOperation? InvokedDelegateReceiver(IInvocationOperation invoke, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        if (invoke.Instance is not { } callee)
+        {
+            return null;
+        }
+
+        // Follows the same hops that FIND the body: the alias collapse stops at a variable
+        // whose initializer is a method GROUP (not a reference shape), so the initializer
+        // chain is walked here too, delegate-creation wrappers unwrapped.
+        var current = Unwrap(ResolveDelegateValue(ResolveConditionalReceiver(callee), semanticModel, argumentMap));
+        HashSet<ISymbol>? visited = null;
+        while (true)
+        {
+            if (current is IDelegateCreationOperation creation)
+            {
+                current = Unwrap(creation.Target);
+                continue;
+            }
+
+            if (current is IMethodReferenceOperation methodReference)
+            {
+                return methodReference.Instance;
+            }
+
+            if (ReferencedVariable(current) is not { } variable)
+            {
+                return null;
+            }
+
+            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visited.Add(variable) || SameTreeInitializerOperation(variable, semanticModel) is not { } initializer)
+            {
+                return null;
+            }
+
+            current = Unwrap(initializer);
+        }
+    }
+
     // The invoked delegate's OWN parameters bind to the call's arguments, exactly like a
     // called helper's: `Action<C> step = c => c.Counter++; step(this);` writes the
     // computation's instance, and `step(otherSignal)` carries that signal's provenance.
@@ -979,10 +1041,16 @@ internal static class ComputationLambdas
             return outer;
         }
 
+        // The ARGUMENT's own parameter decides its slot, so `step(other: a, mine: b)` binds
+        // by name; the delegate's Invoke parameters line up positionally with the resolved
+        // body's, which is what carries the value to the lambda's own parameter symbol.
         var map = CopyOf(outer);
-        for (var i = 0; i < parameters.Length && i < invoke.Arguments.Length; i++)
+        foreach (var argument in invoke.Arguments)
         {
-            map[parameters[i]] = invoke.Arguments[i].Value;
+            if (argument.Parameter is { Ordinal: var ordinal } && ordinal < parameters.Length)
+            {
+                map[parameters[ordinal]] = argument.Value;
+            }
         }
 
         return map;
@@ -1190,8 +1258,28 @@ internal static class ComputationLambdas
     // by the out-helper kill filter and the surviving-write resolution. Member writes count
     // only through the member's OWN receiver -- `other.patch = safe;` on some other instance
     // neither kills nor stands in for what a `this.patch` read observes.
+    // A write the flow can never reach -- one after an unconditional `return`/`throw` --
+    // binds nothing the caller can observe, so it is no candidate and kills nothing.
+    // Roslyn answers this exactly; anything it cannot analyse counts as reachable.
+    public static bool IsReachable(SyntaxNode node, SemanticModel semanticModel)
+    {
+        var statement = node.FirstAncestorOrSelf<StatementSyntax>();
+        if (statement is null || statement.Parent is not BlockSyntax || statement.SyntaxTree != semanticModel.SyntaxTree)
+        {
+            return true;
+        }
+
+        var flow = semanticModel.AnalyzeControlFlow(statement);
+        return !flow.Succeeded || flow.StartPointIsReachable;
+    }
+
     private static bool IsVariableWriteNode(SyntaxNode node, ISymbol variable, SemanticModel semanticModel)
     {
+        if (!IsReachable(node, semanticModel))
+        {
+            return false;
+        }
+
         return node switch
         {
             AssignmentExpressionSyntax assignment => ReassignmentTargets(assignment) is { } targets

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -577,7 +577,7 @@ internal static class ComputationLambdas
     // forwarded handoffs), or returned by a same-tree computed get-only delegate property.
     // Resolution only -- MZR004 owns the unverifiable accounting for these shapes; MZR003
     // needs the BODIES, because a Set inside them still throws under the evaluation lock.
-    public static IEnumerable<ComputationBody> AssembledPatchBodies(IOperation value, SemanticModel? semanticModel)
+    public static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssembledPatchBodies(IOperation value, SemanticModel? semanticModel)
     {
         var reference = value;
         while (reference is IConversionOperation conversion)
@@ -588,7 +588,7 @@ internal static class ComputationLambdas
         var variable = ReferencedVariable(reference);
         if (variable is not null && EffectiveInitializerWrite(variable, semanticModel) is ArgumentSyntax outWrite)
         {
-            foreach (var body in OutHandoffBodies(outWrite, semanticModel, new HashSet<SyntaxNode>()))
+            foreach (var body in OutHandoffBodies(outWrite, semanticModel, new HashSet<SyntaxNode>(), outerMap: null))
             {
                 yield return body;
             }
@@ -599,7 +599,7 @@ internal static class ComputationLambdas
         {
             foreach (var body in ReturnedBodies(getterBody, semanticModel))
             {
-                yield return body;
+                yield return (body, null);
             }
         }
     }
@@ -622,27 +622,42 @@ internal static class ComputationLambdas
 
     // The delegate bodies an out-helper binds to its parameter: direct assignments'
     // paired values, plus FORWARDED out handoffs (`Provide(out d) { Build(out d); }`)
-    // followed recursively -- the visited set bounds forwarding cycles.
-    public static IEnumerable<ComputationBody> OutHandoffBodies(ArgumentSyntax argument, SemanticModel? semanticModel, HashSet<SyntaxNode> visited)
+    // followed recursively -- the visited set bounds forwarding cycles. Each body carries
+    // the CALL-SITE argument map (composed through forwarding), so a lambda using another
+    // helper parameter keeps its provenance.
+    public static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> OutHandoffBodies(
+        ArgumentSyntax argument,
+        SemanticModel? semanticModel,
+        HashSet<SyntaxNode> visited,
+        Dictionary<IParameterSymbol, IOperation>? outerMap)
     {
         if (semanticModel is null || !visited.Add(argument)
-            || (semanticModel.GetOperation(argument) as IArgumentOperation)?.Parameter is not { } parameter
+            || (semanticModel.GetOperation(argument) as IArgumentOperation) is not { Parameter: { } parameter } argumentOperation
             || parameter.ContainingSymbol is not IMethodSymbol method
             || ResolveMethodBody(method, semanticModel) is not { } helper)
         {
             yield break;
         }
 
+        var callMap = argumentOperation.Parent is { } call
+            ? BuildArgumentMap(call, outerMap)
+            : outerMap;
+
         foreach (var node in helper.Scope.DescendantNodes())
         {
-            foreach (var body in OutHandoffNodeBodies(node, parameter, semanticModel, visited))
+            foreach (var body in OutHandoffNodeBodies(node, parameter, semanticModel, visited, callMap))
             {
                 yield return body;
             }
         }
     }
 
-    private static IEnumerable<ComputationBody> OutHandoffNodeBodies(SyntaxNode node, IParameterSymbol parameter, SemanticModel semanticModel, HashSet<SyntaxNode> visited)
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> OutHandoffNodeBodies(
+        SyntaxNode node,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        HashSet<SyntaxNode> visited,
+        Dictionary<IParameterSymbol, IOperation>? callMap)
     {
         switch (node)
         {
@@ -653,7 +668,7 @@ internal static class ComputationLambdas
                 {
                     foreach (var body in OfArgumentValue(value, semanticModel))
                     {
-                        yield return body;
+                        yield return (body, callMap);
                     }
                 }
 
@@ -661,7 +676,7 @@ internal static class ComputationLambdas
             case ArgumentSyntax forwarded
                 when forwarded.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
                     && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(forwarded.Expression).Symbol, parameter):
-                foreach (var body in OutHandoffBodies(forwarded, semanticModel, visited))
+                foreach (var body in OutHandoffBodies(forwarded, semanticModel, visited, callMap))
                 {
                     yield return body;
                 }

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -504,26 +504,31 @@ internal static class ComputationLambdas
 
     // Execution-order reasoning without dataflow: an assignment in a DIFFERENT function body
     // (a helper, a lambda, another method) runs whenever that function does -- unknowable, so
-    // it counts, UNLESS that function is a local function never referenced in the tree (dead
-    // code cannot execute). In the same function, one textually before the reference obviously
-    // precedes it, and one textually after still reaches it when a loop encloses both AND the
-    // variable outlives the iteration (a loop-body local is freshly initialized each pass).
-    // Shared by MZR004's delegate-reassignment scan and the provenance checks in
-    // ReceiverChains.
+    // it counts, UNLESS that function is a LOCAL FUNCTION none of whose references can run
+    // before the read (dead code, or only called later). In the same function, one textually
+    // before the reference obviously precedes it, and one textually after still reaches it
+    // when a loop encloses both AND the variable outlives the iteration (a loop-body local is
+    // freshly initialized each pass). Shared by MZR004's delegate-reassignment scan and the
+    // provenance checks in ReceiverChains.
     public static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference, ISymbol variable, SemanticModel? semanticModel)
     {
-        var assignmentFunction = EnclosingFunction(assignment);
-        if (!ReferenceEquals(assignmentFunction, EnclosingFunction(reference)))
+        return CanExecuteBefore(assignment, reference, variable, semanticModel, visitedFunctions: null);
+    }
+
+    private static bool CanExecuteBefore(SyntaxNode node, SyntaxNode reference, ISymbol variable, SemanticModel? semanticModel, HashSet<SyntaxNode>? visitedFunctions)
+    {
+        var enclosing = EnclosingFunction(node);
+        if (!ReferenceEquals(enclosing, EnclosingFunction(reference)))
         {
-            return CouldExecute(assignmentFunction, semanticModel);
+            return CouldRunBefore(enclosing, reference, variable, semanticModel, visitedFunctions);
         }
 
-        if (assignment.SpanStart < reference.SpanStart)
+        if (node.SpanStart < reference.SpanStart)
         {
             return true;
         }
 
-        for (var current = assignment.Parent; current is not null; current = current.Parent)
+        for (var current = node.Parent; current is not null; current = current.Parent)
         {
             if (current is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax
                 && current.Span.Contains(reference.Span)
@@ -550,10 +555,12 @@ internal static class ComputationLambdas
         return null;
     }
 
-    // A LOCAL FUNCTION with no reference outside its own body is dead code: its writes cannot
-    // execute. Anything else -- a method, accessor, or lambda, all reachable from outside this
-    // tree or through stored values -- stays unknowable and counts.
-    private static bool CouldExecute(SyntaxNode? function, SemanticModel? semanticModel)
+    // A write inside a LOCAL FUNCTION runs only when some call site does: it can precede the
+    // read only if a REFERENCE to the function can (each reference is ordered recursively --
+    // the visited set breaks mutual-recursion cycles). Anything else -- a method, accessor, or
+    // lambda, all reachable from outside this tree or through stored values -- stays
+    // unknowable and counts.
+    private static bool CouldRunBefore(SyntaxNode? function, SyntaxNode reference, ISymbol variable, SemanticModel? semanticModel, HashSet<SyntaxNode>? visitedFunctions)
     {
         if (function is not LocalFunctionStatementSyntax local || semanticModel is null
             || semanticModel.GetDeclaredSymbol(local) is not { } symbol)
@@ -561,11 +568,18 @@ internal static class ComputationLambdas
             return true;
         }
 
+        visitedFunctions ??= new HashSet<SyntaxNode>();
+        if (!visitedFunctions.Add(local))
+        {
+            return false;
+        }
+
         foreach (var identifier in semanticModel.SyntaxTree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>())
         {
             if (identifier.Identifier.ValueText == symbol.Name
                 && !local.Span.Contains(identifier.Span)
-                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier).Symbol, symbol))
+                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier).Symbol, symbol)
+                && CanExecuteBefore(identifier, reference, variable, semanticModel, visitedFunctions))
             {
                 return true;
             }
@@ -638,6 +652,78 @@ internal static class ComputationLambdas
                     yield return accessor;
                 }
 
+                break;
+
+            // `using` runs Dispose/DisposeAsync before the evaluation exits: the resource
+            // type's concrete implementation is what actually runs.
+            case IUsingDeclarationOperation usingDeclaration:
+                foreach (var dispose in DisposeMethods(ResourceTypes(usingDeclaration.DeclarationGroup), usingDeclaration.IsAsynchronous))
+                {
+                    yield return dispose;
+                }
+
+                break;
+            case IUsingOperation usingOperation:
+                foreach (var dispose in DisposeMethods(ResourceTypes(usingOperation.Resources), usingOperation.IsAsynchronous))
+                {
+                    yield return dispose;
+                }
+
+                break;
+        }
+    }
+
+    private static IEnumerable<IMethodSymbol> DisposeMethods(IEnumerable<ITypeSymbol?> resourceTypes, bool isAsynchronous)
+    {
+        foreach (var type in resourceTypes)
+        {
+            if (ConcreteDispose(type, isAsynchronous) is { } dispose)
+            {
+                yield return dispose;
+            }
+        }
+    }
+
+    private static IMethodSymbol? ConcreteDispose(ITypeSymbol? type, bool isAsynchronous)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        var interfaceName = isAsynchronous ? "IAsyncDisposable" : "IDisposable";
+        var methodName = isAsynchronous ? "DisposeAsync" : "Dispose";
+        foreach (var implemented in type.AllInterfaces)
+        {
+            if (implemented.Name == interfaceName && implemented.ContainingNamespace?.ToDisplayString() == "System"
+                && implemented.GetMembers(methodName).FirstOrDefault() is IMethodSymbol member
+                && type.FindImplementationForInterfaceMember(member) is IMethodSymbol implementation)
+            {
+                return implementation;
+            }
+        }
+
+        // Pattern-based disposal (ref structs): a parameterless instance Dispose.
+        return type.GetMembers(methodName).OfType<IMethodSymbol>()
+            .FirstOrDefault(candidate => !candidate.IsStatic && candidate.Parameters.Length == 0);
+    }
+
+    private static IEnumerable<ITypeSymbol?> ResourceTypes(IOperation? resources)
+    {
+        switch (resources)
+        {
+            case IVariableDeclarationGroupOperation group:
+                foreach (var declaration in group.Declarations)
+                {
+                    foreach (var declarator in declaration.Declarators)
+                    {
+                        yield return declarator.Symbol.Type;
+                    }
+                }
+
+                break;
+            case { } expression:
+                yield return expression.Type;
                 break;
         }
     }

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -168,6 +168,18 @@ internal static class ComputationLambdas
         return callee;
     }
 
+    // An operation stripped of its implicit/explicit conversion wrappers -- the shape every
+    // resolution here actually wants to match on.
+    public static IOperation Unwrap(IOperation value)
+    {
+        while (value is IConversionOperation conversion)
+        {
+            value = conversion.Operand;
+        }
+
+        return value;
+    }
+
     // Shared with MZR004's method-group receiver resolution.
     public static ISymbol? ReferencedVariable(IOperation reference)
     {
@@ -178,6 +190,43 @@ internal static class ComputationLambdas
             IPropertyReferenceOperation property => property.Property,
             _ => null,
         };
+    }
+
+    // ReferencedVariable widened to PARAMETERS, for the chases that hop through a callee's
+    // binding as readily as through storage. Deliberately a separate function: the
+    // initializer resolutions below must NOT treat a parameter as declared storage.
+    public static ISymbol? ReferencedSymbol(IOperation? reference)
+    {
+        return reference switch
+        {
+            IParameterReferenceOperation parameter => parameter.Parameter,
+            null => null,
+            _ => ReferencedVariable(reference),
+        };
+    }
+
+    // The leaf ARMS of a conditional or coalesced value: each is a candidate the flow can
+    // pick, and each resolves independently. Null when the value is neither -- callers
+    // distinguish "not a conditional" from "one arm".
+    public static IReadOnlyList<IOperation>? ConditionalArms(IOperation value)
+    {
+        return value switch
+        {
+            IConditionalOperation { WhenFalse: { } whenFalse } conditional => new[] { conditional.WhenTrue, whenFalse },
+            IConditionalOperation conditional => new[] { conditional.WhenTrue },
+            ICoalesceOperation coalesce => new[] { coalesce.Value, coalesce.WhenNull },
+            _ => null,
+        };
+    }
+
+    // Every value a body RETURNS, on its own execution path (built callbacks' returns
+    // belong to the callback, not to this body -- hence the pruned walk).
+    public static IEnumerable<IOperation> ReturnedValues(IOperation body)
+    {
+        return DescendDirectExecution(body)
+            .OfType<IReturnOperation>()
+            .Select(returnOperation => returnOperation.ReturnedValue)
+            .OfType<IOperation>();
     }
 
     // `Func<Task<int>> compute = async () => ...; f.CreateMemoizR(compute);` is the same
@@ -564,11 +613,12 @@ internal static class ComputationLambdas
 
     public static IOperation? SubstituteArguments(IOperation? reference, Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        var current = reference;
-        while (current is IConversionOperation conversion)
+        if (reference is null)
         {
-            current = conversion.Operand;
+            return null;
         }
+
+        var current = Unwrap(reference);
 
         return current is IParameterReferenceOperation parameterReference
             && argumentMap?.TryGetValue(parameterReference.Parameter, out var argument) == true
@@ -641,11 +691,7 @@ internal static class ComputationLambdas
     // needs the BODIES, because a Set inside them still throws under the evaluation lock.
     public static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssembledPatchBodies(IOperation value, SemanticModel? semanticModel)
     {
-        var reference = value;
-        while (reference is IConversionOperation conversion)
-        {
-            reference = conversion.Operand;
-        }
+        var reference = Unwrap(value);
 
         // A conditional patch stores whichever arm the flow picked: each arm resolves
         // through this same supplemental chain separately, so a direct lambda arm cannot
@@ -682,11 +728,7 @@ internal static class ComputationLambdas
         // An ALIAS resolves to its assembled source first: `Func<int,int> p = Patch;`
         // stores whatever the computed property's getter (or the stored factory call)
         // returned.
-        var source = ResolveDelegateValue(reference, semanticModel, null);
-        while (source is IConversionOperation sourceConversion)
-        {
-            source = sourceConversion.Operand;
-        }
+        var source = Unwrap(ResolveDelegateValue(reference, semanticModel, null));
 
         foreach (var body in AssembledSourceBodies(source, semanticModel))
         {
@@ -762,10 +804,7 @@ internal static class ComputationLambdas
             }
 
             link = next;
-            while (link is IConversionOperation conversion)
-            {
-                link = conversion.Operand;
-            }
+            link = Unwrap(link);
         }
     }
 
@@ -796,7 +835,7 @@ internal static class ComputationLambdas
 
         foreach (var write in writes)
         {
-            if (writes.Any(other => other != write && DefinitelyOverwrites(other, write, reference.Syntax, variable, semanticModel)))
+            if (IsOverwrittenWithin(write, writes, reference.Syntax, variable, semanticModel))
             {
                 continue;
             }
@@ -843,17 +882,17 @@ internal static class ComputationLambdas
     // argument hops -- the resolution-only mirror of MZR004's invoked-delegate resolver,
     // with a strict rebind guard: a written alias or parameter stays put, because the
     // write (not the initializer or the call site) owns the value.
-    public static IOperation ResolveDelegateValue(IOperation value, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    public static IOperation ResolveDelegateValue(
+        IOperation value,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        Func<ISymbol, IOperation, bool>? aliasRebound = null)
     {
         var current = value;
         HashSet<ISymbol>? visited = null;
         while (true)
         {
-            var unwrapped = current;
-            while (unwrapped is IConversionOperation conversion)
-            {
-                unwrapped = conversion.Operand;
-            }
+            var unwrapped = Unwrap(current);
 
             if (unwrapped is IParameterReferenceOperation rebound
                 && argumentMap?.ContainsKey(rebound.Parameter) == true
@@ -875,9 +914,8 @@ internal static class ComputationLambdas
 
             visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
             var initializer = SameTreeInitializerOperation(variable, semanticModel);
-            if (!visited.Add(variable) || initializer is null
-                || IsWrittenBefore(variable, current.Syntax, semanticModel)
-                || !IsReferenceShape(initializer))
+            if (!visited.Add(variable) || initializer is null || !IsReferenceShape(initializer)
+                || AliasRebound(variable, current, semanticModel, aliasRebound))
             {
                 return current;
             }
@@ -886,38 +924,84 @@ internal static class ComputationLambdas
         }
     }
 
-    private static bool IsReferenceShape(IOperation operation)
+    // The bodies a synchronously INVOKED delegate runs, with the argument map each resolved
+    // under. Direct resolutions (a same-tree lambda or method group, through aliases and
+    // parameter bindings, null-conditional invokes unwrapped) come first; only when none
+    // resolve does the callee's own SOURCE decide -- a factory call's returns, or a computed
+    // get-only property's. Resolution only: the callers own what they do per body, and
+    // MZR004 keeps its accounting-rich chase.
+    public static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> InvokedDelegateBodies(
+        IOperation callee,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        while (operation is IConversionOperation conversion)
+        var resolved = ResolveDelegateValue(ResolveConditionalReceiver(callee), semanticModel, argumentMap);
+        var found = false;
+        foreach (var body in OfArgumentValue(resolved, semanticModel))
         {
-            operation = conversion.Operand;
+            found = true;
+            yield return (body, argumentMap);
         }
 
-        return operation is IParameterReferenceOperation || ReferencedVariable(operation) is not null;
+        if (found)
+        {
+            yield break;
+        }
+
+        foreach (var entry in InvokedSourceBodies(Unwrap(resolved), semanticModel, argumentMap))
+        {
+            yield return entry;
+        }
+    }
+
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> InvokedSourceBodies(
+        IOperation resolved,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        // `Get()(x)` runs whatever the factory returned; `Step()` whatever the getter did.
+        if (resolved is IInvocationOperation call && ResolveMethodBody(call.TargetMethod, semanticModel) is { } factory)
+        {
+            return ReturnedBodies(factory, semanticModel, BuildArgumentMap(call, argumentMap));
+        }
+
+        if (ReferencedVariable(resolved) is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
+            && ResolveMethodBody(getter, semanticModel) is { } getterBody)
+        {
+            return ReturnedBodies(getterBody, semanticModel, BuildArgumentMap(resolved, argumentMap));
+        }
+
+        return Enumerable.Empty<(ComputationBody, Dictionary<IParameterSymbol, IOperation>?)>();
+    }
+
+    // How far an alias chain may be followed is the ONE thing the two callers disagree on:
+    // resolution-only chases stop at any same-tree write, while MZR004 excuses the write
+    // that stands in for a missing initializer (its own IsReassignedBefore).
+    private static bool AliasRebound(ISymbol variable, IOperation at, SemanticModel? semanticModel, Func<ISymbol, IOperation, bool>? custom)
+    {
+        return custom is null
+            ? IsWrittenBefore(variable, at.Syntax, semanticModel)
+            : custom(variable, at);
+    }
+
+    public static bool IsReferenceShape(IOperation operation)
+    {
+        return ReferencedSymbol(Unwrap(operation)) is not null;
     }
 
     private static IInvocationOperation? UnwrappedInitializerCall(ISymbol? variable, SemanticModel? semanticModel)
     {
         var initializer = SameTreeInitializerOperation(variable, semanticModel);
-        while (initializer is IConversionOperation conversion)
-        {
-            initializer = conversion.Operand;
-        }
 
-        return initializer as IInvocationOperation;
+        return initializer is null ? null : Unwrap(initializer) as IInvocationOperation;
     }
 
     // Each body carries the ARGUMENT MAP that resolved it: a nested factory's returns bind
     // that factory's own parameters, which the caller's map knows nothing about.
     public static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null, HashSet<(IMethodSymbol, string)>? visitedFactories = null)
     {
-        foreach (var inner in DescendDirectExecution(methodBody.Body))
+        foreach (var returned in ReturnedValues(methodBody.Body))
         {
-            if (inner is not IReturnOperation { ReturnedValue: { } returned })
-            {
-                continue;
-            }
-
             // A conditional return stores whichever arm the flow picked: each arm is its
             // own candidate, so a direct lambda arm cannot silence a factory-call one.
             foreach (var arm in ValueArms(returned))
@@ -961,11 +1045,7 @@ internal static class ComputationLambdas
     // candidate the flow can pick, and each resolves independently.
     private static IEnumerable<IOperation> ValueArms(IOperation value)
     {
-        var unwrapped = value;
-        while (unwrapped is IConversionOperation conversion)
-        {
-            unwrapped = conversion.Operand;
-        }
+        var unwrapped = Unwrap(value);
 
         switch (unwrapped)
         {
@@ -1007,10 +1087,7 @@ internal static class ComputationLambdas
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<(IMethodSymbol, string)> visitedFactories)
     {
-        while (resolved is IConversionOperation conversion)
-        {
-            resolved = conversion.Operand;
-        }
+        resolved = Unwrap(resolved);
 
         if (resolved is not IInvocationOperation call
             || ResolveMethodBody(call.TargetMethod, semanticModel) is not { } nested)
@@ -1067,7 +1144,7 @@ internal static class ComputationLambdas
 
         foreach (var node in writes)
         {
-            if (writes.Any(other => other != node && DefinitelyOverwrites(other, node, helper.Scope, parameter, semanticModel)))
+            if (IsOverwrittenWithin(node, writes, helper.Scope, parameter, semanticModel))
             {
                 continue;
             }
@@ -1152,15 +1229,19 @@ internal static class ComputationLambdas
             yield break;
         }
 
-        while (resolved is IConversionOperation conversion)
-        {
-            resolved = conversion.Operand;
-        }
+        resolved = Unwrap(resolved);
 
         foreach (var entry in AssembledSourceBodies(resolved, semanticModel, callMap))
         {
             yield return entry;
         }
+    }
+
+    // Whether ANOTHER candidate write definitely kills this one before the value is
+    // observed -- the survivor test every write-collecting scan applies.
+    public static bool IsOverwrittenWithin(SyntaxNode write, IReadOnlyCollection<SyntaxNode> candidates, SyntaxNode observedAt, ISymbol variable, SemanticModel semanticModel)
+    {
+        return candidates.Any(other => other != write && DefinitelyOverwrites(other, write, observedAt, variable, semanticModel));
     }
 
     // "Straight-line" = the killer sits in plain statements between itself and wherever the
@@ -1170,9 +1251,11 @@ internal static class ComputationLambdas
     // argument-list hop covers out-handoff killers; a conditional-access call stays rejected.
     public static bool DefinitelyOverwrites(SyntaxNode killer, SyntaxNode victim, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel)
     {
-        if (!IsDeterminingWrite(killer, variable, semanticModel)
-            || killer.SpanStart <= victim.SpanStart
+        // Span order first: it rejects most candidate pairs outright, while the write test
+        // below issues semantic queries and the exit walk covers a whole function.
+        if (killer.SpanStart <= victim.SpanStart
             || killer.SpanStart >= reference.Span.End
+            || !IsDeterminingWrite(killer, variable, semanticModel)
             || ExitsBetween(victim, killer))
         {
             return false;
@@ -1902,12 +1985,7 @@ internal static class ComputationLambdas
 
     private static ITypeSymbol? UnwrappedType(IOperation? value)
     {
-        while (value is IConversionOperation conversion)
-        {
-            value = conversion.Operand;
-        }
-
-        return value?.Type;
+        return value is null ? null : Unwrap(value).Type;
     }
 
     // How an access uses the property: a plain read runs the getter, an assignment target

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -647,6 +647,19 @@ internal static class ComputationLambdas
             reference = conversion.Operand;
         }
 
+        // A conditional patch stores whichever arm the flow picked: each arm resolves
+        // through this same supplemental chain separately, so a direct lambda arm cannot
+        // hide an assembled sibling.
+        if (reference is IConditionalOperation or ICoalesceOperation)
+        {
+            foreach (var body in ConditionalArmPatchBodies(reference, semanticModel))
+            {
+                yield return body;
+            }
+
+            yield break;
+        }
+
         var variable = ReferencedVariable(reference);
         if (variable is not null && EffectiveInitializerWrite(variable, semanticModel, reference.Syntax) is ArgumentSyntax outWrite)
         {
@@ -681,7 +694,18 @@ internal static class ComputationLambdas
         }
     }
 
-    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssembledSourceBodies(IOperation source, SemanticModel? semanticModel)
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> ConditionalArmPatchBodies(IOperation reference, SemanticModel? semanticModel)
+    {
+        foreach (var arm in ValueArms(reference))
+        {
+            foreach (var body in AssembledPatchBodies(arm, semanticModel))
+            {
+                yield return body;
+            }
+        }
+    }
+
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssembledSourceBodies(IOperation source, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? outerMap = null)
     {
         var resolvedVariable = ReferencedVariable(source);
 
@@ -690,7 +714,7 @@ internal static class ComputationLambdas
         if (resolvedVariable is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
             && ResolveMethodBody(getter, semanticModel) is { } getterBody)
         {
-            foreach (var entry in ReturnedBodies(getterBody, semanticModel, BuildArgumentMap(source, null)))
+            foreach (var entry in ReturnedBodies(getterBody, semanticModel, BuildArgumentMap(source, outerMap)))
             {
                 yield return entry;
             }
@@ -703,7 +727,7 @@ internal static class ComputationLambdas
             ?? UnwrappedInitializerCall(resolvedVariable, semanticModel);
         if (call is not null && ResolveMethodBody(call.TargetMethod, semanticModel) is { } factoryBody)
         {
-            foreach (var entry in ReturnedBodies(factoryBody, semanticModel, BuildArgumentMap(call, null)))
+            foreach (var entry in ReturnedBodies(factoryBody, semanticModel, BuildArgumentMap(call, outerMap)))
             {
                 yield return entry;
             }
@@ -791,7 +815,7 @@ internal static class ComputationLambdas
         if (!ReadsThroughOwnReceiver(reference.Syntax, variable)
             || variable.DeclaringSyntaxReferences.FirstOrDefault() is not { } declaration
             || declaration.SyntaxTree != semanticModel.SyntaxTree
-            || declaration.GetSyntax() is not VariableDeclaratorSyntax { Initializer: not null } declarator)
+            || DeclaredInitializerSite(declaration.GetSyntax()) is not { } declarator)
         {
             return false;
         }
@@ -800,6 +824,19 @@ internal static class ComputationLambdas
             IsVariableWriteNode(node, variable, semanticModel)
             && CanExecuteBefore(node, reference.Syntax, variable, semanticModel)
             && DefinitelyOverwrites(node, declarator, reference.Syntax, variable, semanticModel));
+    }
+
+    // Every declaration shape SameTreeInitializerOperation trusts can go stale the same way:
+    // a local/field declarator, an auto-property initializer, a deconstruction designation.
+    public static SyntaxNode? DeclaredInitializerSite(SyntaxNode declaration)
+    {
+        return declaration switch
+        {
+            VariableDeclaratorSyntax { Initializer: not null } => declaration,
+            PropertyDeclarationSyntax { Initializer: not null } => declaration,
+            SingleVariableDesignationSyntax => declaration,
+            _ => null,
+        };
     }
 
     // A delegate VALUE collapsed through variable-alias initializers and parameter-to-
@@ -881,25 +918,84 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            // Aliases resolve too: `var q = p; return q;` hands back the call-site value.
-            var resolved = ResolveDelegateValue(returned, semanticModel, argumentMap);
-            var resolvedAny = false;
-            foreach (var body in OfArgumentValue(resolved, semanticModel))
+            // A conditional return stores whichever arm the flow picked: each arm is its
+            // own candidate, so a direct lambda arm cannot silence a factory-call one.
+            foreach (var arm in ValueArms(returned))
             {
-                resolvedAny = true;
-                yield return (body, argumentMap);
+                visitedFactories ??= new HashSet<(IMethodSymbol, string)>();
+                foreach (var entry in ReturnedArmBodies(arm, semanticModel, argumentMap, visitedFactories))
+                {
+                    yield return entry;
+                }
             }
+        }
+    }
 
-            if (resolvedAny)
-            {
-                continue;
-            }
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> ReturnedArmBodies(
+        IOperation arm,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<(IMethodSymbol, string)> visitedFactories)
+    {
+        // Aliases resolve too: `var q = p; return q;` hands back the call-site value.
+        var resolved = ResolveDelegateValue(arm, semanticModel, argumentMap);
+        var resolvedAny = false;
+        foreach (var body in OfArgumentValue(resolved, semanticModel))
+        {
+            resolvedAny = true;
+            yield return (body, argumentMap);
+        }
 
-            visitedFactories ??= new HashSet<(IMethodSymbol, string)>();
-            foreach (var entry in NestedFactoryReturnedBodies(resolved, semanticModel, argumentMap, visitedFactories))
-            {
-                yield return entry;
-            }
+        if (resolvedAny)
+        {
+            yield break;
+        }
+
+        foreach (var entry in NestedFactoryReturnedBodies(resolved, semanticModel, argumentMap, visitedFactories))
+        {
+            yield return entry;
+        }
+    }
+
+    // The leaf ARMS of a conditional or coalesced value, conversions unwrapped: each is a
+    // candidate the flow can pick, and each resolves independently.
+    private static IEnumerable<IOperation> ValueArms(IOperation value)
+    {
+        var unwrapped = value;
+        while (unwrapped is IConversionOperation conversion)
+        {
+            unwrapped = conversion.Operand;
+        }
+
+        switch (unwrapped)
+        {
+            case IConditionalOperation { WhenFalse: { } whenFalse } conditional:
+                foreach (var arm in ValueArms(conditional.WhenTrue))
+                {
+                    yield return arm;
+                }
+
+                foreach (var arm in ValueArms(whenFalse))
+                {
+                    yield return arm;
+                }
+
+                break;
+            case ICoalesceOperation coalesce:
+                foreach (var arm in ValueArms(coalesce.Value))
+                {
+                    yield return arm;
+                }
+
+                foreach (var arm in ValueArms(coalesce.WhenNull))
+                {
+                    yield return arm;
+                }
+
+                break;
+            default:
+                yield return unwrapped;
+                break;
         }
     }
 
@@ -1015,12 +1111,9 @@ internal static class ComputationLambdas
                     && targets.Any(target => WritesVariable(target, variable, semanticModel)):
                 foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
                 {
-                    // The call-site map resolves a value forwarded from ANOTHER delegate
-                    // parameter (`Provide(source, out patch)` with `p = source`), aliases
-                    // included.
-                    foreach (var body in OfArgumentValue(ResolveDelegateValue(value, semanticModel, callMap), semanticModel))
+                    foreach (var body in AssignedValueBodies(value, semanticModel, callMap))
                     {
-                        yield return (body, callMap);
+                        yield return body;
                     }
                 }
 
@@ -1034,6 +1127,39 @@ internal static class ComputationLambdas
                 }
 
                 break;
+        }
+    }
+
+    // The call-site map resolves a value forwarded from ANOTHER delegate parameter
+    // (`Provide(source, out patch)` with `p = source`), aliases included -- and a value
+    // ASSEMBLED in place (`d = Make(v);` binds the factory's returns, `d = Step;` the
+    // computed property's) resolves through the assembled-source chain with the same map.
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssignedValueBodies(
+        IOperation value,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? callMap)
+    {
+        var resolved = ResolveDelegateValue(value, semanticModel, callMap);
+        var resolvedAny = false;
+        foreach (var body in OfArgumentValue(resolved, semanticModel))
+        {
+            resolvedAny = true;
+            yield return (body, callMap);
+        }
+
+        if (resolvedAny)
+        {
+            yield break;
+        }
+
+        while (resolved is IConversionOperation conversion)
+        {
+            resolved = conversion.Operand;
+        }
+
+        foreach (var entry in AssembledSourceBodies(resolved, semanticModel, callMap))
+        {
+            yield return entry;
         }
     }
 
@@ -1063,15 +1189,17 @@ internal static class ComputationLambdas
         return true;
     }
 
-    // A killer must fully DETERMINE the new value: a simple non-tuple assignment, or an
-    // `out` handoff (the language requires the callee to assign before returning).
+    // A killer must fully DETERMINE the new value: a simple assignment -- deconstruction
+    // included, which assigns every target slot -- or an `out` handoff (the language
+    // requires the callee to assign before returning). `??=`/compound forms can keep the
+    // old value and stay excluded.
     private static bool IsDeterminingWrite(SyntaxNode killer, ISymbol variable, SemanticModel semanticModel)
     {
         return killer switch
         {
             AssignmentExpressionSyntax assignment => assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
-                && assignment.Left is not TupleExpressionSyntax
-                && WritesVariable(assignment.Left, variable, semanticModel),
+                && ReassignmentTargets(assignment) is { } targets
+                && targets.Any(target => WritesVariable(target, variable, semanticModel)),
             ArgumentSyntax argument => argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
                 && WritesVariable(argument.Expression, variable, semanticModel),
             _ => false,

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -935,28 +935,24 @@ internal static class ComputationLambdas
             return CanExecuteBefore(invocation, reference, variable, semanticModel, visitedFunctions);
         }
 
-        var lifted = current.Parent switch
-        {
-            EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator } => semanticModel.GetDeclaredSymbol(declarator),
-            AssignmentExpressionSyntax assignment when assignment.Right == current && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
-                => semanticModel.GetSymbolInfo(assignment.Left).Symbol,
-            _ => null,
-        };
-
+        var lifted = LiftTargetVariable(current, semanticModel);
         return lifted is null || LiftedDelegateRunsBefore(lifted, reference, variable, semanticModel, visitedFunctions);
     }
 
     // A direct CALL runs the function at the call's own position. A method-group LIFT runs it
     // wherever the receiving delegate variable is invoked -- so those invocation sites become
-    // the ordering points; a lift that escapes anywhere else stays unknowable.
+    // the ordering points; a lift that escapes anywhere else stays unknowable. Casts and
+    // parentheses change neither: `(Action)Rebind` lifted into a variable is still ordered by
+    // that variable's invocation sites.
     private static bool ReferenceRunsBefore(IdentifierNameSyntax use, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel, HashSet<SyntaxNode> visitedFunctions)
     {
-        if (use.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == use)
+        var current = UnwrapCastsAndParentheses(use);
+        if (current.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == current)
         {
-            return CanExecuteBefore(use, reference, variable, semanticModel, visitedFunctions);
+            return CanExecuteBefore(current, reference, variable, semanticModel, visitedFunctions);
         }
 
-        var lifted = LiftTargetVariable(use, semanticModel);
+        var lifted = LiftTargetVariable(current, semanticModel);
         if (lifted is null)
         {
             return true;
@@ -965,7 +961,17 @@ internal static class ComputationLambdas
         return LiftedDelegateRunsBefore(lifted, reference, variable, semanticModel, visitedFunctions);
     }
 
-    private static ISymbol? LiftTargetVariable(IdentifierNameSyntax use, SemanticModel semanticModel)
+    private static SyntaxNode UnwrapCastsAndParentheses(SyntaxNode node)
+    {
+        while (node.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+        {
+            node = node.Parent;
+        }
+
+        return node;
+    }
+
+    private static ISymbol? LiftTargetVariable(SyntaxNode use, SemanticModel semanticModel)
     {
         return use.Parent switch
         {
@@ -987,9 +993,10 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            if (name.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == name)
+            var current = UnwrapCastsAndParentheses(name);
+            if (current.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == current)
             {
-                if (CanExecuteBefore(name, reference, variable, semanticModel, visitedFunctions))
+                if (CanExecuteBefore(current, reference, variable, semanticModel, visitedFunctions))
                 {
                     return true;
                 }
@@ -997,12 +1004,16 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            // A write to the variable is not a use of the delegate; anything else lets the
-            // delegate escape to unknowable invocation sites.
-            if (name.Parent is not AssignmentExpressionSyntax { } write || write.Left != name)
+            // A write to the variable is not a use of the delegate, and a DISCARD
+            // (`_ = unused;`) provably drops it; anything else lets the delegate escape to
+            // unknowable invocation sites.
+            if (current.Parent is AssignmentExpressionSyntax write
+                && (write.Left == current || semanticModel.GetSymbolInfo(write.Left).Symbol is IDiscardSymbol))
             {
-                return true;
+                continue;
             }
+
+            return true;
         }
 
         return false;

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -341,8 +341,16 @@ internal static class ComputationLambdas
     public static bool DeclaredInFunctionEnclosing(ISymbol symbol, SyntaxNode scope)
     {
         var declaration = symbol.ContainingSymbol?.DeclaringSyntaxReferences.FirstOrDefault();
-        return declaration is not null
-            && declaration.SyntaxTree == scope.SyntaxTree
+        if (declaration is null)
+        {
+            // A compiler-synthesized container -- the top-level-statements entry point -- has
+            // no declaration of its own; its locals are the file's global statements, which
+            // enclose everything in the file.
+            return symbol.DeclaringSyntaxReferences.FirstOrDefault() is { } own
+                && own.SyntaxTree == scope.SyntaxTree;
+        }
+
+        return declaration.SyntaxTree == scope.SyntaxTree
             && declaration.Span.Contains(scope.Span);
     }
 

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -528,6 +528,57 @@ internal static class ComputationLambdas
             && body.Span.Contains(declaration.Span);
     }
 
+    // Same-tree code an operation EXECUTES, whatever the syntax: a call; a property access (a
+    // read runs the getter, an assignment target runs the setter, compound forms run both); a
+    // constructor; or a user-defined operator/conversion. Shared by MZR003's and MZR004's
+    // executed chases. (A member mentioned only in nameof is not executed -- callers guard.)
+    public static IEnumerable<IMethodSymbol> ExecutedMethods(IOperation operation)
+    {
+        switch (operation)
+        {
+            case IInvocationOperation invocation:
+                yield return invocation.TargetMethod;
+                break;
+            case IPropertyReferenceOperation property:
+                var (reads, writes) = PropertyUsage(property);
+                if (reads && property.Property.GetMethod is { } getter)
+                {
+                    yield return getter;
+                }
+
+                if (writes && property.Property.SetMethod is { } setter)
+                {
+                    yield return setter;
+                }
+
+                break;
+            case IObjectCreationOperation { Constructor: { } constructor }:
+                yield return constructor;
+                break;
+            case IBinaryOperation { OperatorMethod: { } binaryOperator }:
+                yield return binaryOperator;
+                break;
+            case IUnaryOperation { OperatorMethod: { } unaryOperator }:
+                yield return unaryOperator;
+                break;
+            case IConversionOperation { OperatorMethod: { } conversionOperator }:
+                yield return conversionOperator;
+                break;
+        }
+    }
+
+    private static (bool Reads, bool Writes) PropertyUsage(IPropertyReferenceOperation property)
+    {
+        return property.Parent switch
+        {
+            ISimpleAssignmentOperation assignment when ReferenceEquals(assignment.Target, property) => (false, true),
+            ICompoundAssignmentOperation compound when ReferenceEquals(compound.Target, property) => (true, true),
+            ICoalesceAssignmentOperation coalesce when ReferenceEquals(coalesce.Target, property) => (true, true),
+            IIncrementOrDecrementOperation increment when ReferenceEquals(increment.Target, property) => (true, true),
+            _ => (true, false),
+        };
+    }
+
     // The tightest useful squiggle for an invocation: the member name, not the whole call with
     // its (possibly multi-line lambda) arguments.
     public static Location NameLocation(IInvocationOperation invocation)

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -175,10 +175,87 @@ internal static class ComputationLambdas
         {
             VariableDeclaratorSyntax { Initializer.Value: { } value } => value,
             PropertyDeclarationSyntax { Initializer.Value: { } value } => value,
+            // `var (patch, _) = (...)` declares through a designation; its initializer is the
+            // positionally matching element of the right-hand tuple.
+            SingleVariableDesignationSyntax designation => DeconstructionInitializer(designation),
             _ => null,
         };
 
         return initializer is null ? null : semanticModel.GetOperation(initializer);
+    }
+
+    private static ExpressionSyntax? DeconstructionInitializer(SingleVariableDesignationSyntax designation)
+    {
+        var indexes = new List<int>();
+        SyntaxNode current = designation;
+        while (current.Parent is ParenthesizedVariableDesignationSyntax parent)
+        {
+            indexes.Add(parent.Variables.IndexOf((VariableDesignationSyntax)current));
+            current = parent;
+        }
+
+        if (current.Parent is not DeclarationExpressionSyntax declaration
+            || declaration.Parent is not AssignmentExpressionSyntax { Right: { } right })
+        {
+            return null;
+        }
+
+        // Indexes were recorded innermost-first; apply them outermost-first over the (possibly
+        // nested) tuple literal. A non-literal right-hand side stays unresolvable.
+        for (var i = indexes.Count - 1; i >= 0; i--)
+        {
+            if (right is not TupleExpressionSyntax tuple || indexes[i] >= tuple.Arguments.Count)
+            {
+                return null;
+            }
+
+            right = tuple.Arguments[indexes[i]].Expression;
+        }
+
+        return right;
+    }
+
+    // A ref-local ALIAS writes its referent: `ref var alias = ref patch; alias = ...` rebinds
+    // patch just as directly. The alias chain resolves through `= ref` initializers; the
+    // visited set breaks alias cycles. Shared by MZR004's delegate-reassignment scan and the
+    // provenance checks in ReceiverChains.
+    public static bool WritesVariable(ExpressionSyntax target, ISymbol variable, SemanticModel semanticModel)
+    {
+        var symbol = semanticModel.GetSymbolInfo(target).Symbol;
+        HashSet<ISymbol>? visited = null;
+        while (true)
+        {
+            if (symbol is null)
+            {
+                return false;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(symbol, variable))
+            {
+                return true;
+            }
+
+            if (symbol is not ILocalSymbol { RefKind: RefKind.Ref })
+            {
+                return false;
+            }
+
+            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visited.Add(symbol))
+            {
+                return false;
+            }
+
+            if (symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is not VariableDeclaratorSyntax
+                {
+                    Initializer.Value: RefExpressionSyntax { Expression: { } referent }
+                })
+            {
+                return false;
+            }
+
+            symbol = semanticModel.GetSymbolInfo(referent).Symbol;
+        }
     }
 
     // A method group (`f.CreateMemoizR(Compute)`) or local-function reference is as much a

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -200,7 +200,7 @@ internal static class ComputationLambdas
     {
         if (left is not TupleExpressionSyntax leftTuple)
         {
-            return SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(left).Symbol, variable) ? right : null;
+            return WritesVariable(left, variable, semanticModel) ? right : null;
         }
 
         if (right is not TupleExpressionSyntax rightTuple || leftTuple.Arguments.Count != rightTuple.Arguments.Count)
@@ -236,8 +236,12 @@ internal static class ComputationLambdas
         AssignmentExpressionSyntax? sole = null;
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
+            // WritesVariable, not plain symbol equality: the reassignment scans count a
+            // write through a ref alias (`ref var alias = ref patch; alias = ...`), so the
+            // initializer detection must recognize the same write or the sole initializing
+            // assignment would read as a rebind.
             if (ReassignmentTargets(node) is not { } targets
-                || !targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable)))
+                || !targets.Any(target => WritesVariable(target, variable, semanticModel)))
             {
                 continue;
             }
@@ -262,46 +266,102 @@ internal static class ComputationLambdas
     // Call-site arguments substitute for a chased helper's parameters: maps are built
     // pre-substituted, so nested helper calls resolve through to the original computation's
     // operations. A property SETTER's implicit `value` parameter maps to the assignment's
-    // right-hand side. The OUTER bindings carry through -- a called local function closes
-    // over its enclosing helper's parameters (`void Inner() => s.Set(2); Inner();`), so
-    // dropping them would orphan those references; keys are parameter symbols, so unrelated
-    // callees cannot collide, and a recursive call's fresh binding overwrites the stale one.
-    // Shared by MZR003's Set-target provenance and MZR004's delegate chase.
+    // right-hand side, and an INDEXER's index arguments map like call arguments (aliased
+    // onto the accessors' own parameter symbols, which is what accessor bodies bind). The
+    // OUTER bindings carry through -- a called local function closes over its enclosing
+    // helper's parameters (`void Inner() => s.Set(2); Inner();`), so dropping them would
+    // orphan those references; keys are parameter symbols, so unrelated callees cannot
+    // collide, and a recursive call's fresh binding overwrites the stale one. Shared by
+    // MZR003's Set-target provenance and MZR004's delegate chase.
     public static Dictionary<IParameterSymbol, IOperation>? BuildArgumentMap(IOperation operation, Dictionary<IParameterSymbol, IOperation>? outer)
     {
-        if (operation is IPropertyReferenceOperation { Parent: ISimpleAssignmentOperation setterAssignment } property
-            && ReferenceEquals(setterAssignment.Target, property)
-            && property.Property.SetMethod?.Parameters.LastOrDefault() is { } valueParameter
-            && SubstituteArguments(setterAssignment.Value, outer) is { } setterValue)
-        {
-            var setterMap = CopyOf(outer);
-            setterMap[valueParameter] = setterValue;
-            return setterMap;
-        }
-
         var arguments = operation switch
         {
             IInvocationOperation invocation => invocation.Arguments,
             IObjectCreationOperation creation => creation.Arguments,
+            IPropertyReferenceOperation propertyReference => propertyReference.Arguments,
             _ => default,
         };
 
-        if (arguments.IsDefaultOrEmpty)
-        {
-            return outer;
-        }
-
         Dictionary<IParameterSymbol, IOperation>? map = null;
-        foreach (var argument in arguments)
+        if (!arguments.IsDefaultOrEmpty)
         {
-            if (argument.Parameter is { } parameter && SubstituteArguments(argument.Value, outer) is { } value)
+            foreach (var argument in arguments)
             {
-                map ??= CopyOf(outer);
-                map[parameter] = value;
+                if (argument.Parameter is { } parameter && SubstituteArguments(argument.Value, outer) is { } value)
+                {
+                    map ??= CopyOf(outer);
+                    map[parameter] = value;
+                    AliasAccessorParameters(operation, parameter, value, map);
+                }
             }
         }
 
+        if (SetterValue(operation, outer) is { } setter)
+        {
+            map ??= CopyOf(outer);
+            map[setter.Parameter] = setter.Value;
+        }
+
         return map ?? outer;
+    }
+
+    private static (IParameterSymbol Parameter, IOperation Value)? SetterValue(IOperation operation, Dictionary<IParameterSymbol, IOperation>? outer)
+    {
+        return operation is IPropertyReferenceOperation { Parent: ISimpleAssignmentOperation assignment } property
+            && ReferenceEquals(assignment.Target, property)
+            && property.Property.SetMethod?.Parameters.LastOrDefault() is { } valueParameter
+            && SubstituteArguments(assignment.Value, outer) is { } value
+            ? (valueParameter, value)
+            : null;
+    }
+
+    // An accessor body binds the ACCESSOR's own parameter symbols, distinct from the
+    // property parameters an indexer reference's arguments name: alias the ordinal twins on
+    // the property and both accessors so a chased `set => s.Set(value)` resolves `s` to the
+    // call-site index argument whichever symbol the body carries.
+    private static void AliasAccessorParameters(IOperation operation, IParameterSymbol parameter, IOperation value, Dictionary<IParameterSymbol, IOperation> map)
+    {
+        if (operation is not IPropertyReferenceOperation { Property: { } property })
+        {
+            return;
+        }
+
+        foreach (var parameters in new[] { property.Parameters, property.GetMethod?.Parameters ?? default, property.SetMethod?.Parameters ?? default })
+        {
+            if (!parameters.IsDefaultOrEmpty && parameter.Ordinal < parameters.Length)
+            {
+                map[parameters[parameter.Ordinal]] = value;
+            }
+        }
+    }
+
+    // A stable VALUE identity for an argument map: chase guards key on it so the same
+    // callee syntax re-walks under different bindings (two outer calls handing different
+    // lambdas into one inner call site) while a recursive call -- whose rebuilt map carries
+    // the same substituted values -- terminates. Parameters are identified by declaration
+    // position and ordinal, values by their operation's syntax position: both stable within
+    // one compilation, unlike symbol hash codes.
+    public static string ArgumentMapKey(Dictionary<IParameterSymbol, IOperation>? map)
+    {
+        if (map is null || map.Count == 0)
+        {
+            return "";
+        }
+
+        var parts = new List<string>(map.Count);
+        foreach (var entry in map)
+        {
+            var declaration = entry.Key.DeclaringSyntaxReferences.FirstOrDefault()
+                ?? entry.Key.ContainingSymbol?.DeclaringSyntaxReferences.FirstOrDefault();
+            var parameter = declaration is null
+                ? $"{entry.Key.Name}"
+                : $"{declaration.SyntaxTree.FilePath}:{declaration.Span.Start}";
+            parts.Add($"{parameter}#{entry.Key.Ordinal}={entry.Value.Syntax.SyntaxTree.FilePath}:{entry.Value.Syntax.SpanStart}");
+        }
+
+        parts.Sort(StringComparer.Ordinal);
+        return string.Join(";", parts);
     }
 
     private static Dictionary<IParameterSymbol, IOperation> CopyOf(Dictionary<IParameterSymbol, IOperation>? outer)
@@ -660,12 +720,26 @@ internal static class ComputationLambdas
 
     // A write inside a LOCAL FUNCTION runs only when some call site does: it can precede the
     // read only if a REFERENCE to the function can (each reference is ordered recursively --
-    // the visited set breaks mutual-recursion cycles). Anything else -- a method, accessor, or
-    // lambda, all reachable from outside this tree or through stored values -- stays
-    // unknowable and counts.
+    // the visited set breaks mutual-recursion cycles). A write inside a LAMBDA runs where
+    // the built delegate does: immediately for an immediately-invoked one, at the receiving
+    // variable's invocation sites for a lifted one -- a callback that is merely BUILT and
+    // never runs before the read cannot feed it. Anything else -- a method or accessor,
+    // reachable from outside this tree, or a lambda that escapes -- stays unknowable and
+    // counts.
     private static bool CouldRunBefore(SyntaxNode? function, SyntaxNode reference, ISymbol variable, SemanticModel? semanticModel, HashSet<SyntaxNode>? visitedFunctions)
     {
-        if (function is not LocalFunctionStatementSyntax local || semanticModel is null
+        if (semanticModel is null)
+        {
+            return true;
+        }
+
+        if (function is AnonymousFunctionExpressionSyntax lambda)
+        {
+            visitedFunctions ??= new HashSet<SyntaxNode>();
+            return visitedFunctions.Add(lambda) && LambdaRunsBefore(lambda, reference, variable, semanticModel, visitedFunctions);
+        }
+
+        if (function is not LocalFunctionStatementSyntax local
             || semanticModel.GetDeclaredSymbol(local) is not { } symbol)
         {
             return true;
@@ -689,6 +763,34 @@ internal static class ComputationLambdas
         }
 
         return false;
+    }
+
+    // Where a lambda's body can run: at the invocation site for an immediately-invoked one
+    // (`(() => ...)()`), at the receiving variable's invocation sites for one lifted into a
+    // delegate variable -- resolved with the same machinery as method-group lifts. A lambda
+    // that goes anywhere else (an argument, a return value) escapes to unknowable callers.
+    private static bool LambdaRunsBefore(AnonymousFunctionExpressionSyntax lambda, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel, HashSet<SyntaxNode> visitedFunctions)
+    {
+        SyntaxNode current = lambda;
+        while (current.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+        {
+            current = current.Parent;
+        }
+
+        if (current.Parent is InvocationExpressionSyntax { Expression: { } invoked } invocation && invoked == current)
+        {
+            return CanExecuteBefore(invocation, reference, variable, semanticModel, visitedFunctions);
+        }
+
+        var lifted = current.Parent switch
+        {
+            EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator } => semanticModel.GetDeclaredSymbol(declarator),
+            AssignmentExpressionSyntax assignment when assignment.Right == current && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                => semanticModel.GetSymbolInfo(assignment.Left).Symbol,
+            _ => null,
+        };
+
+        return lifted is null || LiftedDelegateRunsBefore(lifted, reference, variable, semanticModel, visitedFunctions);
     }
 
     // A direct CALL runs the function at the call's own position. A method-group LIFT runs it
@@ -904,7 +1006,9 @@ internal static class ComputationLambdas
         return value?.Type;
     }
 
-    private static (bool Reads, bool Writes) PropertyUsage(IPropertyReferenceOperation property)
+    // How an access uses the property: a plain read runs the getter, an assignment target
+    // the setter, compound forms both. Shared with MZR002's getter chase.
+    public static (bool Reads, bool Writes) PropertyUsage(IPropertyReferenceOperation property)
     {
         return property.Parent switch
         {

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -594,17 +594,45 @@ internal static class ComputationLambdas
             }
         }
 
+        // The INDEXER's argument map keeps the returned lambda's index-parameter references
+        // resolvable (`this[Signal<int> s] { get { return x => { s.Set(1); ... }; } }`).
         if (variable is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
             && ResolveMethodBody(getter, semanticModel) is { } getterBody)
         {
-            foreach (var body in ReturnedBodies(getterBody, semanticModel))
+            var propertyMap = BuildArgumentMap(reference, null);
+            foreach (var body in ReturnedBodies(getterBody, semanticModel, propertyMap))
             {
-                yield return (body, null);
+                yield return (body, propertyMap);
+            }
+        }
+
+        // A patch produced by a same-tree delegate FACTORY -- called inline, or stored
+        // through the variable's initializer -- resolves through the factory's returns,
+        // with the call's own argument map.
+        var call = reference as IInvocationOperation
+            ?? UnwrappedInitializerCall(variable, semanticModel);
+        if (call is not null && ResolveMethodBody(call.TargetMethod, semanticModel) is { } factoryBody)
+        {
+            var callMap = BuildArgumentMap(call, null);
+            foreach (var body in ReturnedBodies(factoryBody, semanticModel, callMap))
+            {
+                yield return (body, callMap);
             }
         }
     }
 
-    private static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel)
+    private static IInvocationOperation? UnwrappedInitializerCall(ISymbol? variable, SemanticModel? semanticModel)
+    {
+        var initializer = SameTreeInitializerOperation(variable, semanticModel);
+        while (initializer is IConversionOperation conversion)
+        {
+            initializer = conversion.Operand;
+        }
+
+        return initializer as IInvocationOperation;
+    }
+
+    private static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
         foreach (var inner in DescendDirectExecution(methodBody.Body))
         {
@@ -613,7 +641,7 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            foreach (var body in OfArgumentValue(returned, semanticModel))
+            foreach (var body in OfArgumentValue(SubstituteArguments(returned, argumentMap) ?? returned, semanticModel))
             {
                 yield return body;
             }
@@ -643,8 +671,28 @@ internal static class ComputationLambdas
             ? BuildArgumentMap(call, outerMap)
             : outerMap;
 
+        // The kill filter mirrors MZR004's accounting chase: an assignment definitely
+        // overwritten on the straight-line path to the helper's return can never be the
+        // delegate the caller receives.
+        var writes = new List<SyntaxNode>();
         foreach (var node in helper.Scope.DescendantNodes())
         {
+            if (node is AssignmentExpressionSyntax candidate
+                && ReassignmentTargets(candidate) is { } targets
+                && targets.Any(target => WritesVariable(target, parameter, semanticModel)))
+            {
+                writes.Add(candidate);
+            }
+        }
+
+        foreach (var node in helper.Scope.DescendantNodes())
+        {
+            if (node is AssignmentExpressionSyntax victim
+                && writes.Any(other => other != victim && DefinitelyOverwrites(other, victim, helper.Scope, parameter, semanticModel)))
+            {
+                continue;
+            }
+
             foreach (var body in OutHandoffNodeBodies(node, parameter, semanticModel, visited, callMap))
             {
                 yield return body;
@@ -666,7 +714,9 @@ internal static class ComputationLambdas
                     && targets.Any(target => WritesVariable(target, parameter, semanticModel)):
                 foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
                 {
-                    foreach (var body in OfArgumentValue(value, semanticModel))
+                    // The call-site map resolves a value forwarded from ANOTHER delegate
+                    // parameter (`Provide(source, out patch)` with `p = source`).
+                    foreach (var body in OfArgumentValue(SubstituteArguments(value, callMap) ?? value, semanticModel))
                     {
                         yield return (body, callMap);
                     }
@@ -683,6 +733,93 @@ internal static class ComputationLambdas
 
                 break;
         }
+    }
+
+    // "Straight-line" = the killer sits in plain statements between itself and wherever the
+    // value is observed (an invoke site, or an out-helper's own scope end); a killer inside
+    // an if/loop may not run, so it kills nothing -- and an exit statement between the two
+    // writes can leave the earlier value observable, so nothing is definite past one. The
+    // argument-list hop covers out-handoff killers; a conditional-access call stays rejected.
+    public static bool DefinitelyOverwrites(SyntaxNode killer, SyntaxNode victim, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel)
+    {
+        if (!IsDeterminingWrite(killer, variable, semanticModel)
+            || killer.SpanStart <= victim.SpanStart
+            || killer.SpanStart >= reference.Span.End
+            || ExitsBetween(victim, killer))
+        {
+            return false;
+        }
+
+        for (var current = killer.Parent; current is not null && !current.Span.Contains(reference.Span); current = current.Parent)
+        {
+            if (current is not (BlockSyntax or ExpressionStatementSyntax or ArgumentListSyntax or InvocationExpressionSyntax))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // A killer must fully DETERMINE the new value: a simple non-tuple assignment, or an
+    // `out` handoff (the language requires the callee to assign before returning).
+    private static bool IsDeterminingWrite(SyntaxNode killer, ISymbol variable, SemanticModel semanticModel)
+    {
+        return killer switch
+        {
+            AssignmentExpressionSyntax assignment => assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                && assignment.Left is not TupleExpressionSyntax
+                && WritesVariable(assignment.Left, variable, semanticModel),
+            ArgumentSyntax argument => argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
+                && WritesVariable(argument.Expression, variable, semanticModel),
+            _ => false,
+        };
+    }
+
+    // A return/throw/goto/break/continue/yield starting between the two writes diverts
+    // control past the killer with the victim's value still bound (an early return in an
+    // out-helper hands that delegate to the caller). Only the killer's OWN function counts:
+    // an exit inside a nested lambda -- e.g. a `return` in the victim's own delegate body --
+    // diverts nothing here, and neither does a break/continue/case-goto whose OWN construct
+    // ends before the killer (control leaves the switch/loop and still reaches it).
+    private static bool ExitsBetween(SyntaxNode victim, SyntaxNode killer)
+    {
+        var function = killer.Ancestors().FirstOrDefault(IsFunctionBoundary) ?? killer.SyntaxTree.GetRoot();
+        foreach (var node in function.DescendantNodes(descendIntoChildren: n => ReferenceEquals(n, function) || !IsFunctionBoundary(n)))
+        {
+            if (node is ReturnStatementSyntax or ThrowStatementSyntax or GotoStatementSyntax
+                    or BreakStatementSyntax or ContinueStatementSyntax or YieldStatementSyntax
+                && victim.SpanStart < node.SpanStart && node.SpanStart < killer.SpanStart
+                && !(ExitTarget(node) is { } target && target.Span.End <= killer.SpanStart))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // The construct a contained exit leaves: the nearest switch/loop for `break`, the
+    // nearest loop for `continue`, the nearest switch for `goto case`/`goto default`.
+    // Returns null for the truly divergent exits (return/throw/yield, labeled goto).
+    private static SyntaxNode? ExitTarget(SyntaxNode exit)
+    {
+        return exit switch
+        {
+            BreakStatementSyntax => exit.Ancestors().FirstOrDefault(static ancestor =>
+                ancestor is SwitchStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax),
+            ContinueStatementSyntax => exit.Ancestors().FirstOrDefault(static ancestor =>
+                ancestor is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax),
+            GotoStatementSyntax @goto when @goto.IsKind(SyntaxKind.GotoCaseStatement) || @goto.IsKind(SyntaxKind.GotoDefaultStatement)
+                => exit.Ancestors().FirstOrDefault(static ancestor => ancestor is SwitchStatementSyntax),
+            _ => null,
+        };
+    }
+
+    private static bool IsFunctionBoundary(SyntaxNode node)
+    {
+        return node is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
+            or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax;
     }
 
     // A ref-local ALIAS writes its referent: `ref var alias = ref patch; alias = ...` rebinds

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -931,16 +932,21 @@ internal static class ComputationLambdas
     // get-only property's. Resolution only: the callers own what they do per body, and
     // MZR004 keeps its accounting-rich chase.
     public static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> InvokedDelegateBodies(
-        IOperation callee,
+        IInvocationOperation invoke,
         SemanticModel? semanticModel,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
+        if (invoke.Instance is not { } callee)
+        {
+            yield break;
+        }
+
         var resolved = ResolveDelegateValue(ResolveConditionalReceiver(callee), semanticModel, argumentMap);
         var found = false;
         foreach (var body in OfArgumentValue(resolved, semanticModel))
         {
             found = true;
-            yield return (body, argumentMap);
+            yield return (body, BindInvokedParameters(body, invoke, argumentMap, semanticModel));
         }
 
         if (found)
@@ -948,30 +954,53 @@ internal static class ComputationLambdas
             yield break;
         }
 
-        foreach (var entry in InvokedSourceBodies(Unwrap(resolved), semanticModel, argumentMap))
+        // `Get()(x)` runs whatever the factory returned, `Step()` whatever the getter did,
+        // and `Func<int,int> d = Make(v); d(x)` whatever the INITIALIZER's factory did --
+        // the same three sources an assembled patch argument resolves through.
+        foreach (var (body, map) in AssembledSourceBodies(Unwrap(resolved), semanticModel, argumentMap))
         {
-            yield return entry;
+            yield return (body, BindInvokedParameters(body, invoke, map, semanticModel));
         }
     }
 
-    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> InvokedSourceBodies(
-        IOperation resolved,
-        SemanticModel? semanticModel,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    // The invoked delegate's OWN parameters bind to the call's arguments, exactly like a
+    // called helper's: `Action<C> step = c => c.Counter++; step(this);` writes the
+    // computation's instance, and `step(otherSignal)` carries that signal's provenance.
+    // Positional, because a delegate invoke has no named arguments to reorder.
+    private static Dictionary<IParameterSymbol, IOperation>? BindInvokedParameters(
+        ComputationBody body,
+        IInvocationOperation invoke,
+        Dictionary<IParameterSymbol, IOperation>? outer,
+        SemanticModel? semanticModel)
     {
-        // `Get()(x)` runs whatever the factory returned; `Step()` whatever the getter did.
-        if (resolved is IInvocationOperation call && ResolveMethodBody(call.TargetMethod, semanticModel) is { } factory)
+        var parameters = BodyParameters(body, semanticModel);
+        if (parameters.IsDefaultOrEmpty || invoke.Arguments.Length == 0)
         {
-            return ReturnedBodies(factory, semanticModel, BuildArgumentMap(call, argumentMap));
+            return outer;
         }
 
-        if (ReferencedVariable(resolved) is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
-            && ResolveMethodBody(getter, semanticModel) is { } getterBody)
+        var map = CopyOf(outer);
+        for (var i = 0; i < parameters.Length && i < invoke.Arguments.Length; i++)
         {
-            return ReturnedBodies(getterBody, semanticModel, BuildArgumentMap(resolved, argumentMap));
+            map[parameters[i]] = invoke.Arguments[i].Value;
         }
 
-        return Enumerable.Empty<(ComputationBody, Dictionary<IParameterSymbol, IOperation>?)>();
+        return map;
+    }
+
+    // The parameters of a resolved body, whether it came from a lambda (its scope is the
+    // anonymous function) or a method group / local function (a declaration).
+    private static ImmutableArray<IParameterSymbol> BodyParameters(ComputationBody body, SemanticModel? semanticModel)
+    {
+        if (semanticModel is null || body.Scope.SyntaxTree != semanticModel.SyntaxTree)
+        {
+            return ImmutableArray<IParameterSymbol>.Empty;
+        }
+
+        var symbol = semanticModel.GetSymbolInfo(body.Scope).Symbol as IMethodSymbol
+            ?? semanticModel.GetDeclaredSymbol(body.Scope) as IMethodSymbol;
+
+        return symbol?.Parameters ?? ImmutableArray<IParameterSymbol>.Empty;
     }
 
     // How far an alias chain may be followed is the ONE thing the two callers disagree on:

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -176,8 +176,8 @@ internal static class ComputationLambdas
     // A method group (`f.CreateMemoizR(Compute)`) or local-function reference is as much a
     // computation as a lambda; its declaration is the body to analyze. Resolution is same-tree
     // by design: another tree's declarations have no operation model here, and the runtime
-    // checks still cover what the analyzer cannot see.
-    private static ComputationBody? ResolveMethodBody(IMethodSymbol method, SemanticModel? semanticModel)
+    // checks still cover what the analyzer cannot see. Shared with MZR004's helper chasing.
+    public static ComputationBody? ResolveMethodBody(IMethodSymbol method, SemanticModel? semanticModel)
     {
         if (semanticModel is null)
         {

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -240,8 +240,13 @@ internal static class ComputationLambdas
             // write through a ref alias (`ref var alias = ref patch; alias = ...`), so the
             // initializer detection must recognize the same write or the sole initializing
             // assignment would read as a rebind.
-            if (ReassignmentTargets(node) is not { } targets
-                || !targets.Any(target => WritesVariable(target, variable, semanticModel)))
+            if (ReassignmentTargets(node) is not { } targets)
+            {
+                continue;
+            }
+
+            var target = targets.FirstOrDefault(candidate => WritesVariable(candidate, variable, semanticModel));
+            if (target is null)
             {
                 continue;
             }
@@ -251,6 +256,7 @@ internal static class ComputationLambdas
             // DECONSTRUCTION qualifies too -- the variable's slot is fully determined by its
             // tuple element, which SameTreeInitializerOperation extracts.
             if (sole is not null
+                || !WritesThroughOwnReceiver(target, variable)
                 || node is not AssignmentExpressionSyntax assignment
                 || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
             {
@@ -260,7 +266,52 @@ internal static class ComputationLambdas
             sole = assignment;
         }
 
-        return sole;
+        return sole is not null && DominatesItsFunction(sole, variable) ? sole : null;
+    }
+
+    // For an instance member, only a write through the member's OWN object initializes what
+    // a read observes -- and this synthesis is receiver-blind about the read, so only the
+    // unambiguous shapes count: a bare identifier (implicit this, or a ref alias) or an
+    // explicit `this.X`. A write on any OTHER receiver (`other.Patch = safe;`) says nothing
+    // about `this.Patch`, so the whole story turns unprovable instead.
+    private static bool WritesThroughOwnReceiver(ExpressionSyntax target, ISymbol variable)
+    {
+        if (variable is not (IFieldSymbol or IPropertySymbol) || variable.IsStatic)
+        {
+            return true;
+        }
+
+        return target is IdentifierNameSyntax or MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax };
+    }
+
+    // A synthetic initializer must DOMINATE any read: storage that exists before the write
+    // (a field, a property, a parameter) can still hold a value supplied elsewhere when an
+    // assignment nested in a conditional never runs. Locals need no check -- definite
+    // assignment already forbids reading them on a path that skipped the write. "Dominates"
+    // = plain block statements all the way up to the assignment's own function.
+    private static bool DominatesItsFunction(AssignmentExpressionSyntax assignment, ISymbol variable)
+    {
+        if (variable is ILocalSymbol)
+        {
+            return true;
+        }
+
+        for (SyntaxNode? current = assignment.Parent; current is not null; current = current.Parent)
+        {
+            if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
+                or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or ArrowExpressionClauseSyntax
+                or CompilationUnitSyntax)
+            {
+                return true;
+            }
+
+            if (current is not (BlockSyntax or ExpressionStatementSyntax or GlobalStatementSyntax))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     // Call-site arguments substitute for a chased helper's parameters: maps are built

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -266,6 +266,25 @@ internal static class ComputationLambdas
         };
     }
 
+    // "Captured" = declared outside the computation's declaring syntax (the lambda expression,
+    // or the method/local-function declaration for a method-group computation). The span test
+    // (rather than comparing containing symbols) is what keeps nested non-computation lambdas
+    // correct: a local declared in a nested LINQ lambda belongs to the computation and must not
+    // be treated as captured, while a local of the enclosing method must be. Shared by MZR002
+    // (captured writes) and MZR004 (non-Sendable captures).
+    public static bool IsDeclaredOutside(ISymbol symbol, SyntaxNode scope)
+    {
+        var declaration = symbol.DeclaringSyntaxReferences.FirstOrDefault();
+        if (declaration is null)
+        {
+            // Compiler-generated (e.g. a setter's value parameter): nothing actionable to point at.
+            return false;
+        }
+
+        return declaration.SyntaxTree != scope.SyntaxTree
+            || !scope.Span.Contains(declaration.Span);
+    }
+
     // The tightest useful squiggle for an invocation: the member name, not the whole call with
     // its (possibly multi-line lambda) arguments.
     public static Location NameLocation(IInvocationOperation invocation)

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -612,6 +612,27 @@ internal static class ComputationLambdas
             : new Dictionary<IParameterSymbol, IOperation>(outer, SymbolEqualityComparer.Default);
     }
 
+    // The value bound to a parameter, tolerating GENERIC construction: a map built from
+    // `Make<List<int>>` is keyed by that method's constructed parameters, while the walked
+    // body references `Make<T>`'s originals, and the two are not symbol-equal.
+    public static IOperation? MappedValue(Dictionary<IParameterSymbol, IOperation>? argumentMap, IParameterSymbol parameter)
+    {
+        if (argumentMap is null)
+        {
+            return null;
+        }
+
+        if (argumentMap.TryGetValue(parameter, out var value))
+        {
+            return value;
+        }
+
+        return argumentMap
+            .Where(entry => SymbolEqualityComparer.Default.Equals(entry.Key.OriginalDefinition, parameter.OriginalDefinition))
+            .Select(entry => entry.Value)
+            .FirstOrDefault();
+    }
+
     public static IOperation? SubstituteArguments(IOperation? reference, Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         if (reference is null)
@@ -707,7 +728,7 @@ internal static class ComputationLambdas
             yield break;
         }
 
-        var variable = ReferencedVariable(reference);
+        var variable = ReferencedSymbol(reference);
         if (variable is not null && EffectiveInitializerWrite(variable, semanticModel, reference.Syntax) is ArgumentSyntax outWrite)
         {
             foreach (var body in OutHandoffBodies(outWrite, semanticModel, new HashSet<SyntaxNode>(), outerMap: null))
@@ -750,30 +771,60 @@ internal static class ComputationLambdas
 
     private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssembledSourceBodies(IOperation source, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? outerMap = null)
     {
-        var resolvedVariable = ReferencedVariable(source);
+        var resolvedVariable = ReferencedSymbol(source);
 
         // The INDEXER's argument map keeps the returned lambda's index-parameter references
         // resolvable (`this[Signal<int> s] { get { return x => { s.Set(1); ... }; } }`).
         if (resolvedVariable is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
             && ResolveMethodBody(getter, semanticModel) is { } getterBody)
         {
-            foreach (var entry in ReturnedBodies(getterBody, semanticModel, BuildArgumentMap(source, outerMap)))
+            return ReturnedBodies(getterBody, semanticModel, BuildArgumentMap(source, outerMap));
+        }
+
+        var stored = Unwrap(SameTreeInitializerOperation(resolvedVariable, semanticModel));
+
+        // A CONDITIONAL initializer stores whichever arm ran, so each arm is an assembled
+        // source of its own (`Func<int,int> patch = flag ? safe : Make(v);`).
+        if (stored is not null && ConditionalArms(stored) is not null)
+        {
+            return ConditionalInitializerBodies(stored, semanticModel, outerMap);
+        }
+
+        return AssembledCallBodies(source, stored, semanticModel, outerMap);
+    }
+
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> ConditionalInitializerBodies(
+        IOperation stored,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? outerMap)
+    {
+        foreach (var arm in ValueArms(stored))
+        {
+            foreach (var entry in AssembledSourceBodies(Unwrap(arm), semanticModel, outerMap))
             {
                 yield return entry;
             }
         }
+    }
 
+    private static IEnumerable<(ComputationBody Body, Dictionary<IParameterSymbol, IOperation>? ArgumentMap)> AssembledCallBodies(
+        IOperation source,
+        IOperation? stored,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? outerMap)
+    {
         // A patch produced by a same-tree delegate FACTORY -- called inline, or stored
-        // through the variable's initializer -- resolves through the factory's returns,
-        // with the call's own argument map.
-        var call = source as IInvocationOperation
-            ?? UnwrappedInitializerCall(resolvedVariable, semanticModel);
-        if (call is not null && ResolveMethodBody(call.TargetMethod, semanticModel) is { } factoryBody)
+        // through the variable's initializer (a parameter's initializing write included) --
+        // resolves through the factory's returns, with the call's own argument map.
+        var call = source as IInvocationOperation ?? stored as IInvocationOperation;
+        if (call is null || ResolveMethodBody(call.TargetMethod, semanticModel) is not { } factoryBody)
         {
-            foreach (var entry in ReturnedBodies(factoryBody, semanticModel, BuildArgumentMap(call, outerMap)))
-            {
-                yield return entry;
-            }
+            yield break;
+        }
+
+        foreach (var entry in ReturnedBodies(factoryBody, semanticModel, BuildArgumentMap(call, outerMap)))
+        {
+            yield return entry;
         }
     }
 
@@ -966,6 +1017,18 @@ internal static class ComputationLambdas
         {
             found = true;
             yield return (body, BindInvokedParameters(body, invoke, argumentMap, semanticModel));
+        }
+
+        // A REBOUND parameter stops the hop, but what the caller handed in still runs when
+        // the rebind is conditional: both stay candidates.
+        if (Unwrap(resolved) is IParameterReferenceOperation rebound
+            && argumentMap?.TryGetValue(rebound.Parameter, out var handed) == true)
+        {
+            foreach (var body in OfArgumentValue(handed, semanticModel))
+            {
+                found = true;
+                yield return (body, BindInvokedParameters(body, invoke, argumentMap, semanticModel));
+            }
         }
 
         if (found)

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -36,11 +36,18 @@ internal static class ComputationLambdas
     {
         foreach (var argument in invocation.Arguments)
         {
-            foreach (var body in BodiesIn(argument.Value, invocation.SemanticModel, visitedVariables: null))
+            foreach (var body in OfArgumentValue(argument.Value, invocation.SemanticModel))
             {
                 yield return body;
             }
         }
+    }
+
+    // A single argument's computations, for callers that need per-argument resolution (MZR004
+    // distinguishes "resolved to nothing" from a walked body).
+    public static IEnumerable<ComputationBody> OfArgumentValue(IOperation value, SemanticModel? semanticModel)
+    {
+        return BodiesIn(value, semanticModel, visitedVariables: null);
     }
 
     private static IEnumerable<ComputationBody> BodiesIn(IOperation value, SemanticModel? semanticModel, HashSet<ISymbol>? visitedVariables)

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -211,7 +211,12 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            if (sole is not null || node is not AssignmentExpressionSyntax { Left: not TupleExpressionSyntax } assignment)
+            // Only a plain `x = value` fully DETERMINES the value: `x ??= ...` / `x += ...`
+            // can leave (or combine with) an older value supplied elsewhere.
+            if (sole is not null
+                || node is not AssignmentExpressionSyntax assignment
+                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || assignment.Left is TupleExpressionSyntax)
             {
                 return null;
             }
@@ -220,6 +225,59 @@ internal static class ComputationLambdas
         }
 
         return sole;
+    }
+
+    // Call-site arguments substitute for a chased helper's parameters: maps are built
+    // pre-substituted, so nested helper calls resolve through to the original computation's
+    // operations. A property SETTER's implicit `value` parameter maps to the assignment's
+    // right-hand side. Shared by MZR003's Set-target provenance and MZR004's delegate chase.
+    public static Dictionary<IParameterSymbol, IOperation>? BuildArgumentMap(IOperation operation, Dictionary<IParameterSymbol, IOperation>? outer)
+    {
+        if (operation is IPropertyReferenceOperation { Parent: ISimpleAssignmentOperation setterAssignment } property
+            && ReferenceEquals(setterAssignment.Target, property)
+            && property.Property.SetMethod?.Parameters.LastOrDefault() is { } valueParameter
+            && SubstituteArguments(setterAssignment.Value, outer) is { } setterValue)
+        {
+            return new Dictionary<IParameterSymbol, IOperation>(SymbolEqualityComparer.Default) { [valueParameter] = setterValue };
+        }
+
+        var arguments = operation switch
+        {
+            IInvocationOperation invocation => invocation.Arguments,
+            IObjectCreationOperation creation => creation.Arguments,
+            _ => default,
+        };
+
+        if (arguments.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        Dictionary<IParameterSymbol, IOperation>? map = null;
+        foreach (var argument in arguments)
+        {
+            if (argument.Parameter is { } parameter && SubstituteArguments(argument.Value, outer) is { } value)
+            {
+                map ??= new Dictionary<IParameterSymbol, IOperation>(SymbolEqualityComparer.Default);
+                map[parameter] = value;
+            }
+        }
+
+        return map;
+    }
+
+    public static IOperation? SubstituteArguments(IOperation? reference, Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        var current = reference;
+        while (current is IConversionOperation conversion)
+        {
+            current = conversion.Operand;
+        }
+
+        return current is IParameterReferenceOperation parameterReference
+            && argumentMap?.TryGetValue(parameterReference.Parameter, out var argument) == true
+            ? argument
+            : reference;
     }
 
     private static ExpressionSyntax? DeconstructionInitializer(SingleVariableDesignationSyntax designation)
@@ -579,7 +637,68 @@ internal static class ComputationLambdas
             if (identifier.Identifier.ValueText == symbol.Name
                 && !local.Span.Contains(identifier.Span)
                 && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier).Symbol, symbol)
-                && CanExecuteBefore(identifier, reference, variable, semanticModel, visitedFunctions))
+                && ReferenceRunsBefore(identifier, reference, variable, semanticModel, visitedFunctions))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // A direct CALL runs the function at the call's own position. A method-group LIFT runs it
+    // wherever the receiving delegate variable is invoked -- so those invocation sites become
+    // the ordering points; a lift that escapes anywhere else stays unknowable.
+    private static bool ReferenceRunsBefore(IdentifierNameSyntax use, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel, HashSet<SyntaxNode> visitedFunctions)
+    {
+        if (use.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == use)
+        {
+            return CanExecuteBefore(use, reference, variable, semanticModel, visitedFunctions);
+        }
+
+        var lifted = LiftTargetVariable(use, semanticModel);
+        if (lifted is null)
+        {
+            return true;
+        }
+
+        return LiftedDelegateRunsBefore(lifted, reference, variable, semanticModel, visitedFunctions);
+    }
+
+    private static ISymbol? LiftTargetVariable(IdentifierNameSyntax use, SemanticModel semanticModel)
+    {
+        return use.Parent switch
+        {
+            EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator } => semanticModel.GetDeclaredSymbol(declarator),
+            AssignmentExpressionSyntax assignment when assignment.Right == use && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                => semanticModel.GetSymbolInfo(assignment.Left).Symbol,
+            _ => null,
+        };
+    }
+
+    private static bool LiftedDelegateRunsBefore(ISymbol lifted, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel, HashSet<SyntaxNode> visitedFunctions)
+    {
+        foreach (var name in semanticModel.SyntaxTree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (name.Identifier.ValueText != lifted.Name
+                || !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(name).Symbol, lifted))
+            {
+                continue;
+            }
+
+            if (name.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == name)
+            {
+                if (CanExecuteBefore(name, reference, variable, semanticModel, visitedFunctions))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            // A write to the variable is not a use of the delegate; anything else lets the
+            // delegate escape to unknowable invocation sites.
+            if (name.Parent is not AssignmentExpressionSyntax { } write || write.Left != name)
             {
                 return true;
             }
@@ -708,6 +827,8 @@ internal static class ComputationLambdas
             .FirstOrDefault(candidate => !candidate.IsStatic && candidate.Parameters.Length == 0);
     }
 
+    // The INITIALIZER's type beats the declared type: `using IDisposable _ = new Writer(v);`
+    // runs Writer.Dispose, not an unwalkable interface member.
     private static IEnumerable<ITypeSymbol?> ResourceTypes(IOperation? resources)
     {
         switch (resources)
@@ -717,15 +838,25 @@ internal static class ComputationLambdas
                 {
                     foreach (var declarator in declaration.Declarators)
                     {
-                        yield return declarator.Symbol.Type;
+                        yield return UnwrappedType(declarator.Initializer?.Value) ?? declarator.Symbol.Type;
                     }
                 }
 
                 break;
             case { } expression:
-                yield return expression.Type;
+                yield return UnwrappedType(expression) ?? expression.Type;
                 break;
         }
+    }
+
+    private static ITypeSymbol? UnwrappedType(IOperation? value)
+    {
+        while (value is IConversionOperation conversion)
+        {
+            value = conversion.Operand;
+        }
+
+        return value?.Type;
     }
 
     private static (bool Reads, bool Writes) PropertyUsage(IPropertyReferenceOperation property)

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -352,6 +353,102 @@ internal static class ComputationLambdas
 
         return declaration.SyntaxTree == scope.SyntaxTree
             && declaration.Span.Contains(scope.Span);
+    }
+
+    // The expressions a node writes: an assignment's left-hand side (deconstruction tuples
+    // flattened, nesting included -- `(patch, _) = ...` writes `patch`) or a ref/out argument
+    // (`in` is excluded: a readonly reference cannot rebind the variable). Shared by MZR004's
+    // delegate-reassignment scan and the provenance checks in ReceiverChains.
+    public static IEnumerable<ExpressionSyntax>? ReassignmentTargets(SyntaxNode node)
+    {
+        return node switch
+        {
+            AssignmentExpressionSyntax assignment => FlattenTargets(assignment.Left),
+            ArgumentSyntax argument when argument.RefOrOutKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword
+                => new[] { argument.Expression },
+            _ => null,
+        };
+    }
+
+    private static IEnumerable<ExpressionSyntax> FlattenTargets(ExpressionSyntax left)
+    {
+        if (left is not TupleExpressionSyntax tuple)
+        {
+            yield return left;
+            yield break;
+        }
+
+        foreach (var element in tuple.Arguments)
+        {
+            foreach (var nested in FlattenTargets(element.Expression))
+            {
+                yield return nested;
+            }
+        }
+    }
+
+    // Execution-order reasoning without dataflow: an assignment in a DIFFERENT function body
+    // (a helper, a lambda, another method) runs whenever that function does -- unknowable, so
+    // it counts. In the same function, one textually before the reference obviously precedes
+    // it, and one textually after still reaches it when a loop encloses both AND the variable
+    // outlives the iteration (a loop-body local is freshly initialized each pass). Shared by
+    // MZR004's delegate-reassignment scan and the provenance checks in ReceiverChains.
+    public static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference, ISymbol variable)
+    {
+        if (!ReferenceEquals(EnclosingFunction(assignment), EnclosingFunction(reference)))
+        {
+            return true;
+        }
+
+        if (assignment.SpanStart < reference.SpanStart)
+        {
+            return true;
+        }
+
+        for (var current = assignment.Parent; current is not null; current = current.Parent)
+        {
+            if (current is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax
+                && current.Span.Contains(reference.Span)
+                && !DeclaredWithin(variable, current))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static SyntaxNode? EnclosingFunction(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
+                or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or ArrowExpressionClauseSyntax)
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    // Only the loop BODY re-declares per iteration: a variable in a for-INITIALIZER is
+    // declared once and carries across iterations like one declared before the loop.
+    private static bool DeclaredWithin(ISymbol variable, SyntaxNode loop)
+    {
+        var body = loop switch
+        {
+            ForStatementSyntax @for => (SyntaxNode)@for.Statement,
+            ForEachStatementSyntax forEach => forEach.Statement,
+            WhileStatementSyntax @while => @while.Statement,
+            DoStatementSyntax @do => @do.Statement,
+            _ => loop,
+        };
+
+        var declaration = variable.DeclaringSyntaxReferences.FirstOrDefault();
+        return declaration is not null
+            && declaration.SyntaxTree == body.SyntaxTree
+            && body.Span.Contains(declaration.Span);
     }
 
     // The tightest useful squiggle for an invocation: the member name, not the whole call with

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -182,10 +182,41 @@ internal static class ComputationLambdas
         };
 
         // `Func<int,int> patch; patch = static x => x;` initializes by assignment: when the
-        // SOLE same-tree write is a simple assignment, its right-hand side is the initializer.
-        initializer ??= EffectiveInitializerAssignment(variable, semanticModel)?.Right;
+        // SOLE same-tree write is a simple assignment, its right-hand side is the initializer
+        // -- for a deconstruction form, the positionally matching tuple element.
+        if (initializer is null && EffectiveInitializerAssignment(variable, semanticModel) is { } assignment)
+        {
+            initializer = AssignedElementFor(assignment.Left, assignment.Right, variable, semanticModel);
+        }
 
         return initializer is null ? null : semanticModel.GetOperation(initializer);
+    }
+
+    // The right-hand expression a simple assignment gives THIS variable: the whole right side
+    // for `x = value`, the positionally matching element for `(x, _) = (value, 0)` (nesting
+    // included). A non-literal tuple right side stays unresolvable, like the declaration
+    // deconstruction above.
+    private static ExpressionSyntax? AssignedElementFor(ExpressionSyntax left, ExpressionSyntax right, ISymbol variable, SemanticModel semanticModel)
+    {
+        if (left is not TupleExpressionSyntax leftTuple)
+        {
+            return SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(left).Symbol, variable) ? right : null;
+        }
+
+        if (right is not TupleExpressionSyntax rightTuple || leftTuple.Arguments.Count != rightTuple.Arguments.Count)
+        {
+            return null;
+        }
+
+        for (var i = 0; i < leftTuple.Arguments.Count; i++)
+        {
+            if (AssignedElementFor(leftTuple.Arguments[i].Expression, rightTuple.Arguments[i].Expression, variable, semanticModel) is { } element)
+            {
+                return element;
+            }
+        }
+
+        return null;
     }
 
     // The single same-tree assignment standing in for a missing declaration initializer, or
@@ -212,11 +243,12 @@ internal static class ComputationLambdas
             }
 
             // Only a plain `x = value` fully DETERMINES the value: `x ??= ...` / `x += ...`
-            // can leave (or combine with) an older value supplied elsewhere.
+            // can leave (or combine with) an older value supplied elsewhere. A simple
+            // DECONSTRUCTION qualifies too -- the variable's slot is fully determined by its
+            // tuple element, which SameTreeInitializerOperation extracts.
             if (sole is not null
                 || node is not AssignmentExpressionSyntax assignment
-                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
-                || assignment.Left is TupleExpressionSyntax)
+                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
             {
                 return null;
             }
@@ -230,7 +262,11 @@ internal static class ComputationLambdas
     // Call-site arguments substitute for a chased helper's parameters: maps are built
     // pre-substituted, so nested helper calls resolve through to the original computation's
     // operations. A property SETTER's implicit `value` parameter maps to the assignment's
-    // right-hand side. Shared by MZR003's Set-target provenance and MZR004's delegate chase.
+    // right-hand side. The OUTER bindings carry through -- a called local function closes
+    // over its enclosing helper's parameters (`void Inner() => s.Set(2); Inner();`), so
+    // dropping them would orphan those references; keys are parameter symbols, so unrelated
+    // callees cannot collide, and a recursive call's fresh binding overwrites the stale one.
+    // Shared by MZR003's Set-target provenance and MZR004's delegate chase.
     public static Dictionary<IParameterSymbol, IOperation>? BuildArgumentMap(IOperation operation, Dictionary<IParameterSymbol, IOperation>? outer)
     {
         if (operation is IPropertyReferenceOperation { Parent: ISimpleAssignmentOperation setterAssignment } property
@@ -238,7 +274,9 @@ internal static class ComputationLambdas
             && property.Property.SetMethod?.Parameters.LastOrDefault() is { } valueParameter
             && SubstituteArguments(setterAssignment.Value, outer) is { } setterValue)
         {
-            return new Dictionary<IParameterSymbol, IOperation>(SymbolEqualityComparer.Default) { [valueParameter] = setterValue };
+            var setterMap = CopyOf(outer);
+            setterMap[valueParameter] = setterValue;
+            return setterMap;
         }
 
         var arguments = operation switch
@@ -250,7 +288,7 @@ internal static class ComputationLambdas
 
         if (arguments.IsDefaultOrEmpty)
         {
-            return null;
+            return outer;
         }
 
         Dictionary<IParameterSymbol, IOperation>? map = null;
@@ -258,12 +296,19 @@ internal static class ComputationLambdas
         {
             if (argument.Parameter is { } parameter && SubstituteArguments(argument.Value, outer) is { } value)
             {
-                map ??= new Dictionary<IParameterSymbol, IOperation>(SymbolEqualityComparer.Default);
+                map ??= CopyOf(outer);
                 map[parameter] = value;
             }
         }
 
-        return map;
+        return map ?? outer;
+    }
+
+    private static Dictionary<IParameterSymbol, IOperation> CopyOf(Dictionary<IParameterSymbol, IOperation>? outer)
+    {
+        return outer is null
+            ? new Dictionary<IParameterSymbol, IOperation>(SymbolEqualityComparer.Default)
+            : new Dictionary<IParameterSymbol, IOperation>(outer, SymbolEqualityComparer.Default);
     }
 
     public static IOperation? SubstituteArguments(IOperation? reference, Dictionary<IParameterSymbol, IOperation>? argumentMap)

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -219,11 +219,21 @@ internal static class ComputationLambdas
         return null;
     }
 
-    // The single same-tree assignment standing in for a missing declaration initializer, or
-    // null when the declaration has one, there are several writes (ambiguous), or the one
-    // write is not a plain `x = value`. Reassignment scans EXCLUDE this node: it is the
-    // initialization, not a rebind.
+    // The effective initializer narrowed to the shapes whose right-hand side resolves to a
+    // single operation; an out-argument handoff has no RHS here (its bodies come from the
+    // callee's assignments, which MZR004 resolves itself).
     public static AssignmentExpressionSyntax? EffectiveInitializerAssignment(ISymbol variable, SemanticModel? semanticModel)
+    {
+        return EffectiveInitializerWrite(variable, semanticModel) as AssignmentExpressionSyntax;
+    }
+
+    // The single same-tree WRITE standing in for a missing declaration initializer -- a
+    // plain `x = value` (or simple deconstruction), or an OUT-argument handoff
+    // (`Provide(out patch)`, which the language requires to assign) -- or null when the
+    // declaration has an initializer, there are several writes (ambiguous), or the one
+    // write does not fully determine the value. Reassignment scans EXCLUDE this node: it is
+    // the initialization, not a rebind.
+    public static SyntaxNode? EffectiveInitializerWrite(ISymbol variable, SemanticModel? semanticModel)
     {
         if (semanticModel is null || variable.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
                 is VariableDeclaratorSyntax { Initializer: not null }
@@ -233,7 +243,7 @@ internal static class ComputationLambdas
             return null;
         }
 
-        AssignmentExpressionSyntax? sole = null;
+        SyntaxNode? sole = null;
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             // WritesVariable, not plain symbol equality: the reassignment scans count a
@@ -251,22 +261,29 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            // Only a plain `x = value` fully DETERMINES the value: `x ??= ...` / `x += ...`
-            // can leave (or combine with) an older value supplied elsewhere. A simple
-            // DECONSTRUCTION qualifies too -- the variable's slot is fully determined by its
-            // tuple element, which SameTreeInitializerOperation extracts.
-            if (sole is not null
-                || !WritesThroughOwnReceiver(target, variable)
-                || node is not AssignmentExpressionSyntax assignment
-                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            if (sole is not null || !WritesThroughOwnReceiver(target, variable) || !IsInitializingWriteShape(node))
             {
                 return null;
             }
 
-            sole = assignment;
+            sole = node;
         }
 
         return sole is not null && DominatesItsFunction(sole, variable) ? sole : null;
+    }
+
+    // Only a write that fully DETERMINES the value qualifies: `x ??= ...` / `x += ...` can
+    // leave (or combine with) an older value supplied elsewhere, and a `ref` argument may
+    // never assign -- while an `out` argument must, and a simple deconstruction determines
+    // the variable's slot (SameTreeInitializerOperation extracts the element).
+    private static bool IsInitializingWriteShape(SyntaxNode node)
+    {
+        return node switch
+        {
+            AssignmentExpressionSyntax assignment => assignment.IsKind(SyntaxKind.SimpleAssignmentExpression),
+            ArgumentSyntax argument => argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword),
+            _ => false,
+        };
     }
 
     // For an instance member, only a write through the member's OWN object initializes what
@@ -288,15 +305,16 @@ internal static class ComputationLambdas
     // (a field, a property, a parameter) can still hold a value supplied elsewhere when an
     // assignment nested in a conditional never runs. Locals need no check -- definite
     // assignment already forbids reading them on a path that skipped the write. "Dominates"
-    // = plain block statements all the way up to the assignment's own function.
-    private static bool DominatesItsFunction(AssignmentExpressionSyntax assignment, ISymbol variable)
+    // = plain statements all the way up to the write's own function (the argument-list hop
+    // covers the out-argument shape; a conditional-access call stays rejected).
+    private static bool DominatesItsFunction(SyntaxNode write, ISymbol variable)
     {
         if (variable is ILocalSymbol)
         {
             return true;
         }
 
-        for (SyntaxNode? current = assignment.Parent; current is not null; current = current.Parent)
+        for (SyntaxNode? current = write.Parent; current is not null; current = current.Parent)
         {
             if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
                 or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or ArrowExpressionClauseSyntax
@@ -305,13 +323,39 @@ internal static class ComputationLambdas
                 return true;
             }
 
-            if (current is not (BlockSyntax or ExpressionStatementSyntax or GlobalStatementSyntax))
+            if (current is not (BlockSyntax or ExpressionStatementSyntax or GlobalStatementSyntax
+                or ArgumentListSyntax or InvocationExpressionSyntax))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    // Any same-tree write to the symbol that can execute before the read -- unlike the
+    // reassignment checks, WITHOUT the effective-initializer excuse: used where the
+    // declaration itself binds the value (a parameter, an aliased local), so every write is
+    // a rebind. Unverifiable (no model) counts as written: callers hop or trust only on
+    // proof.
+    public static bool IsWrittenBefore(ISymbol variable, SyntaxNode reference, SemanticModel? semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            return true;
+        }
+
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (ReassignmentTargets(node) is { } targets
+                && targets.Any(target => WritesVariable(target, variable, semanticModel))
+                && CanExecuteBefore(node, reference, variable, semanticModel))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Call-site arguments substitute for a chased helper's parameters: maps are built

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -149,6 +149,25 @@ internal static class ComputationLambdas
         }
     }
 
+    // A null-conditional invoke's receiver surfaces as a conditional-access PLACEHOLDER
+    // (`d?.Invoke()`): the real delegate expression is the enclosing conditional access's
+    // operation. Shared by every invoked-delegate chase.
+    public static IOperation ResolveConditionalReceiver(IOperation callee)
+    {
+        if (callee is IConditionalAccessInstanceOperation placeholder)
+        {
+            for (var current = placeholder.Parent; current is not null; current = current.Parent)
+            {
+                if (current is IConditionalAccessOperation conditional)
+                {
+                    return conditional.Operation;
+                }
+            }
+        }
+
+        return callee;
+    }
+
     // Shared with MZR004's method-group receiver resolution.
     public static ISymbol? ReferencedVariable(IOperation reference)
     {

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -803,8 +803,16 @@ internal static class ComputationLambdas
     {
         for (var current = node.Parent; current is not null; current = current.Parent)
         {
+            // An arrow body belongs to the declaration that carries it: attributing it to
+            // the OWNER lets an expression-bodied local function get the same
+            // reference-ordering as a block-bodied one instead of counting as unknowable.
+            if (current is ArrowExpressionClauseSyntax { Parent: { } owner })
+            {
+                return owner;
+            }
+
             if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
-                or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or ArrowExpressionClauseSyntax)
+                or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax)
             {
                 return current;
             }
@@ -850,8 +858,24 @@ internal static class ComputationLambdas
         {
             if (identifier.Identifier.ValueText == symbol.Name
                 && !local.Span.Contains(identifier.Span)
+                && !IsInsideNameOfSyntax(identifier)
                 && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier).Symbol, symbol)
                 && ReferenceRunsBefore(identifier, reference, variable, semanticModel, visitedFunctions))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // A name mentioned only inside nameof() is a compile-time string: it neither runs the
+    // function nor lets a delegate escape, so the ordering scans must not count it.
+    private static bool IsInsideNameOfSyntax(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.ValueText: "nameof" } })
             {
                 return true;
             }
@@ -923,6 +947,7 @@ internal static class ComputationLambdas
         foreach (var name in semanticModel.SyntaxTree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>())
         {
             if (name.Identifier.ValueText != lifted.Name
+                || IsInsideNameOfSyntax(name)
                 || !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(name).Symbol, lifted))
             {
                 continue;

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -629,6 +629,16 @@ internal static class ComputationLambdas
             case IConversionOperation { OperatorMethod: { } conversionOperator }:
                 yield return conversionOperator;
                 break;
+
+            // `Changed += handler` executes the custom add (or remove) accessor immediately.
+            case IEventAssignmentOperation { EventReference: IEventReferenceOperation eventReference } eventAssignment:
+                var accessor = eventAssignment.Adds ? eventReference.Event.AddMethod : eventReference.Event.RemoveMethod;
+                if (accessor is not null)
+                {
+                    yield return accessor;
+                }
+
+                break;
         }
     }
 

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -62,6 +62,15 @@ internal static class ComputationLambdas
                 }
 
                 break;
+            case IMethodReferenceOperation bareMethodReference:
+                // Like the bare-lambda case: GetOperation on a variable initializer's method
+                // group yields the reference without the delegate-creation wrapper.
+                if (ResolveMethodBody(bareMethodReference.Method, semanticModel) is { } resolvedBare)
+                {
+                    yield return resolvedBare;
+                }
+
+                break;
             case IConversionOperation conversion:
                 foreach (var body in BodiesIn(conversion.Operand, semanticModel, visitedVariables))
                 {
@@ -89,7 +98,8 @@ internal static class ComputationLambdas
         }
     }
 
-    private static ISymbol? ReferencedVariable(IOperation reference)
+    // Shared with MZR004's method-group receiver resolution.
+    public static ISymbol? ReferencedVariable(IOperation reference)
     {
         return reference switch
         {
@@ -109,33 +119,12 @@ internal static class ComputationLambdas
     private static IEnumerable<ComputationBody> BodiesFromVariableInitializer(ISymbol? variable, SemanticModel? semanticModel, HashSet<ISymbol>? visitedVariables)
     {
         visitedVariables ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-        if (variable is null || semanticModel is null || !visitedVariables.Add(variable))
+        if (variable is null || !visitedVariables.Add(variable))
         {
             yield break;
         }
 
-        var declaration = variable.DeclaringSyntaxReferences.FirstOrDefault();
-        if (declaration is null || declaration.SyntaxTree != semanticModel.SyntaxTree)
-        {
-            yield break;
-        }
-
-        // Locals and fields declare through VariableDeclaratorSyntax; auto-properties with an
-        // initializer (`Func<...> Compute { get; } = async () => ...`) through
-        // PropertyDeclarationSyntax. Computed properties have no initializer and stay
-        // unresolvable, as they should.
-        var initializer = declaration.GetSyntax() switch
-        {
-            VariableDeclaratorSyntax { Initializer.Value: { } value } => value,
-            PropertyDeclarationSyntax { Initializer.Value: { } value } => value,
-            _ => null,
-        };
-        if (initializer is null)
-        {
-            yield break;
-        }
-
-        var operation = semanticModel.GetOperation(initializer);
+        var operation = SameTreeInitializerOperation(variable, semanticModel);
         if (operation is null)
         {
             yield break;
@@ -145,6 +134,34 @@ internal static class ComputationLambdas
         {
             yield return body;
         }
+    }
+
+    // The variable's same-tree INITIALIZER as an operation. Locals and fields declare through
+    // VariableDeclaratorSyntax; auto-properties with an initializer (`Func<...> Compute { get; }
+    // = async () => ...`) through PropertyDeclarationSyntax. Computed properties have no
+    // initializer and stay unresolvable, as they should. Shared with MZR004's method-group
+    // receiver resolution.
+    public static IOperation? SameTreeInitializerOperation(ISymbol? variable, SemanticModel? semanticModel)
+    {
+        if (variable is null || semanticModel is null)
+        {
+            return null;
+        }
+
+        var declaration = variable.DeclaringSyntaxReferences.FirstOrDefault();
+        if (declaration is null || declaration.SyntaxTree != semanticModel.SyntaxTree)
+        {
+            return null;
+        }
+
+        var initializer = declaration.GetSyntax() switch
+        {
+            VariableDeclaratorSyntax { Initializer.Value: { } value } => value,
+            PropertyDeclarationSyntax { Initializer.Value: { } value } => value,
+            _ => null,
+        };
+
+        return initializer is null ? null : semanticModel.GetOperation(initializer);
     }
 
     // A method group (`f.CreateMemoizR(Compute)`) or local-function reference is as much a

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -545,6 +545,131 @@ internal static class ComputationLambdas
         return right;
     }
 
+    // The values a simple assignment gives THIS variable, deconstructions paired
+    // positionally (`(other, later) = (a, b)` assigns only `b` to `later`). WritesVariable,
+    // not plain symbol equality: an assignment through a ref alias rebinds the variable
+    // too. Shared by MZR004's delegate chases and the assembled-patch resolution below.
+    public static IEnumerable<IOperation> AssignedValuesFor(ExpressionSyntax left, ExpressionSyntax right, ISymbol variable, SemanticModel semanticModel)
+    {
+        if (left is TupleExpressionSyntax leftTuple && right is TupleExpressionSyntax rightTuple
+            && leftTuple.Arguments.Count == rightTuple.Arguments.Count)
+        {
+            for (var i = 0; i < leftTuple.Arguments.Count; i++)
+            {
+                foreach (var value in AssignedValuesFor(leftTuple.Arguments[i].Expression, rightTuple.Arguments[i].Expression, variable, semanticModel))
+                {
+                    yield return value;
+                }
+            }
+
+            yield break;
+        }
+
+        if (WritesVariable(left, variable, semanticModel)
+            && semanticModel.GetOperation(right) is { } operation)
+        {
+            yield return operation;
+        }
+    }
+
+    // Best-effort SUPPLEMENTAL bodies for an Apply patch argument beyond OfArgumentValue: a
+    // patch assembled by a same-tree out-helper (the sole dominating out handoff, following
+    // forwarded handoffs), or returned by a same-tree computed get-only delegate property.
+    // Resolution only -- MZR004 owns the unverifiable accounting for these shapes; MZR003
+    // needs the BODIES, because a Set inside them still throws under the evaluation lock.
+    public static IEnumerable<ComputationBody> AssembledPatchBodies(IOperation value, SemanticModel? semanticModel)
+    {
+        var reference = value;
+        while (reference is IConversionOperation conversion)
+        {
+            reference = conversion.Operand;
+        }
+
+        var variable = ReferencedVariable(reference);
+        if (variable is not null && EffectiveInitializerWrite(variable, semanticModel) is ArgumentSyntax outWrite)
+        {
+            foreach (var body in OutHandoffBodies(outWrite, semanticModel, new HashSet<SyntaxNode>()))
+            {
+                yield return body;
+            }
+        }
+
+        if (variable is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
+            && ResolveMethodBody(getter, semanticModel) is { } getterBody)
+        {
+            foreach (var body in ReturnedBodies(getterBody, semanticModel))
+            {
+                yield return body;
+            }
+        }
+    }
+
+    private static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel)
+    {
+        foreach (var inner in DescendDirectExecution(methodBody.Body))
+        {
+            if (inner is not IReturnOperation { ReturnedValue: { } returned })
+            {
+                continue;
+            }
+
+            foreach (var body in OfArgumentValue(returned, semanticModel))
+            {
+                yield return body;
+            }
+        }
+    }
+
+    // The delegate bodies an out-helper binds to its parameter: direct assignments'
+    // paired values, plus FORWARDED out handoffs (`Provide(out d) { Build(out d); }`)
+    // followed recursively -- the visited set bounds forwarding cycles.
+    public static IEnumerable<ComputationBody> OutHandoffBodies(ArgumentSyntax argument, SemanticModel? semanticModel, HashSet<SyntaxNode> visited)
+    {
+        if (semanticModel is null || !visited.Add(argument)
+            || (semanticModel.GetOperation(argument) as IArgumentOperation)?.Parameter is not { } parameter
+            || parameter.ContainingSymbol is not IMethodSymbol method
+            || ResolveMethodBody(method, semanticModel) is not { } helper)
+        {
+            yield break;
+        }
+
+        foreach (var node in helper.Scope.DescendantNodes())
+        {
+            foreach (var body in OutHandoffNodeBodies(node, parameter, semanticModel, visited))
+            {
+                yield return body;
+            }
+        }
+    }
+
+    private static IEnumerable<ComputationBody> OutHandoffNodeBodies(SyntaxNode node, IParameterSymbol parameter, SemanticModel semanticModel, HashSet<SyntaxNode> visited)
+    {
+        switch (node)
+        {
+            case AssignmentExpressionSyntax assignment
+                when ReassignmentTargets(assignment) is { } targets
+                    && targets.Any(target => WritesVariable(target, parameter, semanticModel)):
+                foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
+                {
+                    foreach (var body in OfArgumentValue(value, semanticModel))
+                    {
+                        yield return body;
+                    }
+                }
+
+                break;
+            case ArgumentSyntax forwarded
+                when forwarded.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
+                    && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(forwarded.Expression).Symbol, parameter):
+                foreach (var body in OutHandoffBodies(forwarded, semanticModel, visited))
+                {
+                    yield return body;
+                }
+
+                break;
+        }
+    }
+
     // A ref-local ALIAS writes its referent: `ref var alias = ref patch; alias = ...` rebinds
     // patch just as directly. The alias chain resolves through `= ref` initializers; the
     // visited set breaks alias cycles. Shared by MZR004's delegate-reassignment scan and the

--- a/MemoizR.Analyzers/ComputationLambdas.cs
+++ b/MemoizR.Analyzers/ComputationLambdas.cs
@@ -256,9 +256,9 @@ internal static class ComputationLambdas
     // The effective initializer narrowed to the shapes whose right-hand side resolves to a
     // single operation; an out-argument handoff has no RHS here (its bodies come from the
     // callee's assignments, which MZR004 resolves itself).
-    public static AssignmentExpressionSyntax? EffectiveInitializerAssignment(ISymbol variable, SemanticModel? semanticModel)
+    public static AssignmentExpressionSyntax? EffectiveInitializerAssignment(ISymbol variable, SemanticModel? semanticModel, SyntaxNode? readSite = null)
     {
-        return EffectiveInitializerWrite(variable, semanticModel) as AssignmentExpressionSyntax;
+        return EffectiveInitializerWrite(variable, semanticModel, readSite) as AssignmentExpressionSyntax;
     }
 
     // The single same-tree WRITE standing in for a missing declaration initializer -- a
@@ -267,7 +267,7 @@ internal static class ComputationLambdas
     // declaration has an initializer, there are several writes (ambiguous), or the one
     // write does not fully determine the value. Reassignment scans EXCLUDE this node: it is
     // the initialization, not a rebind.
-    public static SyntaxNode? EffectiveInitializerWrite(ISymbol variable, SemanticModel? semanticModel)
+    public static SyntaxNode? EffectiveInitializerWrite(ISymbol variable, SemanticModel? semanticModel, SyntaxNode? readSite = null)
     {
         if (semanticModel is null || variable.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
                 is VariableDeclaratorSyntax { Initializer: not null }
@@ -283,8 +283,11 @@ internal static class ComputationLambdas
             // WritesVariable, not plain symbol equality: the reassignment scans count a
             // write through a ref alias (`ref var alias = ref patch; alias = ...`), so the
             // initializer detection must recognize the same write or the sole initializing
-            // assignment would read as a rebind.
-            if (ReassignmentTargets(node) is not { } targets)
+            // assignment would read as a rebind. With a READ SITE, writes that cannot run
+            // before it are ignored outright: a future rebind neither initializes nor
+            // disqualifies the write whose value this read observes.
+            if (ReassignmentTargets(node) is not { } targets
+                || (readSite is not null && !CanExecuteBefore(node, readSite, variable, semanticModel)))
             {
                 continue;
             }
@@ -303,7 +306,32 @@ internal static class ComputationLambdas
             sole = node;
         }
 
-        return sole is not null && DominatesItsFunction(sole, variable) ? sole : null;
+        return sole is not null && DominatesItsFunction(sole, variable) && ReachesMemberRead(sole, variable, readSite)
+            ? sole
+            : null;
+    }
+
+    // For MEMBER storage the sole write must also provably reach THIS read: unlike locals
+    // (definite assignment) and parameters (binding), a field holds its default or an
+    // externally supplied value until the write actually runs -- a write in some unrelated
+    // method that merely COULD run first proves nothing. Provable = the write shares the
+    // read's function, or its function lexically contains the read (the flow reaching a
+    // computation built after the write passed it first).
+    private static bool ReachesMemberRead(SyntaxNode write, ISymbol variable, SyntaxNode? readSite)
+    {
+        if (variable is not (IFieldSymbol or IPropertySymbol))
+        {
+            return true;
+        }
+
+        if (readSite is null)
+        {
+            return false;
+        }
+
+        var function = EnclosingFunction(write);
+        return function is not null
+            && (ReferenceEquals(function, EnclosingFunction(readSite)) || function.Span.Contains(readSite.Span));
     }
 
     // Only a write that fully DETERMINES the value qualifies: `x ??= ...` / `x += ...` can
@@ -586,7 +614,7 @@ internal static class ComputationLambdas
         }
 
         var variable = ReferencedVariable(reference);
-        if (variable is not null && EffectiveInitializerWrite(variable, semanticModel) is ArgumentSyntax outWrite)
+        if (variable is not null && EffectiveInitializerWrite(variable, semanticModel, reference.Syntax) is ArgumentSyntax outWrite)
         {
             foreach (var body in OutHandoffBodies(outWrite, semanticModel, new HashSet<SyntaxNode>(), outerMap: null))
             {
@@ -621,6 +649,63 @@ internal static class ComputationLambdas
         }
     }
 
+    // A delegate VALUE collapsed through variable-alias initializers and parameter-to-
+    // argument hops -- the resolution-only mirror of MZR004's invoked-delegate resolver,
+    // with a strict rebind guard: a written alias or parameter stays put, because the
+    // write (not the initializer or the call site) owns the value.
+    public static IOperation ResolveDelegateValue(IOperation value, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        var current = value;
+        HashSet<ISymbol>? visited = null;
+        while (true)
+        {
+            var unwrapped = current;
+            while (unwrapped is IConversionOperation conversion)
+            {
+                unwrapped = conversion.Operand;
+            }
+
+            if (unwrapped is IParameterReferenceOperation rebound
+                && argumentMap?.ContainsKey(rebound.Parameter) == true
+                && IsWrittenBefore(rebound.Parameter, current.Syntax, semanticModel))
+            {
+                return current;
+            }
+
+            if (SubstituteArguments(current, argumentMap) is { } substituted && !ReferenceEquals(substituted, current))
+            {
+                current = substituted;
+                continue;
+            }
+
+            if (ReferencedVariable(unwrapped) is not { } variable)
+            {
+                return current;
+            }
+
+            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            var initializer = SameTreeInitializerOperation(variable, semanticModel);
+            if (!visited.Add(variable) || initializer is null
+                || IsWrittenBefore(variable, current.Syntax, semanticModel)
+                || !IsReferenceShape(initializer))
+            {
+                return current;
+            }
+
+            current = initializer;
+        }
+    }
+
+    private static bool IsReferenceShape(IOperation operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation is IParameterReferenceOperation || ReferencedVariable(operation) is not null;
+    }
+
     private static IInvocationOperation? UnwrappedInitializerCall(ISymbol? variable, SemanticModel? semanticModel)
     {
         var initializer = SameTreeInitializerOperation(variable, semanticModel);
@@ -632,7 +717,7 @@ internal static class ComputationLambdas
         return initializer as IInvocationOperation;
     }
 
-    private static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
+    public static IEnumerable<ComputationBody> ReturnedBodies(ComputationBody methodBody, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
         foreach (var inner in DescendDirectExecution(methodBody.Body))
         {
@@ -641,7 +726,8 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            foreach (var body in OfArgumentValue(SubstituteArguments(returned, argumentMap) ?? returned, semanticModel))
+            // Aliases resolve too: `var q = p; return q;` hands back the call-site value.
+            foreach (var body in OfArgumentValue(ResolveDelegateValue(returned, semanticModel, argumentMap), semanticModel))
             {
                 yield return body;
             }
@@ -715,8 +801,9 @@ internal static class ComputationLambdas
                 foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
                 {
                     // The call-site map resolves a value forwarded from ANOTHER delegate
-                    // parameter (`Provide(source, out patch)` with `p = source`).
-                    foreach (var body in OfArgumentValue(SubstituteArguments(value, callMap) ?? value, semanticModel))
+                    // parameter (`Provide(source, out patch)` with `p = source`), aliases
+                    // included.
+                    foreach (var body in OfArgumentValue(ResolveDelegateValue(value, semanticModel, callMap), semanticModel))
                     {
                         yield return (body, callMap);
                     }
@@ -1270,30 +1357,34 @@ internal static class ComputationLambdas
                 continue;
             }
 
-            var current = UnwrapCastsAndParentheses(name);
-            if (current.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == current)
+            if (LiftedUseRunsBefore(name, reference, variable, semanticModel, visitedFunctions))
             {
-                if (CanExecuteBefore(current, reference, variable, semanticModel, visitedFunctions))
-                {
-                    return true;
-                }
-
-                continue;
+                return true;
             }
-
-            // A write to the variable is not a use of the delegate, and a DISCARD
-            // (`_ = unused;`) provably drops it; anything else lets the delegate escape to
-            // unknowable invocation sites.
-            if (current.Parent is AssignmentExpressionSyntax write
-                && (write.Left == current || semanticModel.GetSymbolInfo(write.Left).Symbol is IDiscardSymbol))
-            {
-                continue;
-            }
-
-            return true;
         }
 
         return false;
+    }
+
+    private static bool LiftedUseRunsBefore(IdentifierNameSyntax name, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel, HashSet<SyntaxNode> visitedFunctions)
+    {
+        var current = UnwrapCastsAndParentheses(name);
+        if (current.Parent is InvocationExpressionSyntax { Expression: { } invoked } && invoked == current)
+        {
+            return CanExecuteBefore(current, reference, variable, semanticModel, visitedFunctions);
+        }
+
+        // A write to the variable is not a use of the delegate, and a DISCARD
+        // (`_ = unused;`) provably drops it; anything else lets the delegate escape to
+        // unknowable invocation sites -- but only an escape that can itself RUN before
+        // the read can put an invocation before it.
+        if (current.Parent is AssignmentExpressionSyntax write
+            && (write.Left == current || semanticModel.GetSymbolInfo(write.Left).Symbol is IDiscardSymbol))
+        {
+            return false;
+        }
+
+        return CanExecuteBefore(current, reference, variable, semanticModel, visitedFunctions);
     }
 
     // Only the loop BODY re-declares per iteration: a variable in a for-INITIALIZER is

--- a/MemoizR.Analyzers/DiagnosticDescriptors.cs
+++ b/MemoizR.Analyzers/DiagnosticDescriptors.cs
@@ -40,6 +40,23 @@ internal static class DiagnosticDescriptors
                      "mutation — the very thing the reactive graph exists to replace (the SE-0412 analog).",
         helpLinkUri: HelpUri);
 
+    public static readonly DiagnosticDescriptor NonSendablePatchCapture = new(
+        id: "MZR004",
+        title: "Optimistic patch captures non-Sendable state",
+        messageFormat: "'{0}' is captured by an optimistic patch, but {1} — the patch is stored in the overlay " +
+                       "and re-executed by the view's computation on whichever flow pulls it, so captured state " +
+                       "is shared across flows; capture an immutable snapshot instead, or lift the state into a " +
+                       "Signal",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A patch passed to OptimisticActionContext.Apply outlives the applying code: it runs inside " +
+                     "the optimistic view's computation on arbitrary flows until the run ends. Its closure " +
+                     "captures therefore cross flows exactly like node values do — the closure-capture mirror of " +
+                     "MZR001, closing the strict-mode gap recorded in ADR 0007 (runtime checking would reject " +
+                     "every capturing lambda, because closure display classes always carry writable fields).",
+        helpLinkUri: HelpUri);
+
     public static readonly DiagnosticDescriptor SetInsideComputation = new(
         id: "MZR003",
         title: "A graph write inside a reactive computation throws at runtime",

--- a/MemoizR.Analyzers/FactoryMethods.cs
+++ b/MemoizR.Analyzers/FactoryMethods.cs
@@ -34,7 +34,12 @@ internal static class FactoryMethods
             // The factory-level CreateReaction sugar forwards to BuildReaction().CreateReaction,
             // so its action is just as much a reaction computation -- without this, the
             // README-style f.CreateReaction(..) overloads bypass MZR002 entirely.
-            || IsReactiveMemoFactoryMethod(method, "CreateReaction");
+            || IsReactiveMemoFactoryMethod(method, "CreateReaction")
+            // An optimistic PATCH is engine-executed: it is stored in the overlay and re-run by
+            // the view's computation on whichever flow pulls, so a captured-state write in one
+            // is exactly MZR002's data race. (Action BODIES are deliberately NOT hosts -- they
+            // are user-driven process code; see ADR 0007.)
+            || IsOptimisticContextMethod(method, "Apply");
     }
 
     // Hosts whose computations deterministically throw on a Set of their own graph (MZR003): in
@@ -49,7 +54,17 @@ internal static class FactoryMethods
         return IsMemoFactoryMethod(method, "CreateMemoizR", "CreateActorMemoizR")
             || IsStructuredFactoryMethod(method, "CreateConcurrentMapReduce", "CreateConcurrentRace")
             || IsReactionBuilderMethod(method, "CreateReaction", "CreateAdvancedReaction")
-            || IsReactiveMemoFactoryMethod(method, "CreateReaction");
+            || IsReactiveMemoFactoryMethod(method, "CreateReaction")
+            // A patch runs inside the view memo's recompute, whose flow holds the evaluation
+            // lock -- a Set in one throws exactly like a Set in the memo's own computation.
+            || IsOptimisticContextMethod(method, "Apply");
+    }
+
+    // Whether the delegate argument is an OPTIMISTIC PATCH (MZR004's subject, and a computation
+    // for MZR002/MZR003 via the classifications above).
+    public static bool IsOptimisticPatchHost(IMethodSymbol method)
+    {
+        return IsOptimisticContextMethod(method, "Apply");
     }
 
     // Whether the host runs an ACTOR-engine computation (CreateActorMemoizR). MZR003 uses this to
@@ -82,6 +97,12 @@ internal static class FactoryMethods
     private static bool IsReactiveMemoFactoryMethod(IMethodSymbol method, params string[] names)
     {
         return IsOn(method, "MemoizR", "ReactiveMemoFactory", names);
+    }
+
+    // The action-run context an optimistic patch is applied through (ADR 0007).
+    private static bool IsOptimisticContextMethod(IMethodSymbol method, params string[] names)
+    {
+        return IsOn(method, "MemoizR.Reactive", "OptimisticActionContext", names);
     }
 
     private static bool IsOn(IMethodSymbol method, string namespaceName, string typeName, string[] names)

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -77,6 +77,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
+        // A conditional or null-coalescing patch stores whichever arm the flow picks: each
+        // arm gets the full argument treatment, so a safe arm cannot silence an
+        // unverifiable one (and vice versa).
+        if (InspectConditionalArms(context, classifier, value, semanticModel, reported))
+        {
+            return;
+        }
+
         // A delegate variable that is REASSIGNED after its initializer no longer proves which
         // closure the overlay stores -- the initializer may be harmless while the reassignment
         // captures anything -- so it is treated like an unresolvable delegate instead of
@@ -113,19 +121,20 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // like an inline patch body, with unresolvable branches reported by the helper
         // accounting itself; an unwalkable helper falls through to the unverifiable report
         // below.
-        if (!bodyResolved && semanticModel is not null
-            && ReceiverSymbol(Unwrap(value)) is { } assembled
-            && ComputationLambdas.EffectiveInitializerWrite(assembled, semanticModel) is ArgumentSyntax outWrite)
+        if (!bodyResolved)
         {
-            var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
-            var visitedInvokes = new HashSet<(SyntaxNode, string)>();
-            var (bodies, accounted) = OutAssignedBodies(context, classifier, outWrite, semanticModel, visitedCalls, visitedInvokes, argumentMap: null, reported);
-            foreach (var patch in bodies)
-            {
-                InspectPatchBody(context, classifier, patch, semanticModel, reported);
-            }
+            bodyResolved = InspectOutAssembledPatch(context, classifier, value, semanticModel, reported);
+        }
 
-            bodyResolved |= bodies.Count > 0 || accounted;
+        // A same-tree computed get-only delegate PROPERTY resolves through its getter's
+        // returns, like a delegate-returning helper: each return is walked as a patch body,
+        // with unresolvable returns reported.
+        if (!bodyResolved && ReceiverSymbol(Unwrap(value)) is IPropertySymbol patchProperty
+            && !IsSettable(patchProperty) && !HasBackingStorage(patchProperty)
+            && patchProperty.GetMethod is { } patchGetter
+            && ComputationLambdas.ResolveMethodBody(patchGetter, semanticModel) is { } getterBody)
+        {
+            bodyResolved = InspectPropertyPatchReturns(context, classifier, getterBody, patchProperty, semanticModel, reported);
         }
 
         // A SOURCE-declared method group whose body lives in another file cannot be walked:
@@ -153,6 +162,102 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 symbol?.Name ?? SendableSymbolClassifier.Display(value.Type),
                 "it is an already-built delegate whose closure cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (define the patch inline or as a same-tree method)",
                 reported);
+        }
+    }
+
+    private static bool InspectOutAssembledPatch(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        if (semanticModel is null
+            || ReceiverSymbol(Unwrap(value)) is not { } assembled
+            || ComputationLambdas.EffectiveInitializerWrite(assembled, semanticModel) is not ArgumentSyntax outWrite)
+        {
+            return false;
+        }
+
+        var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
+        var visitedInvokes = new HashSet<(SyntaxNode, string)>();
+        var (bodies, accounted) = OutAssignedBodies(context, classifier, outWrite, semanticModel, visitedCalls, visitedInvokes, argumentMap: null, reported);
+        foreach (var patch in bodies)
+        {
+            InspectPatchBody(context, classifier, patch, semanticModel, reported);
+        }
+
+        return bodies.Count > 0 || accounted;
+    }
+
+    // Each getter return is a CANDIDATE: walked as a patch body when it resolves, trusted
+    // when it is a metadata target, reported otherwise -- a safe return must not silence an
+    // unresolvable one. (The getter runs at the Apply call, once; only the RETURNED
+    // delegate replays, so the getter's own statements need no per-replay walk here.)
+    private static bool InspectPropertyPatchReturns(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        ComputationLambdas.ComputationBody getterBody,
+        IPropertySymbol property,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        var accounted = false;
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
+        {
+            if (inner is not IReturnOperation { ReturnedValue: { } returned })
+            {
+                continue;
+            }
+
+            accounted = true;
+            var resolvedValue = ResolveDelegateReference(returned, semanticModel, argumentMap: null);
+            var resolvedAny = false;
+            foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
+            {
+                resolvedAny = true;
+                InspectPatchBody(context, classifier, patch, semanticModel, reported);
+            }
+
+            if (!resolvedAny
+                && ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is not { Method.DeclaringSyntaxReferences.Length: 0 })
+            {
+                Report(
+                    context,
+                    returned,
+                    property,
+                    property.Name,
+                    "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)",
+                    reported);
+            }
+        }
+
+        return accounted;
+    }
+
+    private static bool InspectConditionalArms(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        switch (Unwrap(value))
+        {
+            case IConditionalOperation conditional:
+                InspectPatchArgument(context, classifier, conditional.WhenTrue, semanticModel, reported);
+                if (conditional.WhenFalse is { } whenFalse)
+                {
+                    InspectPatchArgument(context, classifier, whenFalse, semanticModel, reported);
+                }
+
+                return true;
+            case ICoalesceOperation coalesce:
+                InspectPatchArgument(context, classifier, coalesce.Value, semanticModel, reported);
+                InspectPatchArgument(context, classifier, coalesce.WhenNull, semanticModel, reported);
+                return true;
+            default:
+                return false;
         }
     }
 
@@ -775,14 +880,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         IMethodSymbol method,
         HashSet<ISymbol> reported)
     {
-        if (!IsUnverifiableExecutedShape(operation) || method.DeclaringSyntaxReferences.Length == 0)
+        if ((!IsUnverifiableExecutedShape(operation) && !IsExecutedSetter(operation, method))
+            || method.DeclaringSyntaxReferences.Length == 0)
         {
             return;
         }
 
         var name = method.MethodKind == MethodKind.Constructor
             ? SendableSymbolClassifier.Display(method.ContainingType)
-            : method.Name;
+            : method.AssociatedSymbol?.Name ?? method.Name;
         Report(
             context,
             operation,
@@ -798,6 +904,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             or IBinaryOperation { OperatorMethod: not null }
             or IUnaryOperation { OperatorMethod: not null }
             or IConversionOperation { OperatorMethod: not null };
+    }
+
+    // A SETTER an assignment runs is executed code like a call: on a receiver the capture
+    // walk gives no verdict for (a computation-local object, a Sendable-trusted type), this
+    // fallback is the only look a cross-file setter body ever gets. Getters stay with their
+    // own member/type/getter verdicts.
+    private static bool IsExecutedSetter(IOperation operation, IMethodSymbol method)
+    {
+        return operation is IPropertyReferenceOperation && method.MethodKind == MethodKind.PropertySet;
     }
 
     // A delegate the patch builds AND synchronously invokes runs its body on every replay:
@@ -830,10 +945,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         var found = false;
-        foreach (var body in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
+        if (!InitializerOverwrittenBeforeInvoke(resolved, semanticModel))
         {
-            found = true;
-            ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            foreach (var body in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
+            {
+                found = true;
+                ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            }
         }
 
         var unwrapped = Unwrap(resolved);
@@ -1191,6 +1309,32 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
         {
             if (AccountsForValue(context, classifier, ResolveDelegateReference(value, semanticModel, argumentMap), semanticModel, visitedCalls, visitedInvokes, argumentMap, reported))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // A declaration initializer definitely OVERWRITTEN on the straight-line path to the
+    // invoke can never be the delegate invoked -- only the surviving assignment candidates
+    // can -- so the stale initializer must not charge its closure to this call.
+    private static bool InitializerOverwrittenBeforeInvoke(IOperation resolved, SemanticModel? semanticModel)
+    {
+        if (semanticModel is null
+            || ComputationLambdas.ReferencedVariable(Unwrap(resolved)) is not { } variable
+            || variable.DeclaringSyntaxReferences.FirstOrDefault() is not { } declaration
+            || declaration.SyntaxTree != semanticModel.SyntaxTree
+            || declaration.GetSyntax() is not VariableDeclaratorSyntax { Initializer: not null } declarator)
+        {
+            return false;
+        }
+
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (WritesDelegateBeforeInvoke(node, variable, resolved, semanticModel)
+                && DefinitelyOverwrites(node, declarator, resolved.Syntax, variable, semanticModel))
             {
                 return true;
             }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -618,12 +618,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectCapturedLocalFunction(context, classifier, operation, patch.Scope, semanticModel, visitedLocalFunctions, reported);
         }
 
-        // Both chases are bounded per SITE, not per symbol: the same delegate reassigned and
-        // invoked again executes a different closure, and the same helper called with
-        // different delegate arguments executes different bodies -- while recursion re-reaches
-        // the same site and stops.
-        var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol)>();
-        var visitedInvokes = new HashSet<SyntaxNode>();
+        // Both chases are bounded per SITE and ARGUMENT BINDING, not per symbol: the same
+        // delegate reassigned and invoked again executes a different closure, and the same
+        // call site reached under different outer bindings executes different bodies (two
+        // outer calls handing different lambdas into one nested call) -- while recursion,
+        // whose rebuilt map carries the same substituted values, stops.
+        var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
+        var visitedInvokes = new HashSet<(SyntaxNode, string)>();
         foreach (var operation in ComputationLambdas.DescendDirectExecution(patch.Body))
         {
             InspectStaticRead(context, classifier, operation, reported);
@@ -672,8 +673,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         IOperation operation,
         SemanticModel? semanticModel,
-        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
-        HashSet<SyntaxNode> visitedInvokes,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
@@ -694,19 +695,54 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // real use.)
         foreach (var method in ComputationLambdas.ExecutedMethods(operation))
         {
-            if (ComputationLambdas.IsInsideNameOf(operation) || !visitedCalls.Add((operation.Syntax, method))
-                || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+            if (ComputationLambdas.IsInsideNameOf(operation))
             {
                 continue;
             }
 
+            if (ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+            {
+                ReportUnwalkableExecutedHelper(context, operation, method, reported);
+                continue;
+            }
+
             var nestedMap = ComputationLambdas.BuildArgumentMap(operation, argumentMap);
+            if (!visitedCalls.Add((operation.Syntax, method, ComputationLambdas.ArgumentMapKey(nestedMap))))
+            {
+                continue;
+            }
+
             foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
             {
                 InspectStaticRead(context, classifier, inner, reported);
                 InspectExecutedHelper(context, classifier, inner, semanticModel, visitedCalls, visitedInvokes, nestedMap, reported);
             }
         }
+    }
+
+    // A helper the patch CALLS whose source body lives in another file is as unverifiable
+    // as a cross-file method-group patch: nothing checks the statics it reads on every
+    // replay, so unverifiable means flagged -- while metadata callees (Math.Abs, List.Add)
+    // stay trusted external contracts. Scoped to CALLS: accessors and constructors keep
+    // their member/type verdicts from the capture walk.
+    private static void ReportUnwalkableExecutedHelper(
+        OperationAnalysisContext context,
+        IOperation operation,
+        IMethodSymbol method,
+        HashSet<ISymbol> reported)
+    {
+        if (operation is not IInvocationOperation || method.DeclaringSyntaxReferences.Length == 0)
+        {
+            return;
+        }
+
+        Report(
+            context,
+            operation,
+            method,
+            method.Name,
+            "its body is declared in another file, so what the patch executes cannot be verified from this call site (declare the helper in this file, or lift its state into MemoizR nodes)",
+            reported);
     }
 
     // A delegate the patch builds AND synchronously invokes runs its body on every replay:
@@ -727,13 +763,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         IOperation callee,
         SemanticModel? semanticModel,
-        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
-        HashSet<SyntaxNode> visitedInvokes,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
         var resolved = ResolveDelegateReference(callee, semanticModel, argumentMap);
-        if (!visitedInvokes.Add(resolved.Syntax))
+        if (!visitedInvokes.Add((resolved.Syntax, ComputationLambdas.ArgumentMapKey(argumentMap))))
         {
             return;
         }
@@ -776,8 +812,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         IInvocationOperation call,
         SemanticModel? semanticModel,
-        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
-        HashSet<SyntaxNode> visitedInvokes,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
@@ -1067,32 +1103,44 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             ? ComputationLambdas.BuildArgumentMap(call, argumentMap)
             : argumentMap;
 
-        var writes = new List<AssignmentExpressionSyntax>();
-        foreach (var node in helper.Scope.DescendantNodes())
-        {
-            if (node is AssignmentExpressionSyntax assignment
-                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, parameter))
-            {
-                writes.Add(assignment);
-            }
-        }
-
+        var writes = ParameterWrites(helper.Scope, parameter, semanticModel);
         foreach (var assignment in writes)
         {
             // What the caller receives is the delegate bound when the helper RETURNS: a later
             // straight-line overwrite inside the helper kills this body exactly like one
             // before an invoke, with the helper's scope end as the observation point.
-            if (writes.Any(other => other != assignment && DefinitelyOverwrites(other, assignment, helper.Scope, parameter, semanticModel))
-                || semanticModel.GetOperation(assignment.Right) is not { } assigned)
+            if (writes.Any(other => other != assignment && DefinitelyOverwrites(other, assignment, helper.Scope, parameter, semanticModel)))
             {
                 continue;
             }
 
-            foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(assigned, semanticModel, callMap), semanticModel))
+            foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
             {
-                yield return body;
+                foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(value, semanticModel, callMap), semanticModel))
+                {
+                    yield return body;
+                }
             }
         }
+    }
+
+    // ReassignmentTargets flattens deconstruction left sides, so `(d, _) = (...)` assembles
+    // the delegate exactly like `d = ...`; AssignedValuesFor later pairs the parameter's
+    // slot with its tuple element.
+    private static List<AssignmentExpressionSyntax> ParameterWrites(SyntaxNode scope, IParameterSymbol parameter, SemanticModel semanticModel)
+    {
+        var writes = new List<AssignmentExpressionSyntax>();
+        foreach (var node in scope.DescendantNodes())
+        {
+            if (node is AssignmentExpressionSyntax assignment
+                && ComputationLambdas.ReassignmentTargets(assignment) is { } targets
+                && targets.Any(target => ComputationLambdas.WritesVariable(target, parameter, semanticModel)))
+            {
+                writes.Add(assignment);
+            }
+        }
+
+        return writes;
     }
 
     private static IEnumerable<IOperation> AssignedValuesFor(ExpressionSyntax left, ExpressionSyntax right, ISymbol variable, SemanticModel semanticModel)
@@ -1125,8 +1173,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         ComputationLambdas.ComputationBody body,
         SemanticModel? semanticModel,
-        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
-        HashSet<SyntaxNode> visitedInvokes,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -11,8 +11,10 @@ namespace MemoizR.Analyzers;
 // optimistic state, so everything its closure captures crosses flows exactly like a node value.
 // A capture whose type is not Sendable (a List<int> local), or a read of writable state on the
 // enclosing object (a non-readonly field, a settable property), is therefore unsynchronized
-// cross-flow sharing. Reads of Sendable-typed captures stay unflagged -- capturing the action
-// payload or other immutable snapshots is the idiomatic pattern. This rule exists because the
+// cross-flow sharing -- and so are a method-group patch's receiver, a bare `this` handed to a
+// helper, and static state a patch reads (shared without any capture at all). Reads of
+// Sendable-typed captures stay unflagged -- capturing the action payload or other immutable
+// snapshots is the idiomatic pattern. This rule exists because the
 // RUNTIME cannot check it: closure display classes always carry writable fields, so a
 // structural runtime check would reject every capturing lambda. Captured-state WRITES inside a
 // patch are MZR002's territory (Apply is a computation host), and a Set inside one is MZR003's.
@@ -55,7 +57,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // metadata or another file and cannot be walked.
         foreach (var argument in invocation.Arguments)
         {
-            InspectMethodGroupReceiver(context, classifier, argument.Value, reported);
+            InspectMethodGroupReceiver(context, classifier, argument.Value, invocation.SemanticModel, reported);
         }
 
         foreach (var patch in ComputationLambdas.OfInvocation(invocation))
@@ -71,14 +73,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
         IOperation value,
+        SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        while (value is IConversionOperation conversion)
-        {
-            value = conversion.Operand;
-        }
-
-        if (value is not IDelegateCreationOperation { Target: IMethodReferenceOperation { Instance: { } receiver } }
+        if (ResolveMethodReference(value, semanticModel, visitedVariables: null) is not { Instance: { } receiver }
             || receiver.Type is not { } receiverType)
         {
             return;
@@ -99,6 +97,44 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             name,
             $"its type '{SendableSymbolClassifier.Display(receiverType)}' is not Sendable ({reason})",
             reported);
+    }
+
+    // The delegate argument may be the method group itself, a conversion over it, or a variable
+    // whose (same-tree) initializer holds it -- the same resolution ComputationLambdas applies
+    // to computation bodies, so a `Func<int,int> patch = helper.Patch;` stored one statement
+    // earlier does not hide the receiver. GetOperation on an initializer yields the reference
+    // without the delegate-creation wrapper, hence the bare case.
+    private static IMethodReferenceOperation? ResolveMethodReference(
+        IOperation? value,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol>? visitedVariables)
+    {
+        while (true)
+        {
+            switch (value)
+            {
+                case IConversionOperation conversion:
+                    value = conversion.Operand;
+                    continue;
+                case IDelegateCreationOperation creation:
+                    value = creation.Target;
+                    continue;
+                case IMethodReferenceOperation methodReference:
+                    return methodReference;
+                case ILocalReferenceOperation or IFieldReferenceOperation or IPropertyReferenceOperation:
+                    visitedVariables ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                    var variable = ComputationLambdas.ReferencedVariable(value);
+                    if (variable is null || !visitedVariables.Add(variable))
+                    {
+                        return null;
+                    }
+
+                    value = ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel);
+                    continue;
+                default:
+                    return null;
+            }
+        }
     }
 
     private static ISymbol? ReceiverSymbol(IOperation receiver)
@@ -159,7 +195,64 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 }
 
                 break;
+
+            // Static state needs no capture to be shared: the read is baked into the stored
+            // delegate and re-executes on pull flows while any code mutates the static. Same
+            // verdicts as enclosing-object state; const fields are compile-time values, not
+            // storage.
+            case IFieldReferenceOperation { Field: { IsStatic: true, IsConst: false } } staticField:
+                if (!staticField.Field.IsReadOnly)
+                {
+                    Report(context, operation, staticField.Field, staticField.Field.Name, "it is writable static state", reported);
+                }
+                else
+                {
+                    ReportIfNotSendable(context, classifier, operation, staticField.Field, staticField.Field.Type, reported);
+                }
+
+                break;
+            case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
+                if (staticProperty.Property.SetMethod is { IsInitOnly: false })
+                {
+                    Report(context, operation, staticProperty.Property, staticProperty.Property.Name, "it is writable static state", reported);
+                }
+                else
+                {
+                    ReportIfNotSendable(context, classifier, operation, staticProperty.Property, staticProperty.Property.Type, reported);
+                }
+
+                break;
+
+            // A bare `this` -- the implicit receiver of a helper call (`ReadCounter()`) or an
+            // explicit argument (`Use(this)`) -- captures the whole enclosing object without
+            // naming a member, so it is held to the TYPE's sendability like a method-group
+            // receiver: hiding a state read behind a helper must not evade what the direct read
+            // would flag. Receivers of the member reads the cases above inspect are skipped;
+            // those get the finer per-member verdict.
+            case IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } instance
+                when instance.Type is { } enclosingType && !IsInspectedMemberReceiver(instance):
+                var reason = classifier.GetNotSendableReason(enclosingType);
+                if (reason is not null)
+                {
+                    Report(
+                        context,
+                        operation,
+                        enclosingType,
+                        "this",
+                        $"its type '{SendableSymbolClassifier.Display(enclosingType)}' is not Sendable ({reason})",
+                        reported);
+                }
+
+                break;
         }
+    }
+
+    // True when the reference is the receiver of a member read InspectCapture handles itself:
+    // reporting `this` under those too would double-count every ordinary `x => x + counter`.
+    private static bool IsInspectedMemberReceiver(IInstanceReferenceOperation instance)
+    {
+        return (instance.Parent is IFieldReferenceOperation field && ReferenceEquals(field.Instance, instance))
+            || (instance.Parent is IPropertyReferenceOperation property && ReferenceEquals(property.Instance, instance));
     }
 
     private static bool IsOnEnclosingInstance(IOperation? receiver)

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -203,7 +203,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         var handled = true;
         foreach (var node in writes)
         {
-            if (!writes.Any(other => other != node && DefinitelyOverwrites(other, node, value.Syntax, variable, semanticModel)))
+            if (!writes.Any(other => other != node && ComputationLambdas.DefinitelyOverwrites(other, node, value.Syntax, variable, semanticModel)))
             {
                 handled &= InspectSurvivingWrite(context, classifier, node, variable, semanticModel, reported);
             }
@@ -318,7 +318,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             && patchProperty.GetMethod is { } patchGetter
             && ComputationLambdas.ResolveMethodBody(patchGetter, semanticModel) is { } getterBody)
         {
-            return InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, argumentMap: null, semanticModel, reported);
+            return InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null), semanticModel, reported);
         }
 
         // A patch produced by a same-tree delegate FACTORY -- called inline, or stored
@@ -1467,7 +1467,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         {
             // A later straight-line simple assignment on the path to the invoke REPLACES the
             // value: the earlier write's body can never be the one invoked.
-            if (writes.Any(other => other != node && DefinitelyOverwrites(other, node, invokeSite, variable, semanticModel)))
+            if (writes.Any(other => other != node && ComputationLambdas.DefinitelyOverwrites(other, node, invokeSite, variable, semanticModel)))
             {
                 continue;
             }
@@ -1572,7 +1572,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (WritesDelegateBeforeInvoke(node, variable, resolved, semanticModel)
-                && DefinitelyOverwrites(node, declarator, resolved.Syntax, variable, semanticModel))
+                && ComputationLambdas.DefinitelyOverwrites(node, declarator, resolved.Syntax, variable, semanticModel))
             {
                 return true;
             }
@@ -1602,92 +1602,6 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    // "Straight-line" = the killer sits in plain statements between itself and wherever the
-    // value is observed (an invoke site, or an out-helper's own scope end); a killer inside
-    // an if/loop may not run, so it kills nothing -- and an exit statement between the two
-    // writes can leave the earlier value observable, so nothing is definite past one. The
-    // argument-list hop covers out-handoff killers; a conditional-access call stays rejected.
-    private static bool DefinitelyOverwrites(SyntaxNode killer, SyntaxNode victim, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel)
-    {
-        if (!IsDeterminingWrite(killer, variable, semanticModel)
-            || killer.SpanStart <= victim.SpanStart
-            || killer.SpanStart >= reference.Span.End
-            || ExitsBetween(victim, killer))
-        {
-            return false;
-        }
-
-        for (var current = killer.Parent; current is not null && !current.Span.Contains(reference.Span); current = current.Parent)
-        {
-            if (current is not (BlockSyntax or ExpressionStatementSyntax or ArgumentListSyntax or InvocationExpressionSyntax))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    // A killer must fully DETERMINE the new value: a simple non-tuple assignment, or an
-    // `out` handoff (the language requires the callee to assign before returning).
-    private static bool IsDeterminingWrite(SyntaxNode killer, ISymbol variable, SemanticModel semanticModel)
-    {
-        return killer switch
-        {
-            AssignmentExpressionSyntax assignment => assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
-                && assignment.Left is not TupleExpressionSyntax
-                && ComputationLambdas.WritesVariable(assignment.Left, variable, semanticModel),
-            ArgumentSyntax argument => argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
-                && ComputationLambdas.WritesVariable(argument.Expression, variable, semanticModel),
-            _ => false,
-        };
-    }
-
-    // A return/throw/goto/break/continue/yield starting between the two writes diverts
-    // control past the killer with the victim's value still bound (an early return in an
-    // out-helper hands that delegate to the caller). Only the killer's OWN function counts:
-    // an exit inside a nested lambda -- e.g. a `return` in the victim's own delegate body --
-    // diverts nothing here, and neither does a break/continue/case-goto whose OWN construct
-    // ends before the killer (control leaves the switch/loop and still reaches it).
-    private static bool ExitsBetween(SyntaxNode victim, SyntaxNode killer)
-    {
-        var function = killer.Ancestors().FirstOrDefault(IsFunctionBoundary) ?? killer.SyntaxTree.GetRoot();
-        foreach (var node in function.DescendantNodes(descendIntoChildren: n => ReferenceEquals(n, function) || !IsFunctionBoundary(n)))
-        {
-            if (node is ReturnStatementSyntax or ThrowStatementSyntax or GotoStatementSyntax
-                    or BreakStatementSyntax or ContinueStatementSyntax or YieldStatementSyntax
-                && victim.SpanStart < node.SpanStart && node.SpanStart < killer.SpanStart
-                && !(ExitTarget(node) is { } target && target.Span.End <= killer.SpanStart))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    // The construct a contained exit leaves: the nearest switch/loop for `break`, the
-    // nearest loop for `continue`, the nearest switch for `goto case`/`goto default`.
-    // Returns null for the truly divergent exits (return/throw/yield, labeled goto).
-    private static SyntaxNode? ExitTarget(SyntaxNode exit)
-    {
-        return exit switch
-        {
-            BreakStatementSyntax => exit.Ancestors().FirstOrDefault(static ancestor =>
-                ancestor is SwitchStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax),
-            ContinueStatementSyntax => exit.Ancestors().FirstOrDefault(static ancestor =>
-                ancestor is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax),
-            GotoStatementSyntax @goto when @goto.IsKind(SyntaxKind.GotoCaseStatement) || @goto.IsKind(SyntaxKind.GotoDefaultStatement)
-                => exit.Ancestors().FirstOrDefault(static ancestor => ancestor is SwitchStatementSyntax),
-            _ => null,
-        };
-    }
-
-    private static bool IsFunctionBoundary(SyntaxNode node)
-    {
-        return node is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
-            or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax;
-    }
 
     private static IEnumerable<ComputationLambdas.ComputationBody> NodeAssignedBodies(
         SyntaxNode node,
@@ -1757,7 +1671,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             // What the caller receives is the delegate bound when the helper RETURNS: a later
             // straight-line overwrite inside the helper kills this body exactly like one
             // before an invoke, with the helper's scope end as the observation point.
-            if (writes.Any(other => other != assignment && DefinitelyOverwrites(other, assignment, helper.Scope, parameter, semanticModel)))
+            if (writes.Any(other => other != assignment && ComputationLambdas.DefinitelyOverwrites(other, assignment, helper.Scope, parameter, semanticModel)))
             {
                 continue;
             }
@@ -1962,27 +1876,80 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // A captured DELEGATE whose same-tree bodies resolve is verified by WALKING those
-        // bodies as patch code -- their own captures included -- instead of rejected
-        // wholesale for its type: the stored closure is fully visible. Reassigned or
-        // unresolvable delegate captures keep the type verdict, and the reported-set add
-        // both dedupes and bounds self-referential delegate cycles.
+        // A captured DELEGATE whose same-tree candidates ALL resolve is verified by
+        // WALKING those bodies as patch code -- their own captures and method-group
+        // receivers included -- instead of rejected wholesale for its type: the stored
+        // closure is fully visible. A conditional initializer must account for EVERY arm (a
+        // safe arm cannot vouch for an opaque one); reassigned or unresolvable delegate
+        // captures keep the type verdict, and the reported-set add both dedupes and bounds
+        // self-referential delegate cycles.
         if (type.TypeKind == TypeKind.Delegate
             && !IsReassignedBefore(symbol, operation, semanticModel)
-            && ComputationLambdas.OfArgumentValue(operation, semanticModel).Any())
+            && ComputationLambdas.SameTreeInitializerOperation(symbol, semanticModel) is { } initializer
+            && CapturedDelegateArmsResolve(initializer, semanticModel))
         {
             if (reported.Add(symbol))
             {
-                foreach (var body in ComputationLambdas.OfArgumentValue(operation, semanticModel))
-                {
-                    InspectPatchBody(context, classifier, body, semanticModel, reported);
-                }
+                WalkCapturedDelegateArms(context, classifier, initializer, semanticModel, reported);
             }
 
             return;
         }
 
         ReportIfNotSendable(context, classifier, operation, symbol, type, reported);
+    }
+
+    private static bool CapturedDelegateArmsResolve(IOperation value, SemanticModel? semanticModel)
+    {
+        switch (Unwrap(value))
+        {
+            case IConditionalOperation conditional:
+                return CapturedDelegateArmsResolve(conditional.WhenTrue, semanticModel)
+                    && conditional.WhenFalse is { } whenFalse
+                    && CapturedDelegateArmsResolve(whenFalse, semanticModel);
+            case ICoalesceOperation coalesce:
+                return CapturedDelegateArmsResolve(coalesce.Value, semanticModel)
+                    && CapturedDelegateArmsResolve(coalesce.WhenNull, semanticModel);
+            default:
+                return ComputationLambdas.OfArgumentValue(value, semanticModel).Any()
+                    || ResolveMethodReference(value, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 };
+        }
+    }
+
+    private static void WalkCapturedDelegateArms(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        switch (Unwrap(value))
+        {
+            case IConditionalOperation conditional:
+                WalkCapturedDelegateArms(context, classifier, conditional.WhenTrue, semanticModel, reported);
+                if (conditional.WhenFalse is { } whenFalse)
+                {
+                    WalkCapturedDelegateArms(context, classifier, whenFalse, semanticModel, reported);
+                }
+
+                return;
+            case ICoalesceOperation coalesce:
+                WalkCapturedDelegateArms(context, classifier, coalesce.Value, semanticModel, reported);
+                WalkCapturedDelegateArms(context, classifier, coalesce.WhenNull, semanticModel, reported);
+                return;
+        }
+
+        // A method-group candidate already CAPTURED its receiver: the stored patch shares
+        // it across flows even when the target body itself is safe.
+        if (ResolveMethodReference(value, semanticModel, visitedVariables: null) is { } methodReference)
+        {
+            InspectMethodGroupReceiver(context, classifier, methodReference, reported);
+        }
+
+        foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
+        {
+            InspectPatchBody(context, classifier, body, semanticModel, reported);
+        }
     }
 
     // A value type with directly writable instance state. Enums have no user state (their

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -1250,8 +1250,52 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         if (!found)
         {
+            found = ChaseInvokedPropertyBodies(context, classifier, unwrapped, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+        }
+
+        if (!found)
+        {
             ReportUnresolvedInvokedDelegate(context, resolved, variable, semanticModel, reported);
         }
+    }
+
+    // A delegate READ from a same-tree computed get-only property and invoked executes
+    // whatever the getter returns, exactly like an invoked factory result: each return is
+    // its own accounted candidate, with the property's (indexer) argument map.
+    private static bool ChaseInvokedPropertyBodies(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation reference,
+        SemanticModel? semanticModel,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
+    {
+        if (ComputationLambdas.ReferencedVariable(reference) is not IPropertySymbol property
+            || IsSettable(property) || HasBackingStorage(property)
+            || property.GetMethod is not { } getter
+            || ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } getterBody)
+        {
+            return false;
+        }
+
+        var propertyMap = ComputationLambdas.BuildArgumentMap(reference, argumentMap);
+        if (!visitedCalls.Add((reference.Syntax, getter, ComputationLambdas.ArgumentMapKey(propertyMap))))
+        {
+            return true;
+        }
+
+        var found = false;
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
+        {
+            if (inner is IReturnOperation { ReturnedValue: { } returned })
+            {
+                found |= ChaseReturnCandidate(context, classifier, returned, semanticModel, visitedCalls, visitedInvokes, propertyMap, reported);
+            }
+        }
+
+        return found;
     }
 
     // A delegate RETURNED by a same-tree helper and immediately invoked (`Get()()`) executes
@@ -1478,18 +1522,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // the real delegate expression is the enclosing conditional access's Operation.
     private static IOperation ResolveConditionalReceiver(IOperation callee)
     {
-        if (callee is IConditionalAccessInstanceOperation placeholder)
-        {
-            for (var current = placeholder.Parent; current is not null; current = current.Parent)
-            {
-                if (current is IConditionalAccessOperation conditional)
-                {
-                    return conditional.Operation;
-                }
-            }
-        }
-
-        return callee;
+        return ComputationLambdas.ResolveConditionalReceiver(callee);
     }
 
     // A delegate assembled by ASSIGNMENT (`Func<int> later; later = () => hits;`, including
@@ -1996,7 +2029,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             default:
                 return ComputationLambdas.OfArgumentValue(value, semanticModel).Any()
                     || ResolveMethodReference(value, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 }
-                    || CapturedFactoryReturnsResolve(value, semanticModel);
+                    || CapturedFactoryReturnsResolve(value, semanticModel)
+                    || CapturedPropertyReturnsResolve(value, semanticModel);
         }
     }
 
@@ -2008,6 +2042,18 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return Unwrap(value) is IInvocationOperation call
             && ComputationLambdas.ResolveMethodBody(call.TargetMethod, semanticModel) is { } factoryBody
             && ComputationLambdas.ReturnedBodies(factoryBody, semanticModel, ComputationLambdas.BuildArgumentMap(call, outer: null)).Any();
+    }
+
+    // A captured delegate READ from a same-tree computed get-only property (`var d = Safe;`
+    // with `Func<int> Safe => ...`) stores whatever the getter returned: the same
+    // returned-body resolution, sourced from the accessor.
+    private static bool CapturedPropertyReturnsResolve(IOperation value, SemanticModel? semanticModel)
+    {
+        return ComputationLambdas.ReferencedVariable(Unwrap(value)) is IPropertySymbol property
+            && !IsSettable(property) && !HasBackingStorage(property)
+            && property.GetMethod is { } getter
+            && ComputationLambdas.ResolveMethodBody(getter, semanticModel) is { } getterBody
+            && ComputationLambdas.ReturnedBodies(getterBody, semanticModel, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null)).Any();
     }
 
     private static void WalkCapturedDelegateArms(
@@ -2052,7 +2098,16 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         if (!resolvedAny && Unwrap(value) is IInvocationOperation factoryCall
             && ComputationLambdas.ResolveMethodBody(factoryCall.TargetMethod, semanticModel) is { } factoryBody)
         {
-            InspectReturnedPatchBodies(context, classifier, factoryBody, factoryCall.TargetMethod, ComputationLambdas.BuildArgumentMap(factoryCall, outer: null), semanticModel, reported);
+            resolvedAny = InspectReturnedPatchBodies(context, classifier, factoryBody, factoryCall.TargetMethod, ComputationLambdas.BuildArgumentMap(factoryCall, outer: null), semanticModel, reported);
+        }
+
+        // The computed-property candidate: the getter's returns, with the same accounting.
+        if (!resolvedAny && ComputationLambdas.ReferencedVariable(Unwrap(value)) is IPropertySymbol patchProperty
+            && !IsSettable(patchProperty) && !HasBackingStorage(patchProperty)
+            && patchProperty.GetMethod is { } propertyGetter
+            && ComputationLambdas.ResolveMethodBody(propertyGetter, semanticModel) is { } propertyBody)
+        {
+            InspectReturnedPatchBodies(context, classifier, propertyBody, patchProperty, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null), semanticModel, reported);
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -10,12 +10,14 @@ namespace MemoizR.Analyzers;
 // stored in the overlay and re-executed by the view's computation on whichever flow pulls the
 // optimistic state, so everything its closure captures crosses flows exactly like a node value.
 // A capture whose type is not Sendable (a List<int> local), or a read of writable state on a
-// non-Sendable enclosing object (a non-readonly field, a settable property), is therefore
-// unsynchronized cross-flow sharing -- and so are a method-group patch's receiver (including a
-// mutable struct boxed into the delegate), a bare `this` handed to a helper, and static state
-// the patch reads directly or through same-tree helpers (shared without any capture at all).
-// Reads of Sendable-typed captures stay unflagged -- capturing the action payload or other
-// immutable snapshots is the idiomatic pattern. This rule exists because the
+// non-Sendable enclosing object (a non-readonly field, a settable or ref-returning property),
+// is therefore unsynchronized cross-flow sharing -- and so are a method-group patch's receiver
+// (including a mutable struct boxed into the delegate), a bare `this` handed to a helper,
+// static state the patch reads directly or through same-tree helpers (shared without any
+// capture at all), closure state of outside-the-patch local functions it calls, and an
+// already-built delegate that resolves to nothing walkable. Reads of Sendable-typed captures
+// stay unflagged -- capturing the action payload or other immutable snapshots is the idiomatic
+// pattern. This rule exists because the
 // RUNTIME cannot check it: closure display classes always carry writable fields, so a
 // structural runtime check would reject every capturing lambda. Captured-state WRITES inside a
 // patch are MZR002's territory (Apply is a computation host), and a Set inside one is MZR003's.
@@ -53,35 +55,67 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // of its reads.
         var reported = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
 
-        // A method-group patch (`ctx.Apply(state, helper.Patch)`) captures its RECEIVER into
-        // the stored delegate -- shared across pull flows even when the method body lives in
-        // metadata or another file and cannot be walked.
         foreach (var argument in invocation.Arguments)
         {
-            InspectMethodGroupReceiver(context, classifier, argument.Value, invocation.SemanticModel, reported);
-        }
-
-        var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-        foreach (var patch in ComputationLambdas.OfInvocation(invocation))
-        {
-            foreach (var operation in ComputationLambdas.Descend(patch.Body))
-            {
-                InspectCapture(context, classifier, operation, patch.Scope, reported);
-                InspectStaticRead(context, classifier, operation, reported);
-                InspectCalledHelper(context, classifier, operation, invocation.SemanticModel, visitedHelpers, reported);
-            }
+            InspectPatchArgument(context, classifier, argument.Value, invocation.SemanticModel, reported);
         }
     }
 
-    private static void InspectMethodGroupReceiver(
+    // One patch argument, all shapes: a lambda (or a delegate variable resolving to one) walks
+    // its body; a method group (however stored) checks its receiver and walks its same-tree
+    // body; a delegate-typed argument resolving to NEITHER is an already-built closure Roslyn
+    // cannot see into -- flagged, because the overlay stores it all the same, this rule is the
+    // only check the patch will ever get, and a delegate can capture arbitrary mutable state
+    // (the classifier rejects delegate-typed values for the same reason).
+    private static void InspectPatchArgument(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
         IOperation value,
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        if (ResolveMethodReference(value, semanticModel, visitedVariables: null) is not { Instance: { } receiver } methodReference
-            || receiver.Type is not { } receiverType)
+        var methodReference = ResolveMethodReference(value, semanticModel, visitedVariables: null);
+        if (methodReference is not null)
+        {
+            InspectMethodGroupReceiver(context, classifier, methodReference, reported);
+        }
+
+        var resolved = methodReference is not null;
+        var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        foreach (var patch in ComputationLambdas.OfArgumentValue(value, semanticModel))
+        {
+            resolved = true;
+            foreach (var operation in ComputationLambdas.Descend(patch.Body))
+            {
+                InspectCapture(context, classifier, operation, patch.Scope, reported);
+                InspectStaticRead(context, classifier, operation, reported);
+                InspectCalledHelper(context, classifier, operation, patch.Scope, semanticModel, visitedHelpers, reported);
+            }
+        }
+
+        if (!resolved && value.Type is { TypeKind: TypeKind.Delegate })
+        {
+            var symbol = ReceiverSymbol(Unwrap(value));
+            Report(
+                context,
+                value,
+                symbol ?? value.Type,
+                symbol?.Name ?? SendableSymbolClassifier.Display(value.Type),
+                "it is an already-built delegate whose closure cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (define the patch inline or as a same-tree method)",
+                reported);
+        }
+    }
+
+    // A method-group patch (`ctx.Apply(state, helper.Patch)`) captures its RECEIVER into the
+    // stored delegate -- shared across pull flows even when the method body lives in metadata
+    // or another file and cannot be walked.
+    private static void InspectMethodGroupReceiver(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IMethodReferenceOperation methodReference,
+        HashSet<ISymbol> reported)
+    {
+        if (methodReference.Instance is not { } receiver || receiver.Type is not { } receiverType)
         {
             return;
         }
@@ -94,7 +128,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             // A Sendable verdict for a VALUE TYPE rests on copy semantics -- but a method-group
             // delegate stores ONE boxed receiver that every re-execution shares, and a
             // non-readonly struct method mutates that box in place. (A readonly method cannot,
-            // and the box is reachable only through the delegate.)
+            // and the box is reachable only through the delegate. Extension methods need no
+            // exemption: CS1113 forbids creating a delegate from a value-type extension
+            // receiver, so only real instance methods reach this branch.)
             if (receiverType.IsValueType && !methodReference.Method.IsReadOnly)
             {
                 Report(
@@ -154,6 +190,16 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                     return null;
             }
         }
+    }
+
+    private static IOperation Unwrap(IOperation value)
+    {
+        while (value is IConversionOperation conversion)
+        {
+            value = conversion.Operand;
+        }
+
+        return value;
     }
 
     private static ISymbol? ReceiverSymbol(IOperation receiver)
@@ -263,6 +309,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
         IOperation operation,
+        SyntaxNode patchScope,
         SemanticModel? semanticModel,
         HashSet<IMethodSymbol> visitedHelpers,
         HashSet<ISymbol> reported)
@@ -280,10 +327,24 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // A LOCAL FUNCTION has no receiver, so no receiver/`this` verdict covers its closure:
+        // one declared outside the patch shares the enclosing method's locals with the patch,
+        // and what its body reads from outside its own declaration is captured state, held to
+        // the ordinary capture verdicts. (One declared INSIDE the patch was already walked
+        // under the patch's own scope, and its reads of patch-locals are patch-internal, not
+        // shared -- re-inspecting it against its own scope would flag them falsely.)
+        var inspectCaptures = method.MethodKind == MethodKind.LocalFunction
+            && ComputationLambdas.IsDeclaredOutside(method, patchScope);
+
         foreach (var inner in ComputationLambdas.Descend(helper.Body))
         {
+            if (inspectCaptures)
+            {
+                InspectCapture(context, classifier, inner, helper.Scope, reported);
+            }
+
             InspectStaticRead(context, classifier, inner, reported);
-            InspectCalledHelper(context, classifier, inner, semanticModel, visitedHelpers, reported);
+            InspectCalledHelper(context, classifier, inner, patchScope, semanticModel, visitedHelpers, reported);
         }
     }
 
@@ -311,10 +372,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
     // An init accessor surfaces as SetMethod but cannot run after construction: `{ get; init; }`
     // is immutable state, held (like readonly fields) only to its TYPE's sendability -- the same
-    // verdict the runtime SendableChecker gives it.
+    // verdict the runtime SendableChecker gives it. A ref-RETURNING property is the reverse
+    // disguise: no setter, yet `ref int Counter => ref counter` hands out assignable live
+    // storage, so it counts as writable.
     private static bool IsSettable(IPropertySymbol property)
     {
-        return property.SetMethod is { IsInitOnly: false };
+        return property.SetMethod is { IsInitOnly: false } || property.RefKind == RefKind.Ref;
     }
 
     // True when the reference is the receiver of a member read InspectCapture handles itself:

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -110,17 +110,22 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         // A patch definitely ASSEMBLED by a same-tree out-helper (`Provide(out patch)` as
         // the sole dominating write) resolves to the helper's assignments -- each walked
-        // like an inline patch body; an unresolvable helper falls through to the
-        // unverifiable report below.
+        // like an inline patch body, with unresolvable branches reported by the helper
+        // accounting itself; an unwalkable helper falls through to the unverifiable report
+        // below.
         if (!bodyResolved && semanticModel is not null
             && ReceiverSymbol(Unwrap(value)) is { } assembled
             && ComputationLambdas.EffectiveInitializerWrite(assembled, semanticModel) is ArgumentSyntax outWrite)
         {
-            foreach (var patch in OutAssignedBodies(outWrite, semanticModel, argumentMap: null))
+            var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
+            var visitedInvokes = new HashSet<(SyntaxNode, string)>();
+            var (bodies, accounted) = OutAssignedBodies(context, classifier, outWrite, semanticModel, visitedCalls, visitedInvokes, argumentMap: null, reported);
+            foreach (var patch in bodies)
             {
-                bodyResolved = true;
                 InspectPatchBody(context, classifier, patch, semanticModel, reported);
             }
+
+            bodyResolved |= bodies.Count > 0 || accounted;
         }
 
         // A SOURCE-declared method group whose body lives in another file cannot be walked:
@@ -866,8 +871,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // A delegate RETURNED by a same-tree helper and immediately invoked (`Get()()`) executes
     // whatever the helper's return statements assemble, on every replay -- resolved through
     // the call's own argument map, so `Make(() => hits)()` reaches the call-site lambda.
-    // DescendDirectExecution keeps returns inside built callbacks out: those belong to the
-    // callback, not to the helper's own return path.
+    // Each return is a CANDIDATE accounted for separately: a safe branch must not silence
+    // one that resolves to nothing. The visited guard keys on the call site and binding, so
+    // recursive factories terminate; DescendDirectExecution keeps returns inside built
+    // callbacks out (those belong to the callback, not to the helper's own return path).
     private static bool ChaseReturnedDelegateBodies(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
@@ -883,24 +890,83 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        var found = false;
         var callMap = ComputationLambdas.BuildArgumentMap(call, argumentMap);
+        if (!visitedCalls.Add((call.Syntax, call.TargetMethod, ComputationLambdas.ArgumentMapKey(callMap))))
+        {
+            return true;
+        }
+
+        var found = false;
         foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
         {
-            if (inner is not IReturnOperation { ReturnedValue: { } returned })
+            if (inner is IReturnOperation { ReturnedValue: { } returned })
             {
-                continue;
-            }
-
-            var resolved = ResolveDelegateReference(returned, semanticModel, callMap);
-            foreach (var body in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
-            {
-                found = true;
-                ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
+                found |= ChaseReturnCandidate(context, classifier, returned, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
             }
         }
 
         return found;
+    }
+
+    private static bool ChaseReturnCandidate(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation returned,
+        SemanticModel? semanticModel,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? callMap,
+        HashSet<ISymbol> reported)
+    {
+        var resolved = ResolveDelegateReference(returned, semanticModel, callMap);
+        var resolvedAny = false;
+        foreach (var body in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
+        {
+            resolvedAny = true;
+            ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
+        }
+
+        if (!resolvedAny)
+        {
+            resolvedAny = AccountsForValue(context, classifier, resolved, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
+        }
+
+        if (!resolvedAny)
+        {
+            var unwrapped = Unwrap(resolved);
+            ReportUnresolvedInvokedDelegate(
+                context,
+                resolved,
+                ComputationLambdas.ReferencedVariable(unwrapped) ?? (unwrapped as IParameterReferenceOperation)?.Parameter,
+                semanticModel,
+                reported);
+        }
+
+        // Chased, trusted, or reported -- either way this return is accounted for (a silent
+        // dead end like `return null` stays silent by design: nothing runs from it).
+        return true;
+    }
+
+    // A resolved candidate VALUE that yields no walkable body can still be accounted for: a
+    // METADATA method-group target is a trusted external contract, and a same-tree
+    // delegate-returning call resolves through its return statements.
+    private static bool AccountsForValue(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation resolvedValue,
+        SemanticModel? semanticModel,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
+    {
+        if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 })
+        {
+            return true;
+        }
+
+        return Unwrap(resolvedValue) is IInvocationOperation callResult
+            && ChaseReturnedDelegateBodies(context, classifier, callResult, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
     }
 
     // The invoked reference, collapsed through parameter-to-argument hops (the map) and
@@ -1050,18 +1116,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var resolvedAny = false;
-            foreach (var body in NodeAssignedBodies(node, variable, semanticModel, argumentMap))
-            {
-                resolvedAny = true;
-                ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
-            }
-
-            if (!resolvedAny)
-            {
-                resolvedAny = ResolvesOutsideBodies(context, classifier, node, variable, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
-            }
-
+            var resolvedAny = ChaseWriteCandidate(context, classifier, node, variable, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             if (!resolvedAny && semanticModel.GetOperation(node) is { } writeOperation)
             {
                 Report(
@@ -1079,10 +1134,44 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return found;
     }
 
+    private static bool ChaseWriteCandidate(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        SyntaxNode node,
+        ISymbol variable,
+        SemanticModel semanticModel,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
+    {
+        // `Provide(out later)` assembles the delegate inside the callee: the helper does its
+        // own per-branch accounting (and reporting), so a handled helper never falls through
+        // to the caller-side report.
+        if (node is ArgumentSyntax outArgument)
+        {
+            var (bodies, accounted) = OutAssignedBodies(context, classifier, outArgument, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            foreach (var body in bodies)
+            {
+                ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            }
+
+            return bodies.Count > 0 || accounted;
+        }
+
+        var resolvedAny = false;
+        foreach (var body in NodeAssignedBodies(node, variable, semanticModel, argumentMap))
+        {
+            resolvedAny = true;
+            ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+        }
+
+        return resolvedAny || ResolvesOutsideBodies(context, classifier, node, variable, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+    }
+
     // A candidate write whose right-hand side yields no walkable body can still be
-    // accounted for: a METADATA method-group target is a trusted external contract, and a
-    // same-tree delegate-returning call resolves through its return statements. Anything
-    // else stays unaccounted and gets flagged by the caller.
+    // accounted for via AccountsForValue; anything else stays unaccounted and gets flagged
+    // by the caller.
     private static bool ResolvesOutsideBodies(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
@@ -1101,14 +1190,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
         {
-            var resolvedValue = ResolveDelegateReference(value, semanticModel, argumentMap);
-            if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 })
-            {
-                return true;
-            }
-
-            if (Unwrap(resolvedValue) is IInvocationOperation callResult
-                && ChaseReturnedDelegateBodies(context, classifier, callResult, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported))
+            if (AccountsForValue(context, classifier, ResolveDelegateReference(value, semanticModel, argumentMap), semanticModel, visitedCalls, visitedInvokes, argumentMap, reported))
             {
                 return true;
             }
@@ -1199,43 +1281,45 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel semanticModel,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        switch (node)
+        if (node is not AssignmentExpressionSyntax assignment)
         {
-            case AssignmentExpressionSyntax assignment:
-                foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
-                {
-                    foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(value, semanticModel, argumentMap), semanticModel))
-                    {
-                        yield return body;
-                    }
-                }
+            yield break;
+        }
 
-                break;
-
-            // `Provide(out later)` assembles the delegate inside the callee: the bodies come
-            // from the helper's assignments to its out/ref parameter.
-            case ArgumentSyntax argument:
-                foreach (var body in OutAssignedBodies(argument, semanticModel, argumentMap))
-                {
-                    yield return body;
-                }
-
-                break;
+        foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+        {
+            foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(value, semanticModel, argumentMap), semanticModel))
+            {
+                yield return body;
+            }
         }
     }
 
-    private static IEnumerable<ComputationLambdas.ComputationBody> OutAssignedBodies(
+    // The delegate bodies an out-helper hands back, with each surviving assignment BRANCH
+    // accounted for separately: a value resolving to nothing walkable (and not trusted
+    // metadata or a chased delegate-returning call) is reported on the spot, keyed on the
+    // out parameter -- a safe branch beside it must not silence it. Accounted=false only
+    // when the helper itself is unwalkable or never assigns, where the CALLER owns the
+    // report.
+    private static (List<ComputationLambdas.ComputationBody> Bodies, bool Accounted) OutAssignedBodies(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
         ArgumentSyntax argument,
         SemanticModel semanticModel,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
     {
+        var bodies = new List<ComputationLambdas.ComputationBody>();
+
         // The SEMANTIC parameter, not the syntactic position: named arguments reorder freely
         // (`Provide(second: out later, first: 0)`).
         if ((semanticModel.GetOperation(argument) as IArgumentOperation) is not { Parameter: { } parameter } argumentOperation
             || parameter.ContainingSymbol is not IMethodSymbol method
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
-            yield break;
+            return (bodies, false);
         }
 
         // The helper's OTHER parameters resolve through this call's own arguments:
@@ -1245,6 +1329,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             ? ComputationLambdas.BuildArgumentMap(call, argumentMap)
             : argumentMap;
 
+        var assigned = false;
         var writes = ParameterWrites(helper.Scope, parameter, semanticModel);
         foreach (var assignment in writes)
         {
@@ -1256,14 +1341,28 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
+            assigned = true;
             foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
             {
-                foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(value, semanticModel, callMap), semanticModel))
+                var resolvedValue = ResolveDelegateReference(value, semanticModel, callMap);
+                var count = bodies.Count;
+                bodies.AddRange(ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel));
+                if (bodies.Count == count
+                    && !AccountsForValue(context, classifier, resolvedValue, semanticModel, visitedCalls, visitedInvokes, callMap, reported)
+                    && semanticModel.GetOperation(assignment) is { } writeOperation)
                 {
-                    yield return body;
+                    Report(
+                        context,
+                        writeOperation,
+                        parameter,
+                        parameter.Name,
+                        "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                        reported);
                 }
             }
         }
+
+        return (bodies, assigned);
     }
 
     // ReassignmentTargets flattens deconstruction left sides, so `(d, _) = (...)` assembles

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -110,6 +110,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // A delegate variable initialized from a conditional stores whichever arm ran: the
+        // arms are accounted for separately, exactly like a conditional argument.
+        if (InspectConditionalInitializer(context, classifier, value, semanticModel, reported))
+        {
+            return;
+        }
+
         var methodReference = ResolveMethodReference(value, semanticModel, visitedVariables: null);
         if (methodReference is not null)
         {
@@ -141,7 +148,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             && patchProperty.GetMethod is { } patchGetter
             && ComputationLambdas.ResolveMethodBody(patchGetter, semanticModel) is { } getterBody)
         {
-            bodyResolved = InspectPropertyPatchReturns(context, classifier, getterBody, patchProperty, semanticModel, reported);
+            bodyResolved = InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, argumentMap: null, semanticModel, reported);
         }
 
         // A SOURCE-declared method group whose body lives in another file cannot be walked:
@@ -221,32 +228,78 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel semanticModel,
         HashSet<ISymbol> reported)
     {
+        // A surviving OUT handoff routes through the out-helper resolver, walking its
+        // assembled bodies as patches.
+        if (node is ArgumentSyntax outWrite)
+        {
+            return InspectOutWrite(context, classifier, outWrite, semanticModel, reported);
+        }
+
         if (node is not AssignmentExpressionSyntax assignment)
         {
             return false;
         }
 
+        var paired = false;
         var handled = true;
-        foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+        foreach (var value in ComputationLambdas.AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
         {
-            var resolvedValue = ResolveDelegateReference(value, semanticModel, argumentMap: null);
-            var methodReference = ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null);
-            if (methodReference is not null)
-            {
-                InspectMethodGroupReceiver(context, classifier, methodReference, reported);
-            }
-
-            var resolvedAny = false;
-            foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
-            {
-                resolvedAny = true;
-                InspectPatchBody(context, classifier, patch, semanticModel, reported);
-            }
-
-            handled &= resolvedAny || methodReference is { Method.DeclaringSyntaxReferences.Length: 0 };
+            paired = true;
+            handled &= InspectSurvivingValue(context, classifier, value, semanticModel, reported);
         }
 
-        return handled;
+        // An unpairable value (`(patch, _) = External.Pair();`) determines nothing walkable.
+        return paired && handled;
+    }
+
+    private static bool InspectSurvivingValue(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        SemanticModel semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        var resolvedValue = ResolveDelegateReference(value, semanticModel, argumentMap: null);
+        var methodReference = ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null);
+        if (methodReference is not null)
+        {
+            InspectMethodGroupReceiver(context, classifier, methodReference, reported);
+        }
+
+        var resolvedAny = false;
+        foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
+        {
+            resolvedAny = true;
+            InspectPatchBody(context, classifier, patch, semanticModel, reported);
+        }
+
+        // A same-tree delegate FACTORY result resolves through its returns, walked as patch
+        // bodies; metadata method groups stay trusted external contracts.
+        if (!resolvedAny && Unwrap(resolvedValue) is IInvocationOperation factoryCall
+            && ComputationLambdas.ResolveMethodBody(factoryCall.TargetMethod, semanticModel) is { } factoryBody)
+        {
+            resolvedAny = InspectReturnedPatchBodies(context, classifier, factoryBody, factoryCall.TargetMethod, ComputationLambdas.BuildArgumentMap(factoryCall, outer: null), semanticModel, reported);
+        }
+
+        return resolvedAny || methodReference is { Method.DeclaringSyntaxReferences.Length: 0 };
+    }
+
+    private static bool InspectOutWrite(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        ArgumentSyntax outWrite,
+        SemanticModel semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
+        var visitedInvokes = new HashSet<(SyntaxNode, string)>();
+        var (bodies, accounted) = OutAssignedBodies(context, classifier, outWrite, semanticModel, visitedCalls, visitedInvokes, argumentMap: null, reported);
+        foreach (var patch in bodies)
+        {
+            InspectPatchBody(context, classifier, patch, semanticModel, reported);
+        }
+
+        return bodies.Count > 0 || accounted;
     }
 
     private static bool InspectOutAssembledPatch(
@@ -263,31 +316,24 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
-        var visitedInvokes = new HashSet<(SyntaxNode, string)>();
-        var (bodies, accounted) = OutAssignedBodies(context, classifier, outWrite, semanticModel, visitedCalls, visitedInvokes, argumentMap: null, reported);
-        foreach (var patch in bodies)
-        {
-            InspectPatchBody(context, classifier, patch, semanticModel, reported);
-        }
-
-        return bodies.Count > 0 || accounted;
+        return InspectOutWrite(context, classifier, outWrite, semanticModel, reported);
     }
 
     // Each getter return is a CANDIDATE: walked as a patch body when it resolves, trusted
     // when it is a metadata target, reported otherwise -- a safe return must not silence an
     // unresolvable one. (The getter runs at the Apply call, once; only the RETURNED
     // delegate replays, so the getter's own statements need no per-replay walk here.)
-    private static bool InspectPropertyPatchReturns(
+    private static bool InspectReturnedPatchBodies(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
-        ComputationLambdas.ComputationBody getterBody,
-        IPropertySymbol property,
+        ComputationLambdas.ComputationBody methodBody,
+        ISymbol subject,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
         var accounted = false;
-        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(methodBody.Body))
         {
             if (inner is not IReturnOperation { ReturnedValue: { } returned })
             {
@@ -295,7 +341,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             }
 
             accounted = true;
-            var resolvedValue = ResolveDelegateReference(returned, semanticModel, argumentMap: null);
+            var resolvedValue = ResolveDelegateReference(returned, semanticModel, argumentMap);
 
             // A returned method group stores its RECEIVER in the delegate the overlay keeps,
             // exactly like a method-group patch argument.
@@ -317,14 +363,26 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 Report(
                     context,
                     returned,
-                    property,
-                    property.Name,
+                    subject,
+                    subject.Name,
                     "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)",
                     reported);
             }
         }
 
         return accounted;
+    }
+
+    private static bool InspectConditionalInitializer(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        return ReceiverSymbol(Unwrap(value)) is { } source
+            && ComputationLambdas.SameTreeInitializerOperation(source, semanticModel) is { } initializer
+            && InspectConditionalArms(context, classifier, initializer, semanticModel, reported);
     }
 
     private static bool InspectConditionalArms(
@@ -1440,7 +1498,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+        foreach (var value in ComputationLambdas.AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
         {
             if (AccountsForValue(context, classifier, ResolveDelegateReference(value, semanticModel, argumentMap), semanticModel, visitedCalls, visitedInvokes, argumentMap, reported))
             {
@@ -1498,16 +1556,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    // "Straight-line" = the killer sits in plain block statements between itself and wherever
-    // the value is observed (an invoke site, or an out-helper's own scope end); a killer
-    // inside an if/loop may not run, so it kills nothing -- and an exit statement between the
-    // two writes can leave the earlier value observable, so nothing is definite past one.
+    // "Straight-line" = the killer sits in plain statements between itself and wherever the
+    // value is observed (an invoke site, or an out-helper's own scope end); a killer inside
+    // an if/loop may not run, so it kills nothing -- and an exit statement between the two
+    // writes can leave the earlier value observable, so nothing is definite past one. The
+    // argument-list hop covers out-handoff killers; a conditional-access call stays rejected.
     private static bool DefinitelyOverwrites(SyntaxNode killer, SyntaxNode victim, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel)
     {
-        if (killer is not AssignmentExpressionSyntax assignment
-            || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
-            || assignment.Left is TupleExpressionSyntax
-            || !ComputationLambdas.WritesVariable(assignment.Left, variable, semanticModel)
+        if (!IsDeterminingWrite(killer, variable, semanticModel)
             || killer.SpanStart <= victim.SpanStart
             || killer.SpanStart >= reference.Span.End
             || ExitsBetween(victim, killer))
@@ -1517,13 +1573,28 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         for (var current = killer.Parent; current is not null && !current.Span.Contains(reference.Span); current = current.Parent)
         {
-            if (current is not (BlockSyntax or ExpressionStatementSyntax))
+            if (current is not (BlockSyntax or ExpressionStatementSyntax or ArgumentListSyntax or InvocationExpressionSyntax))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    // A killer must fully DETERMINE the new value: a simple non-tuple assignment, or an
+    // `out` handoff (the language requires the callee to assign before returning).
+    private static bool IsDeterminingWrite(SyntaxNode killer, ISymbol variable, SemanticModel semanticModel)
+    {
+        return killer switch
+        {
+            AssignmentExpressionSyntax assignment => assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                && assignment.Left is not TupleExpressionSyntax
+                && ComputationLambdas.WritesVariable(assignment.Left, variable, semanticModel),
+            ArgumentSyntax argument => argument.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
+                && ComputationLambdas.WritesVariable(argument.Expression, variable, semanticModel),
+            _ => false,
+        };
     }
 
     // A return/throw/goto/break/continue/yield starting between the two writes diverts
@@ -1564,7 +1635,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+        foreach (var value in ComputationLambdas.AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
         {
             foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(value, semanticModel, argumentMap), semanticModel))
             {
@@ -1607,6 +1678,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             ? ComputationLambdas.BuildArgumentMap(call, argumentMap)
             : argumentMap;
 
+        // Forwarding chains re-reach argument sites; the guard keys per site and binding so
+        // cycles terminate while different bindings still re-walk.
+        if (!visitedCalls.Add((argument, method, ComputationLambdas.ArgumentMapKey(callMap))))
+        {
+            return (bodies, true);
+        }
+
         var assigned = false;
         var writes = ParameterWrites(helper.Scope, parameter, semanticModel);
         foreach (var assignment in writes)
@@ -1620,13 +1698,82 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             }
 
             assigned = true;
-            foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
+            ChaseOutAssignment(context, classifier, assignment, parameter, semanticModel, bodies, visitedCalls, visitedInvokes, callMap, reported);
+        }
+
+        // A FORWARDED handoff (`Provide(out d) { Build(out d); }`) assembles the delegate
+        // one helper deeper: chased recursively, with an unaccounted chain reported here.
+        foreach (var node in helper.Scope.DescendantNodes())
+        {
+            if (node is ArgumentSyntax forwarded
+                && forwarded.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
+                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(forwarded.Expression).Symbol, parameter))
             {
-                ChaseOutAssignedValue(context, classifier, value, assignment, parameter, semanticModel, bodies, visitedCalls, visitedInvokes, callMap, reported);
+                assigned = true;
+                ChaseForwardedHandoff(context, classifier, forwarded, parameter, semanticModel, bodies, visitedCalls, visitedInvokes, callMap, reported);
             }
         }
 
         return (bodies, assigned);
+    }
+
+    private static void ChaseOutAssignment(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        AssignmentExpressionSyntax assignment,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        List<ComputationLambdas.ComputationBody> bodies,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? callMap,
+        HashSet<ISymbol> reported)
+    {
+        var paired = false;
+        foreach (var value in ComputationLambdas.AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
+        {
+            paired = true;
+            ChaseOutAssignedValue(context, classifier, value, assignment, parameter, semanticModel, bodies, visitedCalls, visitedInvokes, callMap, reported);
+        }
+
+        // A write whose value cannot be PAIRED (`(d, _) = External.Pair();`) binds the
+        // parameter to something nothing can walk: unverifiable means flagged.
+        if (!paired && semanticModel.GetOperation(assignment) is { } writeOperation)
+        {
+            Report(
+                context,
+                writeOperation,
+                parameter,
+                parameter.Name,
+                "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                reported);
+        }
+    }
+
+    private static void ChaseForwardedHandoff(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        ArgumentSyntax forwarded,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        List<ComputationLambdas.ComputationBody> bodies,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? callMap,
+        HashSet<ISymbol> reported)
+    {
+        var (nested, nestedAccounted) = OutAssignedBodies(context, classifier, forwarded, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
+        bodies.AddRange(nested);
+        if (nested.Count == 0 && !nestedAccounted && semanticModel.GetOperation(forwarded) is { } forwardOperation)
+        {
+            Report(
+                context,
+                forwardOperation,
+                parameter,
+                parameter.Name,
+                "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                reported);
+        }
     }
 
     private static void ChaseOutAssignedValue(
@@ -1684,31 +1831,6 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         return writes;
-    }
-
-    private static IEnumerable<IOperation> AssignedValuesFor(ExpressionSyntax left, ExpressionSyntax right, ISymbol variable, SemanticModel semanticModel)
-    {
-        if (left is TupleExpressionSyntax leftTuple && right is TupleExpressionSyntax rightTuple
-            && leftTuple.Arguments.Count == rightTuple.Arguments.Count)
-        {
-            for (var i = 0; i < leftTuple.Arguments.Count; i++)
-            {
-                foreach (var value in AssignedValuesFor(leftTuple.Arguments[i].Expression, rightTuple.Arguments[i].Expression, variable, semanticModel))
-                {
-                    yield return value;
-                }
-            }
-
-            yield break;
-        }
-
-        // WritesVariable, not plain symbol equality: an assignment through a ref alias
-        // (`ref var alias = ref later; alias = () => hits;`) rebinds the delegate too.
-        if (ComputationLambdas.WritesVariable(left, variable, semanticModel)
-            && semanticModel.GetOperation(right) is { } operation)
-        {
-            yield return operation;
-        }
     }
 
     private static void ChaseExecutedBody(

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -449,9 +449,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         if (ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } body)
         {
-            // A source getter declared in another file (a partial type's other half) cannot
-            // be walked: held to the property TYPE's verdict, like unwalkable statics.
-            ReportIfNotSendable(context, classifier, operation, property, property.Type, reported);
+            // A source getter declared in another file (a partial type's other half) re-runs
+            // unverifiable code on every replay, and a Sendable return type proves nothing
+            // about what its body re-reads: flagged like a cross-file executed helper.
+            ReportUnwalkableGetter(context, operation, property, reported);
             return;
         }
 
@@ -573,12 +574,18 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // Only BACKING STORAGE holds a shared object: a computed getter may hand out a fresh
         // value on every replay (`static List<int> Items => new();`), and what it actually
         // returns is covered by the executed chase walking its body. Auto-properties and
-        // metadata properties (no walkable body) keep the type verdict -- and so does a
-        // SOURCE getter declared in another file, which that chase cannot walk either:
-        // trusting it silently would leave the property entirely unchecked.
-        if (HasBackingStorage(property) || !CanWalkGetter(property, operation.SemanticModel))
+        // metadata properties (no walkable body) keep the type verdict; a SOURCE getter
+        // declared in another file, which that chase cannot walk either, is unverifiable
+        // code re-run on every replay -- its return type proves nothing about what it reads.
+        if (HasBackingStorage(property))
         {
             ReportIfNotSendable(context, classifier, operation, property, property.Type, reported);
+            return;
+        }
+
+        if (!CanWalkGetter(property, operation.SemanticModel))
+        {
+            ReportUnwalkableGetter(context, operation, property, reported);
         }
     }
 
@@ -586,6 +593,21 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         return property.GetMethod is { } getter
             && ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not null;
+    }
+
+    private static void ReportUnwalkableGetter(
+        OperationAnalysisContext context,
+        IOperation operation,
+        IPropertySymbol property,
+        HashSet<ISymbol> reported)
+    {
+        Report(
+            context,
+            operation,
+            property,
+            property.Name,
+            "its getter is declared in another file, so what the stored patch re-reads cannot be verified from this call site (declare it in this file, or lift its state into MemoizR nodes)",
+            reported);
     }
 
     private static bool HasBackingStorage(IPropertySymbol property)
@@ -720,29 +742,41 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // A helper the patch CALLS whose source body lives in another file is as unverifiable
-    // as a cross-file method-group patch: nothing checks the statics it reads on every
-    // replay, so unverifiable means flagged -- while metadata callees (Math.Abs, List.Add)
-    // stay trusted external contracts. Scoped to CALLS: accessors and constructors keep
-    // their member/type verdicts from the capture walk.
+    // Code the patch EXECUTES whose source body lives in another file -- a called helper, a
+    // constructor, a user-defined operator or conversion -- is as unverifiable as a
+    // cross-file method-group patch: nothing checks the statics it reads on every replay,
+    // so unverifiable means flagged, while metadata callees (Math.Abs, List.Add) stay
+    // trusted external contracts. Accessors keep their own member/type/getter verdicts from
+    // the capture walk.
     private static void ReportUnwalkableExecutedHelper(
         OperationAnalysisContext context,
         IOperation operation,
         IMethodSymbol method,
         HashSet<ISymbol> reported)
     {
-        if (operation is not IInvocationOperation || method.DeclaringSyntaxReferences.Length == 0)
+        if (!IsUnverifiableExecutedShape(operation) || method.DeclaringSyntaxReferences.Length == 0)
         {
             return;
         }
 
+        var name = method.MethodKind == MethodKind.Constructor
+            ? SendableSymbolClassifier.Display(method.ContainingType)
+            : method.Name;
         Report(
             context,
             operation,
             method,
-            method.Name,
-            "its body is declared in another file, so what the patch executes cannot be verified from this call site (declare the helper in this file, or lift its state into MemoizR nodes)",
+            name,
+            "its body is declared in another file, so what the patch executes cannot be verified from this call site (declare it in this file, or lift its state into MemoizR nodes)",
             reported);
+    }
+
+    private static bool IsUnverifiableExecutedShape(IOperation operation)
+    {
+        return operation is IInvocationOperation or IObjectCreationOperation
+            or IBinaryOperation { OperatorMethod: not null }
+            or IUnaryOperation { OperatorMethod: not null }
+            or IConversionOperation { OperatorMethod: not null };
     }
 
     // A delegate the patch builds AND synchronously invokes runs its body on every replay:

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -321,20 +321,25 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return InspectSurvivingWrite(context, classifier, stepwiseWrite, stepwise, semanticModel, reported);
         }
 
+        // An ALIAS resolves to its assembled source first: `Func<int,int> p = Patch;`
+        // stores whatever the computed property's getter (or the stored factory call)
+        // returned, so the alias must not hide the source the branches below resolve.
+        var resolved = ResolveDelegateReference(value, semanticModel, argumentMap: null);
+
         // A same-tree computed get-only delegate PROPERTY resolves through its getter's
         // returns, like a delegate-returning helper: each return is walked as a patch body,
         // with unresolvable returns reported.
-        if (ReceiverSymbol(Unwrap(value)) is IPropertySymbol patchProperty
+        if (ReceiverSymbol(Unwrap(resolved)) is IPropertySymbol patchProperty
             && !IsSettable(patchProperty) && !HasBackingStorage(patchProperty)
             && patchProperty.GetMethod is { } patchGetter
             && ComputationLambdas.ResolveMethodBody(patchGetter, semanticModel) is { } getterBody)
         {
-            return InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null), semanticModel, reported);
+            return InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, ComputationLambdas.BuildArgumentMap(Unwrap(resolved), outer: null), semanticModel, reported);
         }
 
         // A patch produced by a same-tree delegate FACTORY -- called inline, or stored
         // through a variable initializer -- resolves through the factory's returns.
-        if (FactoryCallOf(value, semanticModel) is { } factoryCall
+        if (FactoryCallOf(resolved, semanticModel) is { } factoryCall
             && ComputationLambdas.ResolveMethodBody(factoryCall.TargetMethod, semanticModel) is { } factoryBody)
         {
             return InspectReturnedPatchBodies(context, classifier, factoryBody, factoryCall.TargetMethod, ComputationLambdas.BuildArgumentMap(factoryCall, outer: null), semanticModel, reported);
@@ -371,7 +376,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         ISymbol subject,
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         SemanticModel? semanticModel,
-        HashSet<ISymbol> reported)
+        HashSet<ISymbol> reported,
+        HashSet<(IMethodSymbol, string)>? visitedFactories = null)
     {
         var accounted = false;
         foreach (var inner in ComputationLambdas.DescendDirectExecution(methodBody.Body))
@@ -382,36 +388,63 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             }
 
             accounted = true;
-            var resolvedValue = ResolveDelegateReference(returned, semanticModel, argumentMap);
-
-            // A returned method group stores its RECEIVER in the delegate the overlay keeps,
-            // exactly like a method-group patch argument.
-            if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { } returnedReference)
-            {
-                InspectMethodGroupReceiver(context, classifier, returnedReference, reported);
-            }
-
-            var resolvedAny = false;
-            foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
-            {
-                resolvedAny = true;
-                InspectPatchBody(context, classifier, patch, semanticModel, reported);
-            }
-
-            if (!resolvedAny
-                && ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is not { Method.DeclaringSyntaxReferences.Length: 0 })
-            {
-                Report(
-                    context,
-                    returned,
-                    subject,
-                    subject.Name,
-                    "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)",
-                    reported);
-            }
+            visitedFactories ??= new HashSet<(IMethodSymbol, string)>();
+            InspectReturnedPatchValue(context, classifier, returned, subject, argumentMap, semanticModel, reported, visitedFactories);
         }
 
         return accounted;
+    }
+
+    private static void InspectReturnedPatchValue(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation returned,
+        ISymbol subject,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported,
+        HashSet<(IMethodSymbol, string)> visitedFactories)
+    {
+        var resolvedValue = ResolveDelegateReference(returned, semanticModel, argumentMap);
+
+        // A returned method group stores its RECEIVER in the delegate the overlay keeps,
+        // exactly like a method-group patch argument.
+        if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { } returnedReference)
+        {
+            InspectMethodGroupReceiver(context, classifier, returnedReference, reported);
+        }
+
+        var resolvedAny = false;
+        foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
+        {
+            resolvedAny = true;
+            InspectPatchBody(context, classifier, patch, semanticModel, reported);
+        }
+
+        // `return Make();` assembles one factory deeper: the nested call's returns get this
+        // same per-return accounting, the visited set bounding recursive factories (a cycle
+        // resolving to nothing still falls through to the report below).
+        if (!resolvedAny && Unwrap(resolvedValue) is IInvocationOperation nestedCall
+            && ComputationLambdas.ResolveMethodBody(nestedCall.TargetMethod, semanticModel) is { } nestedBody)
+        {
+            var nestedMap = ComputationLambdas.BuildArgumentMap(nestedCall, argumentMap);
+            if (visitedFactories.Add((nestedCall.TargetMethod, ComputationLambdas.ArgumentMapKey(nestedMap))))
+            {
+                resolvedAny = InspectReturnedPatchBodies(context, classifier, nestedBody, nestedCall.TargetMethod, nestedMap, semanticModel, reported, visitedFactories);
+            }
+        }
+
+        if (!resolvedAny
+            && ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is not { Method.DeclaringSyntaxReferences.Length: 0 })
+        {
+            Report(
+                context,
+                returned,
+                subject,
+                subject.Name,
+                "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)",
+                reported);
+        }
     }
 
     // The invocation producing this patch value: the argument itself, or the variable's
@@ -952,10 +985,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
     // Two walks with different reach. Closure CONTENTS (captures, receivers, `this`) are
     // storage facts -- a callback the patch merely builds still pins them in the stored
-    // display chain -- so they use the FULL walk, chasing outside local functions wherever
-    // they are referenced. Static READS happen only on execution: one inside a built callback
-    // runs later, off the overlay's re-execution, on whatever flow invokes it -- so statics
-    // (and the helper chase that finds them) follow MZR003's direct-execution pruning.
+    // display chain, and so does a NESTED computation host's delegate (the patch builds it
+    // on every replay from the same display chain) -- so they use the unpruned stored-closure
+    // walk, chasing outside local functions wherever they are referenced. Static READS
+    // happen only on execution: one inside a built callback runs later, off the overlay's
+    // re-execution, on whatever flow invokes it -- so statics (and the helper chase that
+    // finds them) follow MZR003's direct-execution pruning.
     private static void InspectPatchBody(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
@@ -964,7 +999,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<ISymbol> reported)
     {
         var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-        foreach (var operation in ComputationLambdas.Descend(patch.Body))
+        foreach (var operation in ComputationLambdas.DescendStoredClosure(patch.Body))
         {
             InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, semanticModel, reported);
             InspectCapturedLocalFunction(context, classifier, operation, patch.Scope, semanticModel, visitedLocalFunctions, reported);
@@ -1007,7 +1042,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        foreach (var inner in ComputationLambdas.Descend(helper.Body))
+        foreach (var inner in ComputationLambdas.DescendStoredClosure(helper.Body))
         {
             InspectCapture(context, classifier, inner, helper.Scope, patchScope, semanticModel, reported);
             InspectCapturedLocalFunction(context, classifier, inner, patchScope, semanticModel, visited, reported);
@@ -1687,14 +1722,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return (bodies, true);
         }
 
+        // What the caller receives is the delegate bound when the helper RETURNS: a later
+        // straight-line overwrite inside the helper -- a direct assignment or a forwarded
+        // handoff, in either role -- kills the earlier write exactly like one before an
+        // invoke, with the helper's scope end as the observation point.
         var assigned = false;
         var writes = ParameterWrites(helper.Scope, parameter, semanticModel);
+        var handoffs = ForwardedHandoffs(helper.Scope, parameter, semanticModel);
+        var candidates = writes.Concat<SyntaxNode>(handoffs).ToList();
         foreach (var assignment in writes)
         {
-            // What the caller receives is the delegate bound when the helper RETURNS: a later
-            // straight-line overwrite inside the helper kills this body exactly like one
-            // before an invoke, with the helper's scope end as the observation point.
-            if (writes.Any(other => other != assignment && ComputationLambdas.DefinitelyOverwrites(other, assignment, helper.Scope, parameter, semanticModel)))
+            if (IsOverwrittenWithin(assignment, candidates, helper.Scope, parameter, semanticModel))
             {
                 continue;
             }
@@ -1705,18 +1743,39 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         // A FORWARDED handoff (`Provide(out d) { Build(out d); }`) assembles the delegate
         // one helper deeper: chased recursively, with an unaccounted chain reported here.
-        foreach (var node in helper.Scope.DescendantNodes())
+        foreach (var forwarded in handoffs)
+        {
+            if (IsOverwrittenWithin(forwarded, candidates, helper.Scope, parameter, semanticModel))
+            {
+                continue;
+            }
+
+            assigned = true;
+            ChaseForwardedHandoff(context, classifier, forwarded, parameter, semanticModel, bodies, visitedCalls, visitedInvokes, callMap, reported);
+        }
+
+        return (bodies, assigned);
+    }
+
+    private static bool IsOverwrittenWithin(SyntaxNode write, List<SyntaxNode> candidates, SyntaxNode scope, ISymbol variable, SemanticModel semanticModel)
+    {
+        return candidates.Any(other => other != write && ComputationLambdas.DefinitelyOverwrites(other, write, scope, variable, semanticModel));
+    }
+
+    private static List<ArgumentSyntax> ForwardedHandoffs(SyntaxNode scope, IParameterSymbol parameter, SemanticModel semanticModel)
+    {
+        var handoffs = new List<ArgumentSyntax>();
+        foreach (var node in scope.DescendantNodes())
         {
             if (node is ArgumentSyntax forwarded
                 && forwarded.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
                 && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(forwarded.Expression).Symbol, parameter))
             {
-                assigned = true;
-                ChaseForwardedHandoff(context, classifier, forwarded, parameter, semanticModel, bodies, visitedCalls, visitedInvokes, callMap, reported);
+                handoffs.Add(forwarded);
             }
         }
 
-        return (bodies, assigned);
+        return handoffs;
     }
 
     private static void ChaseOutAssignment(

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -101,13 +101,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         if (value.Type is { TypeKind: TypeKind.Delegate }
             && FindReassignedLink(value, semanticModel) is { } reassigned)
         {
-            if (!InspectSurvivingWrites(context, classifier, value, reassigned, semanticModel, reported))
+            if (!InspectSurvivingWrites(context, classifier, reassigned.ReadSite, reassigned.Variable, semanticModel, reported))
             {
                 Report(
                     context,
                     value,
-                    reassigned,
-                    reassigned.Name,
+                    reassigned.Variable,
+                    reassigned.Variable.Name,
                     "it is reassigned after its initializer, so the delegate stored in the overlay cannot be resolved from this call site, and a delegate can capture arbitrary mutable state",
                     reported);
             }
@@ -171,22 +171,21 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // The reassigned-argument carve-out: when the read variable's OWN declaration
-    // initializer is definitely overwritten before this call, the surviving writes are the
-    // only closures the overlay can store -- each is walked like an inline patch body
-    // (method-group receivers included, metadata trusted). Any surviving write that resolves
-    // to nothing keeps the broad reassignment report instead.
+    // The reassigned-link carve-out, at the link's own READ SITE: when the declaration
+    // initializer is definitely overwritten before that read -- the Apply argument itself,
+    // or an alias link's initializer (`src = safe; var patch = src;`) -- the surviving
+    // writes are the only closures the overlay can store, and each is walked like an inline
+    // patch body (method-group receivers included, metadata trusted). Any surviving write
+    // that resolves to nothing keeps the broad reassignment report instead.
     private static bool InspectSurvivingWrites(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
-        IOperation value,
+        IOperation readSite,
         ISymbol variable,
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        if (semanticModel is null
-            || !SymbolEqualityComparer.Default.Equals(ReceiverSymbol(Unwrap(value)), variable)
-            || !InitializerOverwrittenBeforeInvoke(Unwrap(value), semanticModel))
+        if (semanticModel is null || !InitializerOverwrittenBeforeInvoke(readSite, semanticModel))
         {
             return false;
         }
@@ -194,7 +193,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         var writes = new List<SyntaxNode>();
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            if (WritesDelegateBeforeInvoke(node, variable, value, semanticModel))
+            if (WritesDelegateBeforeInvoke(node, variable, readSite, semanticModel))
             {
                 writes.Add(node);
             }
@@ -203,7 +202,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         var handled = true;
         foreach (var node in writes)
         {
-            if (!writes.Any(other => other != node && ComputationLambdas.DefinitelyOverwrites(other, node, value.Syntax, variable, semanticModel)))
+            if (!writes.Any(other => other != node && ComputationLambdas.DefinitelyOverwrites(other, node, readSite.Syntax, variable, semanticModel)))
             {
                 handled &= InspectSurvivingWrite(context, classifier, node, variable, semanticModel, reported);
             }
@@ -668,8 +667,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // The reassignment check applies to EVERY variable in the alias chain, each against the
     // site where its value is READ: `p0 = evil; Func<int,int> patch = p0;` stores p0's
     // post-reassignment closure even though patch itself is never written again. A link whose
-    // initializer is the computation itself (a lambda or method group) ends the chain.
-    private static ISymbol? FindReassignedLink(IOperation value, SemanticModel? semanticModel)
+    // initializer is the computation itself (a lambda or method group) ends the chain. The
+    // READ SITE returns with the link: the overwrite carve-out reasons at that site, not at
+    // the Apply argument.
+    private static (ISymbol Variable, IOperation ReadSite)? FindReassignedLink(IOperation value, SemanticModel? semanticModel)
     {
         var reference = Unwrap(value);
         HashSet<ISymbol>? visited = null;
@@ -677,7 +678,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         {
             if (IsReassignedBefore(variable, reference, semanticModel))
             {
-                return variable;
+                return (variable, reference);
             }
 
             visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -398,7 +398,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 }
                 else
                 {
-                    InspectComputedGetter(context, classifier, property.Property, patchScope, semanticModel, reported, visitedGetters);
+                    InspectComputedGetter(context, classifier, operation, property.Property, patchScope, semanticModel, reported, visitedGetters);
                 }
 
                 break;
@@ -435,15 +435,23 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     private static void InspectComputedGetter(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
+        IOperation operation,
         IPropertySymbol property,
         SyntaxNode patchScope,
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported,
         HashSet<IMethodSymbol>? visitedGetters)
     {
-        if (property.GetMethod is not { } getter
-            || ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } body)
+        if (property.GetMethod is not { } getter)
         {
+            return;
+        }
+
+        if (ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } body)
+        {
+            // A source getter declared in another file (a partial type's other half) cannot
+            // be walked: held to the property TYPE's verdict, like unwalkable statics.
+            ReportIfNotSendable(context, classifier, operation, property, property.Type, reported);
             return;
         }
 
@@ -565,11 +573,19 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // Only BACKING STORAGE holds a shared object: a computed getter may hand out a fresh
         // value on every replay (`static List<int> Items => new();`), and what it actually
         // returns is covered by the executed chase walking its body. Auto-properties and
-        // metadata properties (no walkable body) keep the type verdict.
-        if (HasBackingStorage(property))
+        // metadata properties (no walkable body) keep the type verdict -- and so does a
+        // SOURCE getter declared in another file, which that chase cannot walk either:
+        // trusting it silently would leave the property entirely unchecked.
+        if (HasBackingStorage(property) || !CanWalkGetter(property, operation.SemanticModel))
         {
             ReportIfNotSendable(context, classifier, operation, property, property.Type, reported);
         }
+    }
+
+    private static bool CanWalkGetter(IPropertySymbol property, SemanticModel? semanticModel)
+    {
+        return property.GetMethod is { } getter
+            && ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not null;
     }
 
     private static bool HasBackingStorage(IPropertySymbol property)
@@ -732,17 +748,62 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         var variable = ComputationLambdas.ReferencedVariable(Unwrap(resolved));
         if (variable is not null && semanticModel is not null)
         {
-            foreach (var body in AssignedDelegateBodies(variable, resolved.Syntax, semanticModel))
+            foreach (var body in AssignedDelegateBodies(variable, resolved.Syntax, semanticModel, argumentMap))
             {
                 found = true;
                 ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             }
         }
 
+        if (!found && Unwrap(resolved) is IInvocationOperation callResult)
+        {
+            found = ChaseReturnedDelegateBodies(context, classifier, callResult, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+        }
+
         if (!found)
         {
             ReportUnresolvedInvokedDelegate(context, resolved, variable, semanticModel, reported);
         }
+    }
+
+    // A delegate RETURNED by a same-tree helper and immediately invoked (`Get()()`) executes
+    // whatever the helper's return statements assemble, on every replay -- resolved through
+    // the call's own argument map, so `Make(() => hits)()` reaches the call-site lambda.
+    // DescendDirectExecution keeps returns inside built callbacks out: those belong to the
+    // callback, not to the helper's own return path.
+    private static bool ChaseReturnedDelegateBodies(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IInvocationOperation call,
+        SemanticModel? semanticModel,
+        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
+        HashSet<SyntaxNode> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
+    {
+        if (ComputationLambdas.ResolveMethodBody(call.TargetMethod, semanticModel) is not { } helper)
+        {
+            return false;
+        }
+
+        var found = false;
+        var callMap = ComputationLambdas.BuildArgumentMap(call, argumentMap);
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
+        {
+            if (inner is not IReturnOperation { ReturnedValue: { } returned })
+            {
+                continue;
+            }
+
+            var resolved = ResolveDelegateReference(returned, semanticModel, callMap);
+            foreach (var body in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
+            {
+                found = true;
+                ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
+            }
+        }
+
+        return found;
     }
 
     // The invoked reference, collapsed through parameter-to-argument hops (the map) and
@@ -789,11 +850,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     }
 
     // An invoked delegate resolving to NOTHING walkable -- assembled by an out-helper in
-    // another file, an opaque factory return, a dead-end alias -- executes an arbitrary
-    // closure on every replay: unverifiable means flagged, mirroring the patch-argument
-    // rule. A METADATA method-group target (Math.Abs) stays trusted like every external
-    // contract, and a non-variable dead end (an invoked call-result chain) is left to the
-    // argument-level rules rather than guessed at.
+    // another file, returned by a helper whose returns cannot be resolved, a dead-end alias
+    // -- executes an arbitrary closure on every replay: unverifiable means flagged,
+    // mirroring the patch-argument rule. METADATA targets (a Math.Abs method group, a
+    // BCL-returned delegate) stay trusted like every other external contract.
     private static void ReportUnresolvedInvokedDelegate(
         OperationAnalysisContext context,
         IOperation resolved,
@@ -801,19 +861,32 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        if (variable is null
-            || ResolveMethodReference(resolved, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 })
+        if (variable is not null)
         {
+            if (ResolveMethodReference(resolved, semanticModel, visitedVariables: null) is not { Method.DeclaringSyntaxReferences.Length: 0 })
+            {
+                Report(
+                    context,
+                    resolved,
+                    variable,
+                    variable.Name,
+                    "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                    reported);
+            }
+
             return;
         }
 
-        Report(
-            context,
-            resolved,
-            variable,
-            variable.Name,
-            "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
-            reported);
+        if (Unwrap(resolved) is IInvocationOperation { TargetMethod: { DeclaringSyntaxReferences.Length: > 0 } sourceMethod })
+        {
+            Report(
+                context,
+                resolved,
+                sourceMethod,
+                sourceMethod.Name,
+                "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)",
+                reported);
+        }
     }
 
     // `later?.Invoke()` surfaces the invoke receiver as the conditional-access placeholder;
@@ -839,7 +912,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // right-hand side that can EXECUTE before the invocation is a body that might be the one
     // invoked. Deconstructions pair positionally: `(other, later) = (a, b)` assigns only `b`
     // to `later`, so `a` must not be chased.
-    private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(ISymbol variable, SyntaxNode invokeSite, SemanticModel semanticModel)
+    private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(
+        ISymbol variable,
+        SyntaxNode invokeSite,
+        SemanticModel semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         var writes = new List<SyntaxNode>();
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
@@ -859,7 +936,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var body in NodeAssignedBodies(node, variable, semanticModel))
+            foreach (var body in NodeAssignedBodies(node, variable, semanticModel, argumentMap))
             {
                 yield return body;
             }
@@ -938,14 +1015,18 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax;
     }
 
-    private static IEnumerable<ComputationLambdas.ComputationBody> NodeAssignedBodies(SyntaxNode node, ISymbol variable, SemanticModel semanticModel)
+    private static IEnumerable<ComputationLambdas.ComputationBody> NodeAssignedBodies(
+        SyntaxNode node,
+        ISymbol variable,
+        SemanticModel semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         switch (node)
         {
             case AssignmentExpressionSyntax assignment:
                 foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
                 {
-                    foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
+                    foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(value, semanticModel, argumentMap), semanticModel))
                     {
                         yield return body;
                     }
@@ -956,7 +1037,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             // `Provide(out later)` assembles the delegate inside the callee: the bodies come
             // from the helper's assignments to its out/ref parameter.
             case ArgumentSyntax argument:
-                foreach (var body in OutAssignedBodies(argument, semanticModel))
+                foreach (var body in OutAssignedBodies(argument, semanticModel, argumentMap))
                 {
                     yield return body;
                 }
@@ -965,16 +1046,26 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static IEnumerable<ComputationLambdas.ComputationBody> OutAssignedBodies(ArgumentSyntax argument, SemanticModel semanticModel)
+    private static IEnumerable<ComputationLambdas.ComputationBody> OutAssignedBodies(
+        ArgumentSyntax argument,
+        SemanticModel semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         // The SEMANTIC parameter, not the syntactic position: named arguments reorder freely
         // (`Provide(second: out later, first: 0)`).
-        if ((semanticModel.GetOperation(argument) as IArgumentOperation)?.Parameter is not { } parameter
+        if ((semanticModel.GetOperation(argument) as IArgumentOperation) is not { Parameter: { } parameter } argumentOperation
             || parameter.ContainingSymbol is not IMethodSymbol method
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
             yield break;
         }
+
+        // The helper's OTHER parameters resolve through this call's own arguments:
+        // `Provide(out later, static () => 0)` with `Provide(out d, source) => d = source`
+        // hands the call-site lambda back through `d`.
+        var callMap = argumentOperation.Parent is { } call
+            ? ComputationLambdas.BuildArgumentMap(call, argumentMap)
+            : argumentMap;
 
         var writes = new List<AssignmentExpressionSyntax>();
         foreach (var node in helper.Scope.DescendantNodes())
@@ -997,7 +1088,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var body in ComputationLambdas.OfArgumentValue(assigned, semanticModel))
+            foreach (var body in ComputationLambdas.OfArgumentValue(ResolveDelegateReference(assigned, semanticModel, callMap), semanticModel))
             {
                 yield return body;
             }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -104,16 +104,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         var resolved = methodReference is not null;
-        var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         foreach (var patch in ComputationLambdas.OfArgumentValue(value, semanticModel))
         {
             resolved = true;
-            foreach (var operation in ComputationLambdas.Descend(patch.Body))
-            {
-                InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, reported);
-                InspectStaticRead(context, classifier, operation, reported);
-                InspectCalledHelper(context, classifier, operation, patch.Scope, semanticModel, visitedHelpers, reported);
-            }
+            InspectPatchBody(context, classifier, patch, semanticModel, reported);
         }
 
         if (!resolved && value.Type is { TypeKind: TypeKind.Delegate })
@@ -229,16 +223,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            var target = node switch
-            {
-                AssignmentExpressionSyntax assignment => assignment.Left,
-                ArgumentSyntax argument when !argument.RefOrOutKeyword.IsKind(SyntaxKind.None) => argument.Expression,
-                _ => null,
-            };
-
-            if (target is not null
-                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable)
-                && CanExecuteBefore(node, reference))
+            if (ReassignmentTargets(node) is { } targets
+                && targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable))
+                && CanExecuteBefore(node, reference, variable))
             {
                 return true;
             }
@@ -247,12 +234,41 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
+    // The expressions a node writes: an assignment's left-hand side (deconstruction tuples
+    // flattened, nesting included -- `(patch, _) = ...` writes `patch`) or a ref/out argument.
+    private static IEnumerable<ExpressionSyntax>? ReassignmentTargets(SyntaxNode node)
+    {
+        return node switch
+        {
+            AssignmentExpressionSyntax assignment => FlattenTargets(assignment.Left),
+            ArgumentSyntax argument when !argument.RefOrOutKeyword.IsKind(SyntaxKind.None) => new[] { argument.Expression },
+            _ => null,
+        };
+    }
+
+    private static IEnumerable<ExpressionSyntax> FlattenTargets(ExpressionSyntax left)
+    {
+        if (left is not TupleExpressionSyntax tuple)
+        {
+            yield return left;
+            yield break;
+        }
+
+        foreach (var element in tuple.Arguments)
+        {
+            foreach (var nested in FlattenTargets(element.Expression))
+            {
+                yield return nested;
+            }
+        }
+    }
+
     // Execution-order reasoning without dataflow: an assignment in a DIFFERENT function body
     // (a helper, a lambda, another method) runs whenever that function does -- unknowable, so
     // it counts. In the same function, one textually before the call obviously precedes it,
     // and one textually after still reaches the call when a loop encloses both (the next
     // iteration passes the reassigned delegate).
-    private static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference)
+    private static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference, ISymbol variable)
     {
         if (!ReferenceEquals(EnclosingFunction(assignment), EnclosingFunction(reference)))
         {
@@ -266,14 +282,26 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         for (var current = assignment.Parent; current is not null; current = current.Parent)
         {
+            // Loop-carried only when the variable OUTLIVES the iteration: a delegate local
+            // declared inside the loop body is freshly initialized each pass, so a trailing
+            // reassignment dies with its iteration and can never reach a call.
             if (current is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax
-                && current.Span.Contains(reference.Span))
+                && current.Span.Contains(reference.Span)
+                && !DeclaredWithin(variable, current))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private static bool DeclaredWithin(ISymbol variable, SyntaxNode node)
+    {
+        var declaration = variable.DeclaringSyntaxReferences.FirstOrDefault();
+        return declaration is not null
+            && declaration.SyntaxTree == node.SyntaxTree
+            && node.Span.Contains(declaration.Span);
     }
 
     private static SyntaxNode? EnclosingFunction(SyntaxNode node)
@@ -398,53 +426,99 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // A same-tree method the patch calls (or lifts into a delegate) is chased for STATIC reads
-    // only: a static is shared however deep the call chain that reaches it, and the instance
-    // verdicts (receiver, bare `this`) already cover the object the helper runs on -- but the
-    // classifier deliberately ignores statics, so `int ReadHits() => hits;` on a Sendable type
-    // would otherwise hide what the direct read flags. Metadata bodies stay unwalkable, like
-    // every same-tree-only resolution here; the visited set bounds recursion on call cycles.
-    private static void InspectCalledHelper(
+    // Two walks with different reach. Closure CONTENTS (captures, receivers, `this`) are
+    // storage facts -- a callback the patch merely builds still pins them in the stored
+    // display chain -- so they use the FULL walk, chasing outside local functions wherever
+    // they are referenced. Static READS happen only on execution: one inside a built callback
+    // runs later, off the overlay's re-execution, on whatever flow invokes it -- so statics
+    // (and the helper chase that finds them) follow MZR003's direct-execution pruning.
+    private static void InspectPatchBody(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        ComputationLambdas.ComputationBody patch,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        foreach (var operation in ComputationLambdas.Descend(patch.Body))
+        {
+            InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, reported);
+            InspectCapturedLocalFunction(context, classifier, operation, patch.Scope, semanticModel, visitedLocalFunctions, reported);
+        }
+
+        var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        foreach (var operation in ComputationLambdas.DescendDirectExecution(patch.Body))
+        {
+            InspectStaticRead(context, classifier, operation, reported);
+            InspectExecutedHelper(context, classifier, operation, semanticModel, visitedHelpers, reported);
+        }
+    }
+
+    // A LOCAL FUNCTION referenced by the patch (called, or lifted into a delegate) has no
+    // receiver: its closure is the patch's own environment, so its body is inspected for
+    // captures like patch code -- against its own declaration scope, which keeps helper-call
+    // locals out. One declared inside the patch is already covered by the surrounding walk.
+    private static void InspectCapturedLocalFunction(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
         IOperation operation,
         SyntaxNode patchScope,
         SemanticModel? semanticModel,
-        HashSet<IMethodSymbol> visitedHelpers,
+        HashSet<IMethodSymbol> visited,
         HashSet<ISymbol> reported)
     {
-        var method = operation switch
-        {
-            IInvocationOperation invocation => invocation.TargetMethod,
-            IMethodReferenceOperation reference => reference.Method,
-            _ => null,
-        };
-
-        if (method is null || !visitedHelpers.Add(method)
+        var method = ReferencedMethod(operation);
+        if (method is not { MethodKind: MethodKind.LocalFunction }
+            || !ComputationLambdas.IsDeclaredOutside(method, patchScope)
+            || !visited.Add(method)
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
             return;
         }
 
-        // A LOCAL FUNCTION has no receiver, so no receiver/`this` verdict covers its closure:
-        // one declared outside the patch shares the enclosing method's locals with the patch,
-        // and what its body reads from outside its own declaration is captured state, held to
-        // the ordinary capture verdicts. (One declared INSIDE the patch was already walked
-        // under the patch's own scope, and its reads of patch-locals are patch-internal, not
-        // shared -- re-inspecting it against its own scope would flag them falsely.)
-        var inspectCaptures = method.MethodKind == MethodKind.LocalFunction
-            && ComputationLambdas.IsDeclaredOutside(method, patchScope);
-
         foreach (var inner in ComputationLambdas.Descend(helper.Body))
         {
-            if (inspectCaptures)
-            {
-                InspectCapture(context, classifier, inner, helper.Scope, patchScope, reported);
-            }
-
-            InspectStaticRead(context, classifier, inner, reported);
-            InspectCalledHelper(context, classifier, inner, patchScope, semanticModel, visitedHelpers, reported);
+            InspectCapture(context, classifier, inner, helper.Scope, patchScope, reported);
+            InspectCapturedLocalFunction(context, classifier, inner, patchScope, semanticModel, visited, reported);
         }
+    }
+
+    // Any same-tree method or local function on the patch's own execution path is chased for
+    // STATIC reads: a static is shared however deep the call chain that reaches it, and the
+    // instance verdicts (receiver, bare `this`) already cover the object the helper runs on --
+    // but the classifier deliberately ignores statics, so `int ReadHits() => hits;` on a
+    // Sendable type would otherwise hide what the direct read flags. Metadata bodies stay
+    // unwalkable, like every same-tree-only resolution here.
+    private static void InspectExecutedHelper(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        SemanticModel? semanticModel,
+        HashSet<IMethodSymbol> visited,
+        HashSet<ISymbol> reported)
+    {
+        var method = ReferencedMethod(operation);
+        if (method is null || !visited.Add(method)
+            || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+        {
+            return;
+        }
+
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
+        {
+            InspectStaticRead(context, classifier, inner, reported);
+            InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+        }
+    }
+
+    private static IMethodSymbol? ReferencedMethod(IOperation operation)
+    {
+        return operation switch
+        {
+            IInvocationOperation invocation => invocation.TargetMethod,
+            IMethodReferenceOperation reference => reference.Method,
+            _ => null,
+        };
     }
 
     // Captured by the walked scope AND declared in a function that encloses the PATCH: only
@@ -454,15 +528,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // stay silent.
     private static bool IsSharedCapture(ISymbol symbol, SyntaxNode scope, SyntaxNode patchScope)
     {
-        if (!ComputationLambdas.IsDeclaredOutside(symbol, scope))
-        {
-            return false;
-        }
-
-        var declaringFunction = symbol.ContainingSymbol?.DeclaringSyntaxReferences.FirstOrDefault();
-        return declaringFunction is not null
-            && declaringFunction.SyntaxTree == patchScope.SyntaxTree
-            && declaringFunction.Span.Contains(patchScope.Span);
+        return ComputationLambdas.IsDeclaredOutside(symbol, scope)
+            && ComputationLambdas.DeclaredInFunctionEnclosing(symbol, patchScope);
     }
 
     // The shared verdict for a state read: writable storage is flagged outright; immutable

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -101,14 +101,29 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectMethodGroupReceiver(context, classifier, methodReference, reported);
         }
 
-        var resolved = methodReference is not null;
+        var bodyResolved = false;
         foreach (var patch in ComputationLambdas.OfArgumentValue(value, semanticModel))
         {
-            resolved = true;
+            bodyResolved = true;
             InspectPatchBody(context, classifier, patch, semanticModel, reported);
         }
 
-        if (!resolved && value.Type is { TypeKind: TypeKind.Delegate })
+        // A SOURCE-declared method group whose body lives in another file cannot be walked:
+        // nothing checks the statics it executes, so unverifiable means flagged -- while
+        // metadata targets (Math.Abs) stay trusted like every other external contract.
+        if (methodReference is not null && !bodyResolved
+            && methodReference.Method.DeclaringSyntaxReferences.Length > 0)
+        {
+            Report(
+                context,
+                value,
+                methodReference.Method,
+                methodReference.Method.Name,
+                "its body is declared in another file, so what the stored patch executes cannot be verified from this call site (define the patch in this file, or wrap verified state in a lambda)",
+                reported);
+        }
+
+        if (methodReference is null && !bodyResolved && value.Type is { TypeKind: TypeKind.Delegate })
         {
             var symbol = ReceiverSymbol(Unwrap(value));
             Report(
@@ -221,8 +236,16 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         // The sole assignment standing in for a missing initializer is initialization, not a
         // rebind (`Func<int,int> patch; patch = static x => x;` is the declaration in two
-        // steps).
+        // steps) -- but only when it can actually RUN before this read: a future write proves
+        // nothing about the value read here (a constructor- or externally-supplied delegate
+        // would slip through on its strength).
         var effectiveInitializer = ComputationLambdas.EffectiveInitializerAssignment(variable, semanticModel);
+        if (effectiveInitializer is not null
+            && !ComputationLambdas.CanExecuteBefore(effectiveInitializer, readReference.Syntax, variable, semanticModel))
+        {
+            return true;
+        }
+
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (!ReferenceEquals(node, effectiveInitializer)
@@ -678,18 +701,73 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
+            foreach (var body in NodeAssignedBodies(node, variable, invokeSite, semanticModel))
+            {
+                yield return body;
+            }
+        }
+    }
+
+    private static IEnumerable<ComputationLambdas.ComputationBody> NodeAssignedBodies(SyntaxNode node, ISymbol variable, SyntaxNode invokeSite, SemanticModel semanticModel)
+    {
+        switch (node)
+        {
+            case AssignmentExpressionSyntax assignment when ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable, semanticModel):
+                foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+                {
+                    foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
+                    {
+                        yield return body;
+                    }
+                }
+
+                break;
+
+            // `Provide(out later)` assembles the delegate inside the callee: the bodies come
+            // from the helper's assignments to its out/ref parameter.
+            case ArgumentSyntax argument
+                when argument.RefOrOutKeyword.Kind() is SyntaxKind.OutKeyword or SyntaxKind.RefKeyword
+                    && ComputationLambdas.CanExecuteBefore(argument, invokeSite, variable, semanticModel):
+                foreach (var body in OutAssignedBodies(argument, variable, semanticModel))
+                {
+                    yield return body;
+                }
+
+                break;
+        }
+    }
+
+    private static IEnumerable<ComputationLambdas.ComputationBody> OutAssignedBodies(ArgumentSyntax argument, ISymbol variable, SemanticModel semanticModel)
+    {
+        if (semanticModel.GetSymbolInfo(argument.Expression).Symbol is not { } written
+            || !SymbolEqualityComparer.Default.Equals(written, variable)
+            || argument.Parent is not ArgumentListSyntax argumentList
+            || argumentList.Parent is not InvocationExpressionSyntax invocation
+            || semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method)
+        {
+            yield break;
+        }
+
+        var index = argumentList.Arguments.IndexOf(argument);
+        if (index < 0 || index >= method.Parameters.Length
+            || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+        {
+            yield break;
+        }
+
+        var parameter = method.Parameters[index];
+        foreach (var node in helper.Scope.DescendantNodes())
+        {
             if (node is not AssignmentExpressionSyntax assignment
-                || !ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable, semanticModel))
+                || !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, parameter)
+                || semanticModel.GetOperation(assignment.Right) is not { } assigned)
             {
                 continue;
             }
 
-            foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+            foreach (var body in ComputationLambdas.OfArgumentValue(assigned, semanticModel))
             {
-                foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
-                {
-                    yield return body;
-                }
+                yield return body;
             }
         }
     }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -74,6 +77,26 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
+        // A delegate variable that is REASSIGNED after its initializer no longer proves which
+        // closure the overlay stores -- the initializer may be harmless while the reassignment
+        // captures anything -- so it is treated like an unresolvable delegate instead of
+        // trusted. (MZR003 deliberately keeps trusting initializers: its runtime exception
+        // still covers reassignment, this rule's does not exist.)
+        if (value.Type is { TypeKind: TypeKind.Delegate }
+            && ReceiverSymbol(Unwrap(value)) is { } variable
+            && variable is ILocalSymbol or IFieldSymbol or IPropertySymbol
+            && IsReassigned(variable, semanticModel))
+        {
+            Report(
+                context,
+                value,
+                variable,
+                variable.Name,
+                "it is reassigned after its initializer, so the delegate stored in the overlay cannot be resolved from this call site, and a delegate can capture arbitrary mutable state",
+                reported);
+            return;
+        }
+
         var methodReference = ResolveMethodReference(value, semanticModel, visitedVariables: null);
         if (methodReference is not null)
         {
@@ -87,7 +110,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             resolved = true;
             foreach (var operation in ComputationLambdas.Descend(patch.Body))
             {
-                InspectCapture(context, classifier, operation, patch.Scope, reported);
+                InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, reported);
                 InspectStaticRead(context, classifier, operation, reported);
                 InspectCalledHelper(context, classifier, operation, patch.Scope, semanticModel, visitedHelpers, reported);
             }
@@ -192,6 +215,35 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    // Any assignment beyond the declaration initializer, anywhere in the tree (including a
+    // ref/out handoff): a same-tree syntactic scan, so a reassignment in another file is
+    // residual risk like every same-tree-only resolution here.
+    private static bool IsReassigned(ISymbol variable, SemanticModel? semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            return false;
+        }
+
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            var target = node switch
+            {
+                AssignmentExpressionSyntax assignment => assignment.Left,
+                ArgumentSyntax argument when !argument.RefOrOutKeyword.IsKind(SyntaxKind.None) => argument.Expression,
+                _ => null,
+            };
+
+            if (target is not null
+                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static IOperation Unwrap(IOperation value)
     {
         while (value is IConversionOperation conversion)
@@ -219,14 +271,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         IOperation operation,
         SyntaxNode scope,
+        SyntaxNode patchScope,
         HashSet<ISymbol> reported)
     {
         switch (operation)
         {
-            case ILocalReferenceOperation local when ComputationLambdas.IsDeclaredOutside(local.Local, scope):
+            case ILocalReferenceOperation local when IsSharedCapture(local.Local, scope, patchScope):
                 ReportIfNotSendable(context, classifier, operation, local.Local, local.Local.Type, reported);
                 break;
-            case IParameterReferenceOperation parameter when ComputationLambdas.IsDeclaredOutside(parameter.Parameter, scope):
+            case IParameterReferenceOperation parameter when IsSharedCapture(parameter.Parameter, scope, patchScope):
                 ReportIfNotSendable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, reported);
                 break;
 
@@ -340,12 +393,30 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         {
             if (inspectCaptures)
             {
-                InspectCapture(context, classifier, inner, helper.Scope, reported);
+                InspectCapture(context, classifier, inner, helper.Scope, patchScope, reported);
             }
 
             InspectStaticRead(context, classifier, inner, reported);
             InspectCalledHelper(context, classifier, inner, patchScope, semanticModel, visitedHelpers, reported);
         }
+    }
+
+    // Captured by the walked scope AND declared in a function that encloses the PATCH: only
+    // then does the symbol live in the environment the patch's stored closure shares. A local
+    // function nested inside a called helper also captures that helper's OWN locals -- but
+    // those are recreated on every patch execution, not stored in the delegate, so they must
+    // stay silent.
+    private static bool IsSharedCapture(ISymbol symbol, SyntaxNode scope, SyntaxNode patchScope)
+    {
+        if (!ComputationLambdas.IsDeclaredOutside(symbol, scope))
+        {
+            return false;
+        }
+
+        var declaringFunction = symbol.ContainingSymbol?.DeclaringSyntaxReferences.FirstOrDefault();
+        return declaringFunction is not null
+            && declaringFunction.SyntaxTree == patchScope.SyntaxTree
+            && declaringFunction.Span.Contains(patchScope.Span);
     }
 
     // The shared verdict for a state read: writable storage is flagged outright; immutable

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -548,15 +548,16 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectCapturedLocalFunction(context, classifier, operation, patch.Scope, semanticModel, visitedLocalFunctions, reported);
         }
 
-        // Invoked-delegate chases are bounded per INVOCATION SITE, not per variable: the same
-        // delegate reassigned and invoked again executes a different closure and must be
-        // revisited, while a self-recursive delegate revisits the same site and stops.
-        var visitedHelpers = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        // Both chases are bounded per SITE, not per symbol: the same delegate reassigned and
+        // invoked again executes a different closure, and the same helper called with
+        // different delegate arguments executes different bodies -- while recursion re-reaches
+        // the same site and stops.
+        var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol)>();
         var visitedInvokes = new HashSet<SyntaxNode>();
         foreach (var operation in ComputationLambdas.DescendDirectExecution(patch.Body))
         {
             InspectStaticRead(context, classifier, operation, reported);
-            InspectExecutedHelper(context, classifier, operation, semanticModel, visitedHelpers, visitedInvokes, reported);
+            InspectExecutedHelper(context, classifier, operation, semanticModel, visitedCalls, visitedInvokes, argumentMap: null, reported);
         }
     }
 
@@ -601,13 +602,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         IOperation operation,
         SemanticModel? semanticModel,
-        HashSet<ISymbol> visited,
+        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
         HashSet<SyntaxNode> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
         if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
         {
-            InspectInvokedDelegate(context, classifier, ResolveConditionalReceiver(callee), semanticModel, visited, visitedInvokes, reported);
+            // A delegate PARAMETER invoked by a chased helper resolves through the call-site
+            // arguments: `Run(() => hits)` with `Run(Func<int> f) => f()` executes the lambda.
+            var resolvedCallee = ComputationLambdas.SubstituteArguments(ResolveConditionalReceiver(callee), argumentMap) ?? callee;
+            InspectInvokedDelegate(context, classifier, resolvedCallee, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             return;
         }
 
@@ -622,16 +627,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // real use.)
         foreach (var method in ComputationLambdas.ExecutedMethods(operation))
         {
-            if (ComputationLambdas.IsInsideNameOf(operation) || !visited.Add(method)
+            if (ComputationLambdas.IsInsideNameOf(operation) || !visitedCalls.Add((operation.Syntax, method))
                 || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
             {
                 continue;
             }
 
+            var nestedMap = ComputationLambdas.BuildArgumentMap(operation, argumentMap);
             foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
             {
                 InspectStaticRead(context, classifier, inner, reported);
-                InspectExecutedHelper(context, classifier, inner, semanticModel, visited, visitedInvokes, reported);
+                InspectExecutedHelper(context, classifier, inner, semanticModel, visitedCalls, visitedInvokes, nestedMap, reported);
             }
         }
     }
@@ -648,8 +654,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         IOperation callee,
         SemanticModel? semanticModel,
-        HashSet<ISymbol> visited,
+        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
         HashSet<SyntaxNode> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
         if (!visitedInvokes.Add(callee.Syntax))
@@ -659,7 +666,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var body in ComputationLambdas.OfArgumentValue(callee, semanticModel))
         {
-            ChaseExecutedBody(context, classifier, body, semanticModel, visited, visitedInvokes, reported);
+            ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
         }
 
         var variable = ComputationLambdas.ReferencedVariable(Unwrap(callee));
@@ -670,7 +677,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var body in AssignedDelegateBodies(variable, callee.Syntax, semanticModel))
         {
-            ChaseExecutedBody(context, classifier, body, semanticModel, visited, visitedInvokes, reported);
+            ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
         }
     }
 
@@ -699,20 +706,78 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // to `later`, so `a` must not be chased.
     private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(ISymbol variable, SyntaxNode invokeSite, SemanticModel semanticModel)
     {
+        var writes = new List<SyntaxNode>();
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            foreach (var body in NodeAssignedBodies(node, variable, invokeSite, semanticModel))
+            if (WritesDelegateBeforeInvoke(node, variable, invokeSite, semanticModel))
+            {
+                writes.Add(node);
+            }
+        }
+
+        foreach (var node in writes)
+        {
+            // A later straight-line simple assignment on the path to the invoke REPLACES the
+            // value: the earlier write's body can never be the one invoked.
+            if (writes.Any(other => other != node && DefinitelyOverwrites(other, node, invokeSite, variable, semanticModel)))
+            {
+                continue;
+            }
+
+            foreach (var body in NodeAssignedBodies(node, variable, semanticModel))
             {
                 yield return body;
             }
         }
     }
 
-    private static IEnumerable<ComputationLambdas.ComputationBody> NodeAssignedBodies(SyntaxNode node, ISymbol variable, SyntaxNode invokeSite, SemanticModel semanticModel)
+    private static bool WritesDelegateBeforeInvoke(SyntaxNode node, ISymbol variable, SyntaxNode invokeSite, SemanticModel semanticModel)
+    {
+        return node switch
+        {
+            AssignmentExpressionSyntax assignment =>
+                ComputationLambdas.ReassignmentTargets(assignment) is { } targets
+                && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel))
+                && ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable, semanticModel),
+            ArgumentSyntax argument =>
+                argument.RefOrOutKeyword.Kind() is SyntaxKind.OutKeyword or SyntaxKind.RefKeyword
+                && semanticModel.GetSymbolInfo(argument.Expression).Symbol is { } written
+                && SymbolEqualityComparer.Default.Equals(written, variable)
+                && ComputationLambdas.CanExecuteBefore(argument, invokeSite, variable, semanticModel),
+            _ => false,
+        };
+    }
+
+    // "Straight-line" = the killer sits in plain block statements between itself and wherever
+    // the invoke lives; a killer inside an if/loop may not run, so it kills nothing.
+    private static bool DefinitelyOverwrites(SyntaxNode killer, SyntaxNode victim, SyntaxNode invokeSite, ISymbol variable, SemanticModel semanticModel)
+    {
+        if (killer is not AssignmentExpressionSyntax assignment
+            || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+            || assignment.Left is TupleExpressionSyntax
+            || !ComputationLambdas.WritesVariable(assignment.Left, variable, semanticModel)
+            || killer.SpanStart <= victim.SpanStart
+            || killer.SpanStart >= invokeSite.SpanStart)
+        {
+            return false;
+        }
+
+        for (var current = killer.Parent; current is not null && !current.Span.Contains(invokeSite.Span); current = current.Parent)
+        {
+            if (current is not (BlockSyntax or ExpressionStatementSyntax))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<ComputationLambdas.ComputationBody> NodeAssignedBodies(SyntaxNode node, ISymbol variable, SemanticModel semanticModel)
     {
         switch (node)
         {
-            case AssignmentExpressionSyntax assignment when ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable, semanticModel):
+            case AssignmentExpressionSyntax assignment:
                 foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
                 {
                     foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
@@ -725,10 +790,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
             // `Provide(out later)` assembles the delegate inside the callee: the bodies come
             // from the helper's assignments to its out/ref parameter.
-            case ArgumentSyntax argument
-                when argument.RefOrOutKeyword.Kind() is SyntaxKind.OutKeyword or SyntaxKind.RefKeyword
-                    && ComputationLambdas.CanExecuteBefore(argument, invokeSite, variable, semanticModel):
-                foreach (var body in OutAssignedBodies(argument, variable, semanticModel))
+            case ArgumentSyntax argument:
+                foreach (var body in OutAssignedBodies(argument, semanticModel))
                 {
                     yield return body;
                 }
@@ -737,25 +800,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static IEnumerable<ComputationLambdas.ComputationBody> OutAssignedBodies(ArgumentSyntax argument, ISymbol variable, SemanticModel semanticModel)
+    private static IEnumerable<ComputationLambdas.ComputationBody> OutAssignedBodies(ArgumentSyntax argument, SemanticModel semanticModel)
     {
-        if (semanticModel.GetSymbolInfo(argument.Expression).Symbol is not { } written
-            || !SymbolEqualityComparer.Default.Equals(written, variable)
-            || argument.Parent is not ArgumentListSyntax argumentList
-            || argumentList.Parent is not InvocationExpressionSyntax invocation
-            || semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method)
-        {
-            yield break;
-        }
-
-        var index = argumentList.Arguments.IndexOf(argument);
-        if (index < 0 || index >= method.Parameters.Length
+        // The SEMANTIC parameter, not the syntactic position: named arguments reorder freely
+        // (`Provide(second: out later, first: 0)`).
+        if ((semanticModel.GetOperation(argument) as IArgumentOperation)?.Parameter is not { } parameter
+            || parameter.ContainingSymbol is not IMethodSymbol method
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
             yield break;
         }
 
-        var parameter = method.Parameters[index];
         foreach (var node in helper.Scope.DescendantNodes())
         {
             if (node is not AssignmentExpressionSyntax assignment
@@ -802,14 +857,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         ComputationLambdas.ComputationBody body,
         SemanticModel? semanticModel,
-        HashSet<ISymbol> visited,
+        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
         HashSet<SyntaxNode> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
         foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
         {
             InspectStaticRead(context, classifier, inner, reported);
-            InspectExecutedHelper(context, classifier, inner, semanticModel, visited, visitedInvokes, reported);
+            InspectExecutedHelper(context, classifier, inner, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -171,29 +171,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             // (the object handed out is what gets shared). A computed get-only property's body
             // is not chased: like type parameters elsewhere, it gets the benefit of the doubt.
             case IFieldReferenceOperation { Field.IsStatic: false } field when IsOnEnclosingInstance(field.Instance):
-                if (!field.Field.IsReadOnly)
-                {
-                    Report(context, operation, field.Field, field.Field.Name, "it is writable state of the enclosing object", reported);
-                }
-                else
-                {
-                    ReportIfNotSendable(context, classifier, operation, field.Field, field.Field.Type, reported);
-                }
-
+                InspectStateRead(
+                    context, classifier, operation, field.Field, field.Field.Type,
+                    writable: !field.Field.IsReadOnly, "it is writable state of the enclosing object", reported);
                 break;
             case IPropertyReferenceOperation { Property.IsStatic: false } property when IsOnEnclosingInstance(property.Instance):
-                // An init accessor surfaces as SetMethod but cannot run after construction:
-                // `{ get; init; }` is immutable state, held (like readonly fields) only to its
-                // TYPE's sendability -- the same verdict the runtime SendableChecker gives it.
-                if (property.Property.SetMethod is { IsInitOnly: false })
-                {
-                    Report(context, operation, property.Property, property.Property.Name, "it is writable state of the enclosing object", reported);
-                }
-                else
-                {
-                    ReportIfNotSendable(context, classifier, operation, property.Property, property.Property.Type, reported);
-                }
-
+                InspectStateRead(
+                    context, classifier, operation, property.Property, property.Property.Type,
+                    writable: IsSettable(property.Property), "it is writable state of the enclosing object", reported);
                 break;
 
             // Static state needs no capture to be shared: the read is baked into the stored
@@ -201,26 +186,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             // verdicts as enclosing-object state; const fields are compile-time values, not
             // storage.
             case IFieldReferenceOperation { Field: { IsStatic: true, IsConst: false } } staticField:
-                if (!staticField.Field.IsReadOnly)
-                {
-                    Report(context, operation, staticField.Field, staticField.Field.Name, "it is writable static state", reported);
-                }
-                else
-                {
-                    ReportIfNotSendable(context, classifier, operation, staticField.Field, staticField.Field.Type, reported);
-                }
-
+                InspectStateRead(
+                    context, classifier, operation, staticField.Field, staticField.Field.Type,
+                    writable: !staticField.Field.IsReadOnly, "it is writable static state", reported);
                 break;
             case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
-                if (staticProperty.Property.SetMethod is { IsInitOnly: false })
-                {
-                    Report(context, operation, staticProperty.Property, staticProperty.Property.Name, "it is writable static state", reported);
-                }
-                else
-                {
-                    ReportIfNotSendable(context, classifier, operation, staticProperty.Property, staticProperty.Property.Type, reported);
-                }
-
+                InspectStateRead(
+                    context, classifier, operation, staticProperty.Property, staticProperty.Property.Type,
+                    writable: IsSettable(staticProperty.Property), "it is writable static state", reported);
                 break;
 
             // A bare `this` -- the implicit receiver of a helper call (`ReadCounter()`) or an
@@ -245,6 +218,36 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
                 break;
         }
+    }
+
+    // The shared verdict for a state read: writable storage is flagged outright; immutable
+    // storage is held to the member TYPE's sendability.
+    private static void InspectStateRead(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        ISymbol member,
+        ITypeSymbol type,
+        bool writable,
+        string writableProblem,
+        HashSet<ISymbol> reported)
+    {
+        if (writable)
+        {
+            Report(context, operation, member, member.Name, writableProblem, reported);
+        }
+        else
+        {
+            ReportIfNotSendable(context, classifier, operation, member, type, reported);
+        }
+    }
+
+    // An init accessor surfaces as SetMethod but cannot run after construction: `{ get; init; }`
+    // is immutable state, held (like readonly fields) only to its TYPE's sendability -- the same
+    // verdict the runtime SendableChecker gives it.
+    private static bool IsSettable(IPropertySymbol property)
+    {
+        return property.SetMethod is { IsInitOnly: false };
     }
 
     // True when the reference is the receiver of a member read InspectCapture handles itself:

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -9,12 +9,13 @@ namespace MemoizR.Analyzers;
 // MZR004, the closure-capture mirror of MZR001 (ADR 0007 phase 5): an optimistic patch is
 // stored in the overlay and re-executed by the view's computation on whichever flow pulls the
 // optimistic state, so everything its closure captures crosses flows exactly like a node value.
-// A capture whose type is not Sendable (a List<int> local), or a read of writable state on the
-// enclosing object (a non-readonly field, a settable property), is therefore unsynchronized
-// cross-flow sharing -- and so are a method-group patch's receiver, a bare `this` handed to a
-// helper, and static state a patch reads (shared without any capture at all). Reads of
-// Sendable-typed captures stay unflagged -- capturing the action payload or other immutable
-// snapshots is the idiomatic pattern. This rule exists because the
+// A capture whose type is not Sendable (a List<int> local), or a read of writable state on a
+// non-Sendable enclosing object (a non-readonly field, a settable property), is therefore
+// unsynchronized cross-flow sharing -- and so are a method-group patch's receiver (including a
+// mutable struct boxed into the delegate), a bare `this` handed to a helper, and static state
+// the patch reads directly or through same-tree helpers (shared without any capture at all).
+// Reads of Sendable-typed captures stay unflagged -- capturing the action payload or other
+// immutable snapshots is the idiomatic pattern. This rule exists because the
 // RUNTIME cannot check it: closure display classes always carry writable fields, so a
 // structural runtime check would reject every capturing lambda. Captured-state WRITES inside a
 // patch are MZR002's territory (Apply is a computation host), and a Set inside one is MZR003's.
@@ -60,11 +61,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectMethodGroupReceiver(context, classifier, argument.Value, invocation.SemanticModel, reported);
         }
 
+        var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         foreach (var patch in ComputationLambdas.OfInvocation(invocation))
         {
             foreach (var operation in ComputationLambdas.Descend(patch.Body))
             {
                 InspectCapture(context, classifier, operation, patch.Scope, reported);
+                InspectStaticRead(context, classifier, operation, reported);
+                InspectCalledHelper(context, classifier, operation, invocation.SemanticModel, visitedHelpers, reported);
             }
         }
     }
@@ -76,20 +80,35 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        if (ResolveMethodReference(value, semanticModel, visitedVariables: null) is not { Instance: { } receiver }
+        if (ResolveMethodReference(value, semanticModel, visitedVariables: null) is not { Instance: { } receiver } methodReference
             || receiver.Type is not { } receiverType)
-        {
-            return;
-        }
-
-        var reason = classifier.GetNotSendableReason(receiverType);
-        if (reason is null)
         {
             return;
         }
 
         var symbol = ReceiverSymbol(receiver);
         var name = receiver is IInstanceReferenceOperation ? "this" : symbol?.Name ?? SendableSymbolClassifier.Display(receiverType);
+        var reason = classifier.GetNotSendableReason(receiverType);
+        if (reason is null)
+        {
+            // A Sendable verdict for a VALUE TYPE rests on copy semantics -- but a method-group
+            // delegate stores ONE boxed receiver that every re-execution shares, and a
+            // non-readonly struct method mutates that box in place. (A readonly method cannot,
+            // and the box is reachable only through the delegate.)
+            if (receiverType.IsValueType && !methodReference.Method.IsReadOnly)
+            {
+                Report(
+                    context,
+                    receiver,
+                    symbol ?? receiverType,
+                    name,
+                    $"its non-readonly method '{methodReference.Method.Name}' can mutate the boxed receiver the stored delegate shares across flows",
+                    reported);
+            }
+
+            return;
+        }
+
         Report(
             context,
             receiver,
@@ -165,43 +184,32 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 ReportIfNotSendable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, reported);
                 break;
 
-            // A member access on the enclosing object captures `this`. Writable storage is
-            // flagged outright -- the patch re-reads it on other flows while the owner mutates
-            // it freely; readonly/get-only members are held to the member TYPE's sendability
-            // (the object handed out is what gets shared). A computed get-only property's body
+            // A member access on the enclosing object captures `this`. The per-member verdicts
+            // REFINE a non-Sendable enclosing object -- they say which reads make sharing it
+            // dangerous: writable storage is flagged outright (the patch re-reads it on other
+            // flows while the owner mutates it freely); readonly/get-only members are held to
+            // the member TYPE's sendability (the object handed out is what gets shared). An
+            // enclosing type the classifier accepts ([Sendable], structurally immutable) was
+            // vetted WHOLESALE -- re-walking its members would override that trust, exactly
+            // where the runtime SendableChecker trusts it. A computed get-only property's body
             // is not chased: like type parameters elsewhere, it gets the benefit of the doubt.
-            case IFieldReferenceOperation { Field.IsStatic: false } field when IsOnEnclosingInstance(field.Instance):
+            case IFieldReferenceOperation { Field.IsStatic: false } field when IsOnNonSendableEnclosingInstance(field.Instance, classifier):
                 InspectStateRead(
                     context, classifier, operation, field.Field, field.Field.Type,
                     writable: !field.Field.IsReadOnly, "it is writable state of the enclosing object", reported);
                 break;
-            case IPropertyReferenceOperation { Property.IsStatic: false } property when IsOnEnclosingInstance(property.Instance):
+            case IPropertyReferenceOperation { Property.IsStatic: false } property when IsOnNonSendableEnclosingInstance(property.Instance, classifier):
                 InspectStateRead(
                     context, classifier, operation, property.Property, property.Property.Type,
                     writable: IsSettable(property.Property), "it is writable state of the enclosing object", reported);
-                break;
-
-            // Static state needs no capture to be shared: the read is baked into the stored
-            // delegate and re-executes on pull flows while any code mutates the static. Same
-            // verdicts as enclosing-object state; const fields are compile-time values, not
-            // storage.
-            case IFieldReferenceOperation { Field: { IsStatic: true, IsConst: false } } staticField:
-                InspectStateRead(
-                    context, classifier, operation, staticField.Field, staticField.Field.Type,
-                    writable: !staticField.Field.IsReadOnly, "it is writable static state", reported);
-                break;
-            case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
-                InspectStateRead(
-                    context, classifier, operation, staticProperty.Property, staticProperty.Property.Type,
-                    writable: IsSettable(staticProperty.Property), "it is writable static state", reported);
                 break;
 
             // A bare `this` -- the implicit receiver of a helper call (`ReadCounter()`) or an
             // explicit argument (`Use(this)`) -- captures the whole enclosing object without
             // naming a member, so it is held to the TYPE's sendability like a method-group
             // receiver: hiding a state read behind a helper must not evade what the direct read
-            // would flag. Receivers of the member reads the cases above inspect are skipped;
-            // those get the finer per-member verdict.
+            // would flag. Receivers of the member reads the cases above handle are skipped;
+            // those get the finer per-member verdict (or the same wholesale trust).
             case IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } instance
                 when instance.Type is { } enclosingType && !IsInspectedMemberReceiver(instance):
                 var reason = classifier.GetNotSendableReason(enclosingType);
@@ -217,6 +225,65 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 }
 
                 break;
+        }
+    }
+
+    // Static state needs no capture to be shared: the read is baked into the stored delegate
+    // and re-executes on pull flows while any code mutates the static. Same verdicts as
+    // enclosing-object state; const fields are compile-time values, not storage. Separate from
+    // InspectCapture because the helper walk below applies it to CALLED method bodies too.
+    private static void InspectStaticRead(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        HashSet<ISymbol> reported)
+    {
+        switch (operation)
+        {
+            case IFieldReferenceOperation { Field: { IsStatic: true, IsConst: false } } staticField:
+                InspectStateRead(
+                    context, classifier, operation, staticField.Field, staticField.Field.Type,
+                    writable: !staticField.Field.IsReadOnly, "it is writable static state", reported);
+                break;
+            case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
+                InspectStateRead(
+                    context, classifier, operation, staticProperty.Property, staticProperty.Property.Type,
+                    writable: IsSettable(staticProperty.Property), "it is writable static state", reported);
+                break;
+        }
+    }
+
+    // A same-tree method the patch calls (or lifts into a delegate) is chased for STATIC reads
+    // only: a static is shared however deep the call chain that reaches it, and the instance
+    // verdicts (receiver, bare `this`) already cover the object the helper runs on -- but the
+    // classifier deliberately ignores statics, so `int ReadHits() => hits;` on a Sendable type
+    // would otherwise hide what the direct read flags. Metadata bodies stay unwalkable, like
+    // every same-tree-only resolution here; the visited set bounds recursion on call cycles.
+    private static void InspectCalledHelper(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        SemanticModel? semanticModel,
+        HashSet<IMethodSymbol> visitedHelpers,
+        HashSet<ISymbol> reported)
+    {
+        var method = operation switch
+        {
+            IInvocationOperation invocation => invocation.TargetMethod,
+            IMethodReferenceOperation reference => reference.Method,
+            _ => null,
+        };
+
+        if (method is null || !visitedHelpers.Add(method)
+            || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+        {
+            return;
+        }
+
+        foreach (var inner in ComputationLambdas.Descend(helper.Body))
+        {
+            InspectStaticRead(context, classifier, inner, reported);
+            InspectCalledHelper(context, classifier, inner, semanticModel, visitedHelpers, reported);
         }
     }
 
@@ -258,9 +325,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             || (instance.Parent is IPropertyReferenceOperation property && ReferenceEquals(property.Instance, instance));
     }
 
-    private static bool IsOnEnclosingInstance(IOperation? receiver)
+    private static bool IsOnNonSendableEnclosingInstance(IOperation? receiver, SendableSymbolClassifier classifier)
     {
-        return receiver is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance };
+        return receiver is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance, Type: { } type }
+            && classifier.GetNotSendableReason(type) is not null;
     }
 
     private static void ReportIfNotSendable(

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -108,6 +108,21 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectPatchBody(context, classifier, patch, semanticModel, reported);
         }
 
+        // A patch definitely ASSEMBLED by a same-tree out-helper (`Provide(out patch)` as
+        // the sole dominating write) resolves to the helper's assignments -- each walked
+        // like an inline patch body; an unresolvable helper falls through to the
+        // unverifiable report below.
+        if (!bodyResolved && semanticModel is not null
+            && ReceiverSymbol(Unwrap(value)) is { } assembled
+            && ComputationLambdas.EffectiveInitializerWrite(assembled, semanticModel) is ArgumentSyntax outWrite)
+        {
+            foreach (var patch in OutAssignedBodies(outWrite, semanticModel, argumentMap: null))
+            {
+                bodyResolved = true;
+                InspectPatchBody(context, classifier, patch, semanticModel, reported);
+            }
+        }
+
         // A SOURCE-declared method group whose body lives in another file cannot be walked:
         // nothing checks the statics it executes, so unverifiable means flagged -- while
         // metadata targets (Math.Abs) stay trusted like every other external contract.
@@ -234,12 +249,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // The sole assignment standing in for a missing initializer is initialization, not a
-        // rebind (`Func<int,int> patch; patch = static x => x;` is the declaration in two
+        // The sole WRITE standing in for a missing initializer is initialization, not a
+        // rebind (`Func<int,int> patch; patch = static x => x;` -- or `Provide(out patch)`,
+        // whose bodies the out-helper machinery resolves -- is the declaration in two
         // steps) -- but only when it can actually RUN before this read: a future write proves
         // nothing about the value read here (a constructor- or externally-supplied delegate
         // would slip through on its strength).
-        var effectiveInitializer = ComputationLambdas.EffectiveInitializerAssignment(variable, semanticModel);
+        var effectiveInitializer = ComputationLambdas.EffectiveInitializerWrite(variable, semanticModel);
         if (effectiveInitializer is not null
             && !ComputationLambdas.CanExecuteBefore(effectiveInitializer, readReference.Syntax, variable, semanticModel))
         {
@@ -815,17 +831,28 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
         }
 
-        var variable = ComputationLambdas.ReferencedVariable(Unwrap(resolved));
-        if (variable is not null && semanticModel is not null)
+        var unwrapped = Unwrap(resolved);
+
+        // A REBOUND parameter stops the hop, but what the caller handed in can still run
+        // when the rebind is conditional: both stay candidates.
+        if (unwrapped is IParameterReferenceOperation
+            && ComputationLambdas.SubstituteArguments(unwrapped, argumentMap) is { } handed
+            && !ReferenceEquals(handed, unwrapped))
         {
-            foreach (var body in AssignedDelegateBodies(variable, resolved.Syntax, semanticModel, argumentMap))
+            foreach (var body in ComputationLambdas.OfArgumentValue(handed, semanticModel))
             {
                 found = true;
                 ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             }
         }
 
-        if (!found && Unwrap(resolved) is IInvocationOperation callResult)
+        var variable = ComputationLambdas.ReferencedVariable(unwrapped) ?? (unwrapped as IParameterReferenceOperation)?.Parameter;
+        if (variable is not null && semanticModel is not null)
+        {
+            found |= ChaseAssignedDelegates(context, classifier, variable, resolved, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+        }
+
+        if (!found && unwrapped is IInvocationOperation callResult)
         {
             found = ChaseReturnedDelegateBodies(context, classifier, callResult, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
         }
@@ -879,8 +906,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // The invoked reference, collapsed through parameter-to-argument hops (the map) and
     // variable-to-variable alias initializers. Hops stop at anything the body resolution can
     // consume directly (a lambda, a method group, a variable holding one) so no shape is
-    // lost, and at any alias REASSIGNED before its read -- there the assignment scan owns
-    // the chase, and hopping past it would resurrect the stale initializer.
+    // lost, and at any alias or parameter WRITTEN before its read -- there the assignment
+    // scan owns the chase, and hopping past the write would resurrect a stale value.
     private static IOperation ResolveDelegateReference(
         IOperation callee,
         SemanticModel? semanticModel,
@@ -890,6 +917,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<ISymbol>? visited = null;
         while (true)
         {
+            if (Unwrap(current) is IParameterReferenceOperation rebound
+                && argumentMap?.ContainsKey(rebound.Parameter) == true
+                && ComputationLambdas.IsWrittenBefore(rebound.Parameter, current.Syntax, semanticModel))
+            {
+                return current;
+            }
+
             if (ComputationLambdas.SubstituteArguments(current, argumentMap) is { } substituted
                 && !ReferenceEquals(substituted, current))
             {
@@ -978,25 +1012,35 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     }
 
     // A delegate assembled by ASSIGNMENT (`Func<int> later; later = () => hits;`, including
-    // through deconstruction) has no initializer to resolve, so every same-tree assignment's
-    // right-hand side that can EXECUTE before the invocation is a body that might be the one
-    // invoked. Deconstructions pair positionally: `(other, later) = (a, b)` assigns only `b`
-    // to `later`, so `a` must not be chased.
-    private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(
+    // through deconstruction or an out-helper) has no initializer to resolve, so every
+    // same-tree write that can EXECUTE before the invocation is a CANDIDATE -- and each
+    // candidate is accounted for separately: one write resolving to a safe body must not
+    // silence another that resolves to nothing (`if (external) later = External.Get(); else
+    // later = static () => 0;` can leave either closure to run), so an unaccounted write
+    // gets the unverifiable report itself. Killed writes (definitely overwritten on the way
+    // to the invoke) stay out; deconstructions pair positionally.
+    private static bool ChaseAssignedDelegates(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
         ISymbol variable,
-        SyntaxNode invokeSite,
+        IOperation readReference,
         SemanticModel semanticModel,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
     {
+        var invokeSite = readReference.Syntax;
         var writes = new List<SyntaxNode>();
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            if (WritesDelegateBeforeInvoke(node, variable, invokeSite, semanticModel))
+            if (WritesDelegateBeforeInvoke(node, variable, readReference, semanticModel))
             {
                 writes.Add(node);
             }
         }
 
+        var found = false;
         foreach (var node in writes)
         {
             // A later straight-line simple assignment on the path to the invoke REPLACES the
@@ -1006,26 +1050,90 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
+            var resolvedAny = false;
             foreach (var body in NodeAssignedBodies(node, variable, semanticModel, argumentMap))
             {
-                yield return body;
+                resolvedAny = true;
+                ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             }
+
+            if (!resolvedAny)
+            {
+                resolvedAny = ResolvesOutsideBodies(context, classifier, node, variable, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            }
+
+            if (!resolvedAny && semanticModel.GetOperation(node) is { } writeOperation)
+            {
+                Report(
+                    context,
+                    writeOperation,
+                    variable,
+                    variable.Name,
+                    "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                    reported);
+            }
+
+            found |= resolvedAny;
         }
+
+        return found;
     }
 
-    private static bool WritesDelegateBeforeInvoke(SyntaxNode node, ISymbol variable, SyntaxNode invokeSite, SemanticModel semanticModel)
+    // A candidate write whose right-hand side yields no walkable body can still be
+    // accounted for: a METADATA method-group target is a trusted external contract, and a
+    // same-tree delegate-returning call resolves through its return statements. Anything
+    // else stays unaccounted and gets flagged by the caller.
+    private static bool ResolvesOutsideBodies(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        SyntaxNode write,
+        ISymbol variable,
+        SemanticModel semanticModel,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
+    {
+        if (write is not AssignmentExpressionSyntax assignment)
+        {
+            return false;
+        }
+
+        foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+        {
+            var resolvedValue = ResolveDelegateReference(value, semanticModel, argumentMap);
+            if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 })
+            {
+                return true;
+            }
+
+            if (Unwrap(resolvedValue) is IInvocationOperation callResult
+                && ChaseReturnedDelegateBodies(context, classifier, callResult, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool WritesDelegateBeforeInvoke(SyntaxNode node, ISymbol variable, IOperation readReference, SemanticModel semanticModel)
     {
         return node switch
         {
+            // WritesReadInstance keeps writes on provably-different instances out: a fresh
+            // `other.patch = evil;` cannot rebind the field this invoke reads through
+            // some other receiver.
             AssignmentExpressionSyntax assignment =>
                 ComputationLambdas.ReassignmentTargets(assignment) is { } targets
-                && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel))
-                && ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable, semanticModel),
+                && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel)
+                    && WritesReadInstance(target, variable, readReference, semanticModel))
+                && ComputationLambdas.CanExecuteBefore(assignment, readReference.Syntax, variable, semanticModel),
             ArgumentSyntax argument =>
                 argument.RefOrOutKeyword.Kind() is SyntaxKind.OutKeyword or SyntaxKind.RefKeyword
                 && semanticModel.GetSymbolInfo(argument.Expression).Symbol is { } written
                 && SymbolEqualityComparer.Default.Equals(written, variable)
-                && ComputationLambdas.CanExecuteBefore(argument, invokeSite, variable, semanticModel),
+                && ComputationLambdas.CanExecuteBefore(argument, readReference.Syntax, variable, semanticModel),
             _ => false,
         };
     }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -1656,7 +1656,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             || ComputationLambdas.ReferencedVariable(Unwrap(resolved)) is not { } variable
             || variable.DeclaringSyntaxReferences.FirstOrDefault() is not { } declaration
             || declaration.SyntaxTree != semanticModel.SyntaxTree
-            || declaration.GetSyntax() is not VariableDeclaratorSyntax { Initializer: not null } declarator)
+            || ComputationLambdas.DeclaredInitializerSite(declaration.GetSyntax()) is not { } declarator)
         {
             return false;
         }
@@ -1685,10 +1685,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel)
                     && WritesReadInstance(target, variable, readReference, semanticModel))
                 && ComputationLambdas.CanExecuteBefore(assignment, readReference.Syntax, variable, semanticModel),
+            // WritesVariable, not direct symbol equality: `Provide(out alias)` through a
+            // ref alias hands the delegate to the aliased variable just as directly.
             ArgumentSyntax argument =>
                 argument.RefOrOutKeyword.Kind() is SyntaxKind.OutKeyword or SyntaxKind.RefKeyword
-                && semanticModel.GetSymbolInfo(argument.Expression).Symbol is { } written
-                && SymbolEqualityComparer.Default.Equals(written, variable)
+                && ComputationLambdas.WritesVariable(argument.Expression, variable, semanticModel)
                 && ComputationLambdas.CanExecuteBefore(argument, readReference.Syntax, variable, semanticModel),
             _ => false,
         };

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -83,15 +83,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // trusted. (MZR003 deliberately keeps trusting initializers: its runtime exception
         // still covers reassignment, this rule's does not exist.)
         if (value.Type is { TypeKind: TypeKind.Delegate }
-            && ReceiverSymbol(Unwrap(value)) is { } variable
-            && variable is ILocalSymbol or IFieldSymbol or IPropertySymbol
-            && IsReassignedBefore(variable, value.Syntax, semanticModel))
+            && FindReassignedLink(value, semanticModel) is { } reassigned)
         {
             Report(
                 context,
                 value,
-                variable,
-                variable.Name,
+                reassigned,
+                reassigned.Name,
                 "it is reassigned after its initializer, so the delegate stored in the overlay cannot be resolved from this call site, and a delegate can capture arbitrary mutable state",
                 reported);
             return;
@@ -232,6 +230,36 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    // The reassignment check applies to EVERY variable in the alias chain, each against the
+    // site where its value is READ: `p0 = evil; Func<int,int> patch = p0;` stores p0's
+    // post-reassignment closure even though patch itself is never written again. A link whose
+    // initializer is the computation itself (a lambda or method group) ends the chain.
+    private static ISymbol? FindReassignedLink(IOperation value, SemanticModel? semanticModel)
+    {
+        var reference = Unwrap(value);
+        var site = value.Syntax;
+        HashSet<ISymbol>? visited = null;
+        while (ReceiverSymbol(reference) is (ILocalSymbol or IFieldSymbol or IPropertySymbol) and { } variable)
+        {
+            if (IsReassignedBefore(variable, site, semanticModel))
+            {
+                return variable;
+            }
+
+            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visited.Add(variable)
+                || ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel) is not { } initializer)
+            {
+                return null;
+            }
+
+            site = initializer.Syntax;
+            reference = Unwrap(initializer);
+        }
+
+        return null;
     }
 
     // A ref-local ALIAS writes its referent: `ref var alias = ref patch; alias = ...` rebinds
@@ -478,6 +506,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                     context, classifier, operation, staticProperty.Property, staticProperty.Property.Type,
                     writable: IsSettable(staticProperty.Property), "it is writable static state", reported);
                 break;
+
+            // An event's backing delegate is writable storage by construction: any subscriber
+            // mutates it, so a static event read/invoke shares mutable state like a writable
+            // static field.
+            case IEventReferenceOperation { Event.IsStatic: true } staticEvent:
+                Report(
+                    context, operation, staticEvent.Event, staticEvent.Event.Name,
+                    "it is writable static state (subscribing mutates the event's backing delegate)", reported);
+                break;
         }
     }
 
@@ -501,7 +538,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectCapturedLocalFunction(context, classifier, operation, patch.Scope, semanticModel, visitedLocalFunctions, reported);
         }
 
-        var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        // ISymbol, not IMethodSymbol: the executed chase also visits invoked delegate VARIABLES.
+        var visitedHelpers = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         foreach (var operation in ComputationLambdas.DescendDirectExecution(patch.Body))
         {
             InspectStaticRead(context, classifier, operation, reported);
@@ -550,9 +588,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         IOperation operation,
         SemanticModel? semanticModel,
-        HashSet<IMethodSymbol> visited,
+        HashSet<ISymbol> visited,
         HashSet<ISymbol> reported)
     {
+        if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
+        {
+            InspectInvokedDelegate(context, classifier, callee, semanticModel, visited, reported);
+            return;
+        }
+
         // Only what EXECUTES is chased: a call; a property READ, which runs its getter exactly
         // like a call (`static int Hits => hits;` is the helper-method evasion with property
         // syntax); a constructor; or a user-defined operator/conversion -- each runs on every
@@ -584,6 +628,35 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         {
             InspectStaticRead(context, classifier, inner, reported);
             InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+        }
+    }
+
+    // A delegate the patch builds AND synchronously invokes runs its body on every replay:
+    // the built-but-deferred shape stays pruned, but `Func<int> later = () => hits; later()`
+    // executes now, and unlike MZR003's identical prune there is no runtime backstop. The
+    // callee resolves like a computation argument (same-tree lambda or method group, through
+    // variable initializers); the variable visited-guard bounds self-referential delegates.
+    private static void InspectInvokedDelegate(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation callee,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> visited,
+        HashSet<ISymbol> reported)
+    {
+        var variable = ComputationLambdas.ReferencedVariable(Unwrap(callee));
+        if (variable is not null && !visited.Add(variable))
+        {
+            return;
+        }
+
+        foreach (var body in ComputationLambdas.OfArgumentValue(callee, semanticModel))
+        {
+            foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
+            {
+                InspectStaticRead(context, classifier, inner, reported);
+                InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+            }
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -241,7 +241,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return node switch
         {
             AssignmentExpressionSyntax assignment => FlattenTargets(assignment.Left),
-            ArgumentSyntax argument when !argument.RefOrOutKeyword.IsKind(SyntaxKind.None) => new[] { argument.Expression },
+            // `in` is excluded: a readonly reference cannot rebind the variable.
+            ArgumentSyntax argument when argument.RefOrOutKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword
+                => new[] { argument.Expression },
             _ => null,
         };
     }
@@ -469,6 +471,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         var method = ReferencedMethod(operation);
         if (method is not { MethodKind: MethodKind.LocalFunction }
+            || ComputationLambdas.IsInsideNameOf(operation)
             || !ComputationLambdas.IsDeclaredOutside(method, patchScope)
             || !visited.Add(method)
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
@@ -497,7 +500,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<IMethodSymbol> visited,
         HashSet<ISymbol> reported)
     {
-        var method = ReferencedMethod(operation);
+        // Only a CALL executes the helper: a method group the patch stores builds a delegate
+        // without running it -- the same deferred shape as a built lambda, which this walk
+        // already prunes. (The capture chase above keeps method references: a lifted local
+        // function's closure is pinned either way.)
+        var method = operation is IInvocationOperation invocation ? invocation.TargetMethod : null;
         if (method is null || !visited.Add(method)
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
@@ -609,7 +616,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         string problem,
         HashSet<ISymbol> reported)
     {
-        if (IsInsideNameOf(operation) || !reported.Add(dedupeKey))
+        if (ComputationLambdas.IsInsideNameOf(operation) || !reported.Add(dedupeKey))
         {
             return;
         }
@@ -621,19 +628,4 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             problem));
     }
 
-    // A symbol used only inside nameof() is a compile-time string: the built delegate neither
-    // captures nor reads it, so nothing crosses flows. Checked at the single report choke
-    // point (before the dedupe add, so a real use elsewhere still reports).
-    private static bool IsInsideNameOf(IOperation operation)
-    {
-        for (var current = operation.Parent; current is not null; current = current.Parent)
-        {
-            if (current is INameOfOperation)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -88,18 +88,25 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // A delegate variable that is REASSIGNED after its initializer no longer proves which
         // closure the overlay stores -- the initializer may be harmless while the reassignment
         // captures anything -- so it is treated like an unresolvable delegate instead of
-        // trusted. (MZR003 deliberately keeps trusting initializers: its runtime exception
-        // still covers reassignment, this rule's does not exist.)
+        // trusted, UNLESS the rebind definitely overwrites the initializer on the
+        // straight-line path to this call: then only the surviving writes can be stored, and
+        // they are walked as patch bodies instead (the invoked-delegate overwrite reasoning).
+        // (MZR003 deliberately keeps trusting initializers: its runtime exception still
+        // covers reassignment, this rule's does not exist.)
         if (value.Type is { TypeKind: TypeKind.Delegate }
             && FindReassignedLink(value, semanticModel) is { } reassigned)
         {
-            Report(
-                context,
-                value,
-                reassigned,
-                reassigned.Name,
-                "it is reassigned after its initializer, so the delegate stored in the overlay cannot be resolved from this call site, and a delegate can capture arbitrary mutable state",
-                reported);
+            if (!InspectSurvivingWrites(context, classifier, value, reassigned, semanticModel, reported))
+            {
+                Report(
+                    context,
+                    value,
+                    reassigned,
+                    reassigned.Name,
+                    "it is reassigned after its initializer, so the delegate stored in the overlay cannot be resolved from this call site, and a delegate can capture arbitrary mutable state",
+                    reported);
+            }
+
             return;
         }
 
@@ -165,6 +172,83 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    // The reassigned-argument carve-out: when the read variable's OWN declaration
+    // initializer is definitely overwritten before this call, the surviving writes are the
+    // only closures the overlay can store -- each is walked like an inline patch body
+    // (method-group receivers included, metadata trusted). Any surviving write that resolves
+    // to nothing keeps the broad reassignment report instead.
+    private static bool InspectSurvivingWrites(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        ISymbol variable,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        if (semanticModel is null
+            || !SymbolEqualityComparer.Default.Equals(ReceiverSymbol(Unwrap(value)), variable)
+            || !InitializerOverwrittenBeforeInvoke(Unwrap(value), semanticModel))
+        {
+            return false;
+        }
+
+        var writes = new List<SyntaxNode>();
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (WritesDelegateBeforeInvoke(node, variable, value, semanticModel))
+            {
+                writes.Add(node);
+            }
+        }
+
+        var handled = true;
+        foreach (var node in writes)
+        {
+            if (!writes.Any(other => other != node && DefinitelyOverwrites(other, node, value.Syntax, variable, semanticModel)))
+            {
+                handled &= InspectSurvivingWrite(context, classifier, node, variable, semanticModel, reported);
+            }
+        }
+
+        return handled;
+    }
+
+    private static bool InspectSurvivingWrite(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        SyntaxNode node,
+        ISymbol variable,
+        SemanticModel semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        if (node is not AssignmentExpressionSyntax assignment)
+        {
+            return false;
+        }
+
+        var handled = true;
+        foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
+        {
+            var resolvedValue = ResolveDelegateReference(value, semanticModel, argumentMap: null);
+            var methodReference = ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null);
+            if (methodReference is not null)
+            {
+                InspectMethodGroupReceiver(context, classifier, methodReference, reported);
+            }
+
+            var resolvedAny = false;
+            foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
+            {
+                resolvedAny = true;
+                InspectPatchBody(context, classifier, patch, semanticModel, reported);
+            }
+
+            handled &= resolvedAny || methodReference is { Method.DeclaringSyntaxReferences.Length: 0 };
+        }
+
+        return handled;
+    }
+
     private static bool InspectOutAssembledPatch(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
@@ -212,6 +296,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
             accounted = true;
             var resolvedValue = ResolveDelegateReference(returned, semanticModel, argumentMap: null);
+
+            // A returned method group stores its RECEIVER in the delegate the overlay keeps,
+            // exactly like a method-group patch argument.
+            if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { } returnedReference)
+            {
+                InspectMethodGroupReceiver(context, classifier, returnedReference, reported);
+            }
+
             var resolvedAny = false;
             foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
             {
@@ -900,10 +992,16 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
     private static bool IsUnverifiableExecutedShape(IOperation operation)
     {
+        // Custom event accessors (`e.Changed += h`) and using-driven Dispose run on every
+        // replay exactly like calls, so their cross-file source bodies are equally
+        // unverifiable.
         return operation is IInvocationOperation or IObjectCreationOperation
             or IBinaryOperation { OperatorMethod: not null }
             or IUnaryOperation { OperatorMethod: not null }
-            or IConversionOperation { OperatorMethod: not null };
+            or IConversionOperation { OperatorMethod: not null }
+            or IEventAssignmentOperation
+            or IUsingDeclarationOperation
+            or IUsingOperation;
     }
 
     // A SETTER an assignment runs is executed code like a call: on a receiver the capture
@@ -940,6 +1038,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         var resolved = ResolveDelegateReference(callee, semanticModel, argumentMap);
         if (!visitedInvokes.Add((resolved.Syntax, ComputationLambdas.ArgumentMapKey(argumentMap))))
+        {
+            return;
+        }
+
+        // A conditional or coalesced callee executes whichever arm the flow picks: each arm
+        // is its own invoked candidate, so a safe arm cannot silence an unresolvable one.
+        if (InspectInvokedConditionalArms(context, classifier, resolved, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported))
         {
             return;
         }
@@ -1085,6 +1190,35 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         return Unwrap(resolvedValue) is IInvocationOperation callResult
             && ChaseReturnedDelegateBodies(context, classifier, callResult, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+    }
+
+    private static bool InspectInvokedConditionalArms(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation resolved,
+        SemanticModel? semanticModel,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<ISymbol> reported)
+    {
+        switch (Unwrap(resolved))
+        {
+            case IConditionalOperation conditional:
+                InspectInvokedDelegate(context, classifier, conditional.WhenTrue, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+                if (conditional.WhenFalse is { } whenFalse)
+                {
+                    InspectInvokedDelegate(context, classifier, whenFalse, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+                }
+
+                return true;
+            case ICoalesceOperation coalesce:
+                InspectInvokedDelegate(context, classifier, coalesce.Value, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+                InspectInvokedDelegate(context, classifier, coalesce.WhenNull, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+                return true;
+            default:
+                return false;
+        }
     }
 
     // The invoked reference, collapsed through parameter-to-argument hops (the map) and
@@ -1488,25 +1622,49 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             assigned = true;
             foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, parameter, semanticModel))
             {
-                var resolvedValue = ResolveDelegateReference(value, semanticModel, callMap);
-                var count = bodies.Count;
-                bodies.AddRange(ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel));
-                if (bodies.Count == count
-                    && !AccountsForValue(context, classifier, resolvedValue, semanticModel, visitedCalls, visitedInvokes, callMap, reported)
-                    && semanticModel.GetOperation(assignment) is { } writeOperation)
-                {
-                    Report(
-                        context,
-                        writeOperation,
-                        parameter,
-                        parameter.Name,
-                        "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
-                        reported);
-                }
+                ChaseOutAssignedValue(context, classifier, value, assignment, parameter, semanticModel, bodies, visitedCalls, visitedInvokes, callMap, reported);
             }
         }
 
         return (bodies, assigned);
+    }
+
+    private static void ChaseOutAssignedValue(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        AssignmentExpressionSyntax assignment,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        List<ComputationLambdas.ComputationBody> bodies,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        HashSet<(SyntaxNode, string)> visitedInvokes,
+        Dictionary<IParameterSymbol, IOperation>? callMap,
+        HashSet<ISymbol> reported)
+    {
+        var resolvedValue = ResolveDelegateReference(value, semanticModel, callMap);
+
+        // A method-group value stores its RECEIVER in the handed-back delegate, exactly
+        // like a method-group patch argument.
+        if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { } assignedReference)
+        {
+            InspectMethodGroupReceiver(context, classifier, assignedReference, reported);
+        }
+
+        var count = bodies.Count;
+        bodies.AddRange(ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel));
+        if (bodies.Count == count
+            && !AccountsForValue(context, classifier, resolvedValue, semanticModel, visitedCalls, visitedInvokes, callMap, reported)
+            && semanticModel.GetOperation(assignment) is { } writeOperation)
+        {
+            Report(
+                context,
+                writeOperation,
+                parameter,
+                parameter.Name,
+                "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                reported);
+        }
     }
 
     // ReassignmentTargets flattens deconstruction left sides, so `(d, _) = (...)` assembles

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -219,12 +219,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        // The sole assignment standing in for a missing initializer is initialization, not a
+        // rebind (`Func<int,int> patch; patch = static x => x;` is the declaration in two
+        // steps).
+        var effectiveInitializer = ComputationLambdas.EffectiveInitializerAssignment(variable, semanticModel);
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            if (ComputationLambdas.ReassignmentTargets(node) is { } targets
+            if (!ReferenceEquals(node, effectiveInitializer)
+                && ComputationLambdas.ReassignmentTargets(node) is { } targets
                 && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel)
                     && WritesReadInstance(target, variable, readReference, semanticModel))
-                && ComputationLambdas.CanExecuteBefore(node, readReference.Syntax, variable))
+                && ComputationLambdas.CanExecuteBefore(node, readReference.Syntax, variable, semanticModel))
             {
                 return true;
             }
@@ -331,7 +336,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         IOperation operation,
         SyntaxNode scope,
         SyntaxNode patchScope,
-        HashSet<ISymbol> reported)
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported,
+        HashSet<IMethodSymbol>? visitedGetters = null)
     {
         switch (operation)
         {
@@ -349,17 +356,28 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             // the member TYPE's sendability (the object handed out is what gets shared). An
             // enclosing type the classifier accepts ([Sendable], structurally immutable) was
             // vetted WHOLESALE -- re-walking its members would override that trust, exactly
-            // where the runtime SendableChecker trusts it. A computed get-only property's body
-            // is not chased: like type parameters elsewhere, it gets the benefit of the doubt.
+            // where the runtime SendableChecker trusts it. A COMPUTED get-only property is a
+            // helper call in disguise: its same-tree getter body is walked with these same
+            // verdicts (`int Counter => counter;` re-reads the mutable field on every replay).
             case IFieldReferenceOperation { Field.IsStatic: false } field when IsOnNonSendableEnclosingInstance(field.Instance, classifier):
                 InspectStateRead(
                     context, classifier, operation, field.Field, field.Field.Type,
                     writable: !field.Field.IsReadOnly, "it is writable state of the enclosing object", reported);
                 break;
             case IPropertyReferenceOperation { Property.IsStatic: false } property when IsOnNonSendableEnclosingInstance(property.Instance, classifier):
-                InspectStateRead(
-                    context, classifier, operation, property.Property, property.Property.Type,
-                    writable: IsSettable(property.Property), "it is writable state of the enclosing object", reported);
+                if (IsSettable(property.Property))
+                {
+                    Report(context, operation, property.Property, property.Property.Name, "it is writable state of the enclosing object", reported);
+                }
+                else if (HasBackingStorage(property.Property))
+                {
+                    ReportIfNotSendable(context, classifier, operation, property.Property, property.Property.Type, reported);
+                }
+                else
+                {
+                    InspectComputedGetter(context, classifier, property.Property, patchScope, semanticModel, reported, visitedGetters);
+                }
+
                 break;
 
             // A bare `this` -- the implicit receiver of a helper call (`ReadCounter()`) or an
@@ -383,6 +401,38 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 }
 
                 break;
+        }
+    }
+
+    // A computed get-only property on a non-Sendable enclosing type is a helper call in
+    // disguise: its getter body re-executes on every replay, so it is walked with the same
+    // member verdicts against the getter's own scope. The visited set bounds mutually
+    // recursive getters; metadata and auto-properties never reach here (HasBackingStorage
+    // keeps them on the type verdict).
+    private static void InspectComputedGetter(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IPropertySymbol property,
+        SyntaxNode patchScope,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported,
+        HashSet<IMethodSymbol>? visitedGetters)
+    {
+        if (property.GetMethod is not { } getter
+            || ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } body)
+        {
+            return;
+        }
+
+        visitedGetters ??= new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        if (!visitedGetters.Add(getter))
+        {
+            return;
+        }
+
+        foreach (var inner in ComputationLambdas.Descend(body.Body))
+        {
+            InspectCapture(context, classifier, inner, body.Scope, patchScope, semanticModel, reported, visitedGetters);
         }
     }
 
@@ -467,16 +517,19 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         foreach (var operation in ComputationLambdas.Descend(patch.Body))
         {
-            InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, reported);
+            InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, semanticModel, reported);
             InspectCapturedLocalFunction(context, classifier, operation, patch.Scope, semanticModel, visitedLocalFunctions, reported);
         }
 
-        // ISymbol, not IMethodSymbol: the executed chase also visits invoked delegate VARIABLES.
+        // Invoked-delegate chases are bounded per INVOCATION SITE, not per variable: the same
+        // delegate reassigned and invoked again executes a different closure and must be
+        // revisited, while a self-recursive delegate revisits the same site and stops.
         var visitedHelpers = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var visitedInvokes = new HashSet<SyntaxNode>();
         foreach (var operation in ComputationLambdas.DescendDirectExecution(patch.Body))
         {
             InspectStaticRead(context, classifier, operation, reported);
-            InspectExecutedHelper(context, classifier, operation, semanticModel, visitedHelpers, reported);
+            InspectExecutedHelper(context, classifier, operation, semanticModel, visitedHelpers, visitedInvokes, reported);
         }
     }
 
@@ -505,7 +558,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var inner in ComputationLambdas.Descend(helper.Body))
         {
-            InspectCapture(context, classifier, inner, helper.Scope, patchScope, reported);
+            InspectCapture(context, classifier, inner, helper.Scope, patchScope, semanticModel, reported);
             InspectCapturedLocalFunction(context, classifier, inner, patchScope, semanticModel, visited, reported);
         }
     }
@@ -522,11 +575,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         IOperation operation,
         SemanticModel? semanticModel,
         HashSet<ISymbol> visited,
+        HashSet<SyntaxNode> visitedInvokes,
         HashSet<ISymbol> reported)
     {
         if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
         {
-            InspectInvokedDelegate(context, classifier, ResolveConditionalReceiver(callee), semanticModel, visited, reported);
+            InspectInvokedDelegate(context, classifier, ResolveConditionalReceiver(callee), semanticModel, visited, visitedInvokes, reported);
             return;
         }
 
@@ -550,7 +604,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
             {
                 InspectStaticRead(context, classifier, inner, reported);
-                InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+                InspectExecutedHelper(context, classifier, inner, semanticModel, visited, visitedInvokes, reported);
             }
         }
     }
@@ -559,26 +613,29 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // the built-but-deferred shape stays pruned, but `Func<int> later = () => hits; later()`
     // executes now, and unlike MZR003's identical prune there is no runtime backstop. The
     // callee resolves like a computation argument (same-tree lambda or method group, through
-    // variable initializers); the variable visited-guard bounds self-referential delegates.
+    // variable initializers). The guard is per INVOCATION SITE: a delegate reassigned between
+    // two invokes executes a different closure at each, while a self-recursive delegate
+    // re-reaches the same site inside its own body and stops there.
     private static void InspectInvokedDelegate(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
         IOperation callee,
         SemanticModel? semanticModel,
         HashSet<ISymbol> visited,
+        HashSet<SyntaxNode> visitedInvokes,
         HashSet<ISymbol> reported)
     {
-        var variable = ComputationLambdas.ReferencedVariable(Unwrap(callee));
-        if (variable is not null && !visited.Add(variable))
+        if (!visitedInvokes.Add(callee.Syntax))
         {
             return;
         }
 
         foreach (var body in ComputationLambdas.OfArgumentValue(callee, semanticModel))
         {
-            ChaseExecutedBody(context, classifier, body, semanticModel, visited, reported);
+            ChaseExecutedBody(context, classifier, body, semanticModel, visited, visitedInvokes, reported);
         }
 
+        var variable = ComputationLambdas.ReferencedVariable(Unwrap(callee));
         if (variable is null || semanticModel is null)
         {
             return;
@@ -586,7 +643,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var body in AssignedDelegateBodies(variable, callee.Syntax, semanticModel))
         {
-            ChaseExecutedBody(context, classifier, body, semanticModel, visited, reported);
+            ChaseExecutedBody(context, classifier, body, semanticModel, visited, visitedInvokes, reported);
         }
     }
 
@@ -618,7 +675,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (node is not AssignmentExpressionSyntax assignment
-                || !ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable))
+                || !ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable, semanticModel))
             {
                 continue;
             }
@@ -662,12 +719,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         ComputationLambdas.ComputationBody body,
         SemanticModel? semanticModel,
         HashSet<ISymbol> visited,
+        HashSet<SyntaxNode> visitedInvokes,
         HashSet<ISymbol> reported)
     {
         foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
         {
             InspectStaticRead(context, classifier, inner, reported);
-            InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+            InspectExecutedHelper(context, classifier, inner, semanticModel, visited, visitedInvokes, reported);
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -30,6 +30,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(DiagnosticDescriptors.NonSendablePatchCapture);
 
+    // Pinned verbatim by the tests, and stated at several unresolvable-branch reports each.
+    private const string UnresolvableHeldDelegate =
+        "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)";
+
+    private const string UnresolvableReturnedDelegate =
+        "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)";
+
     public override void Initialize(AnalysisContext context)
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
@@ -122,7 +129,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var methodReference = ResolveMethodReference(value, semanticModel, visitedVariables: null);
+        var methodReference = ResolveMethodReference(value, semanticModel);
         if (methodReference is not null)
         {
             InspectMethodGroupReceiver(context, classifier, methodReference, reported);
@@ -160,7 +167,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         if (methodReference is null && !bodyResolved && value.Type is { TypeKind: TypeKind.Delegate })
         {
-            var symbol = ReceiverSymbol(Unwrap(value));
+            var symbol = ComputationLambdas.ReferencedSymbol(Unwrap(value));
             Report(
                 context,
                 value,
@@ -202,7 +209,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         var handled = true;
         foreach (var node in writes)
         {
-            if (!writes.Any(other => other != node && ComputationLambdas.DefinitelyOverwrites(other, node, readSite.Syntax, variable, semanticModel)))
+            if (!ComputationLambdas.IsOverwrittenWithin(node, writes, readSite.Syntax, variable, semanticModel))
             {
                 handled &= InspectSurvivingWrite(context, classifier, node, variable, semanticModel, reported);
             }
@@ -251,7 +258,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<ISymbol> reported)
     {
         var resolvedValue = ResolveDelegateReference(value, semanticModel, argumentMap: null);
-        var methodReference = ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null);
+        var methodReference = ResolveMethodReference(resolvedValue, semanticModel);
         if (methodReference is not null)
         {
             InspectMethodGroupReceiver(context, classifier, methodReference, reported);
@@ -290,7 +297,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectPatchBody(context, classifier, patch, semanticModel, reported);
         }
 
-        return bodies.Count > 0 || accounted;
+        return accounted;
     }
 
     private static bool InspectAssembledPatchSources(
@@ -314,7 +321,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // rebind makes the global scan ambiguous, but cannot change what this call stored)
         // resolves to that write's value, walked like a surviving reassignment write.
         if (semanticModel is not null
-            && ReceiverSymbol(Unwrap(value)) is { } stepwise
+            && ComputationLambdas.ReferencedSymbol(Unwrap(value)) is { } stepwise
             && ComputationLambdas.EffectiveInitializerWrite(stepwise, semanticModel, Unwrap(value).Syntax) is AssignmentExpressionSyntax stepwiseWrite)
         {
             return InspectSurvivingWrite(context, classifier, stepwiseWrite, stepwise, semanticModel, reported);
@@ -328,12 +335,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // A same-tree computed get-only delegate PROPERTY resolves through its getter's
         // returns, like a delegate-returning helper: each return is walked as a patch body,
         // with unresolvable returns reported.
-        if (ReceiverSymbol(Unwrap(resolved)) is IPropertySymbol patchProperty
-            && !IsSettable(patchProperty) && !HasBackingStorage(patchProperty)
-            && patchProperty.GetMethod is { } patchGetter
-            && ComputationLambdas.ResolveMethodBody(patchGetter, semanticModel) is { } getterBody)
+        if (ComputedGetterBody(Unwrap(resolved), semanticModel) is { } computed)
         {
-            return InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, ComputationLambdas.BuildArgumentMap(Unwrap(resolved), outer: null), semanticModel, reported);
+            return InspectReturnedPatchBodies(context, classifier, computed.Body, computed.Property, ComputationLambdas.BuildArgumentMap(Unwrap(resolved), outer: null), semanticModel, reported);
         }
 
         // A patch produced by a same-tree delegate FACTORY -- called inline, or stored
@@ -355,7 +359,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<ISymbol> reported)
     {
         if (semanticModel is null
-            || ReceiverSymbol(Unwrap(value)) is not { } assembled
+            || ComputationLambdas.ReferencedSymbol(Unwrap(value)) is not { } assembled
             || ComputationLambdas.EffectiveInitializerWrite(assembled, semanticModel, Unwrap(value).Syntax) is not ArgumentSyntax outWrite)
         {
             return false;
@@ -379,13 +383,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<(IMethodSymbol, string)>? visitedFactories = null)
     {
         var accounted = false;
-        foreach (var inner in ComputationLambdas.DescendDirectExecution(methodBody.Body))
+        foreach (var returned in ComputationLambdas.ReturnedValues(methodBody.Body))
         {
-            if (inner is not IReturnOperation { ReturnedValue: { } returned })
-            {
-                continue;
-            }
-
             accounted = true;
             visitedFactories ??= new HashSet<(IMethodSymbol, string)>();
             InspectReturnedPatchValue(context, classifier, returned, subject, argumentMap, semanticModel, reported, visitedFactories);
@@ -405,10 +404,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<(IMethodSymbol, string)> visitedFactories)
     {
         var resolvedValue = ResolveDelegateReference(returned, semanticModel, argumentMap);
+        var returnedReference = ResolveMethodReference(resolvedValue, semanticModel);
 
         // A returned method group stores its RECEIVER in the delegate the overlay keeps,
         // exactly like a method-group patch argument.
-        if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { } returnedReference)
+        if (returnedReference is not null)
         {
             InspectMethodGroupReceiver(context, classifier, returnedReference, reported);
         }
@@ -433,17 +433,30 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        if (!resolvedAny
-            && ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is not { Method.DeclaringSyntaxReferences.Length: 0 })
+        if (!resolvedAny && returnedReference is not { Method.DeclaringSyntaxReferences.Length: 0 })
         {
             Report(
                 context,
                 returned,
                 subject,
                 subject.Name,
-                "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)",
+                UnresolvableReturnedDelegate,
                 reported);
         }
+    }
+
+    // A same-tree computed get-only delegate PROPERTY, with its walkable getter body: the
+    // one definition of "computed" this rule chases, instead of the predicate spelled out
+    // at each of the four sites that need it. Backing storage (an auto-property, metadata)
+    // and settable properties are deliberately excluded -- those keep the type verdict.
+    private static (IPropertySymbol Property, ComputationLambdas.ComputationBody Body)? ComputedGetterBody(IOperation reference, SemanticModel? semanticModel)
+    {
+        return ComputationLambdas.ReferencedVariable(reference) is IPropertySymbol property
+            && !IsSettable(property) && !HasBackingStorage(property)
+            && property.GetMethod is { } getter
+            && ComputationLambdas.ResolveMethodBody(getter, semanticModel) is { } body
+            ? (property, body)
+            : null;
     }
 
     // The invocation producing this patch value: the argument itself, or the variable's
@@ -455,7 +468,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return direct;
         }
 
-        return ReceiverSymbol(Unwrap(value)) is { } variable
+        return ComputationLambdas.ReferencedSymbol(Unwrap(value)) is { } variable
             && ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel) is { } initializer
             && Unwrap(initializer) is IInvocationOperation stored
             ? stored
@@ -469,7 +482,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        return ReceiverSymbol(Unwrap(value)) is { } source
+        return ComputationLambdas.ReferencedSymbol(Unwrap(value)) is { } source
             && ComputationLambdas.SameTreeInitializerOperation(source, semanticModel) is { } initializer
             && InspectConditionalArms(context, classifier, initializer, semanticModel, reported);
     }
@@ -481,23 +494,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        switch (Unwrap(value))
+        if (ComputationLambdas.ConditionalArms(Unwrap(value)) is not { } arms)
         {
-            case IConditionalOperation conditional:
-                InspectPatchArgument(context, classifier, conditional.WhenTrue, semanticModel, reported);
-                if (conditional.WhenFalse is { } whenFalse)
-                {
-                    InspectPatchArgument(context, classifier, whenFalse, semanticModel, reported);
-                }
-
-                return true;
-            case ICoalesceOperation coalesce:
-                InspectPatchArgument(context, classifier, coalesce.Value, semanticModel, reported);
-                InspectPatchArgument(context, classifier, coalesce.WhenNull, semanticModel, reported);
-                return true;
-            default:
-                return false;
+            return false;
         }
+
+        foreach (var arm in arms)
+        {
+            InspectPatchArgument(context, classifier, arm, semanticModel, reported);
+        }
+
+        return true;
     }
 
     // A method-group patch (`ctx.Apply(state, helper.Patch)`) captures its RECEIVER into the
@@ -514,7 +521,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var symbol = ReceiverSymbol(receiver);
+        var symbol = ComputationLambdas.ReferencedSymbol(receiver);
         var name = receiver is IInstanceReferenceOperation ? "this" : symbol?.Name ?? SendableSymbolClassifier.Display(receiverType);
         var reason = classifier.GetNotSendableReason(receiverType);
         if (reason is null)
@@ -553,11 +560,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // to computation bodies, so a `Func<int,int> patch = helper.Patch;` stored one statement
     // earlier does not hide the receiver. GetOperation on an initializer yields the reference
     // without the delegate-creation wrapper, hence the bare case.
-    private static IMethodReferenceOperation? ResolveMethodReference(
-        IOperation? value,
-        SemanticModel? semanticModel,
-        HashSet<ISymbol>? visitedVariables)
+    private static IMethodReferenceOperation? ResolveMethodReference(IOperation? value, SemanticModel? semanticModel)
     {
+        HashSet<ISymbol>? visitedVariables = null;
         while (true)
         {
             switch (value)
@@ -674,7 +679,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         var reference = Unwrap(value);
         HashSet<ISymbol>? visited = null;
-        while (ReceiverSymbol(reference) is (ILocalSymbol or IFieldSymbol or IPropertySymbol) and { } variable)
+        while (ComputationLambdas.ReferencedSymbol(reference) is (ILocalSymbol or IFieldSymbol or IPropertySymbol) and { } variable)
         {
             if (IsReassignedBefore(variable, reference, semanticModel))
             {
@@ -694,26 +699,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    // A local alias for the shared unwrap: this file names it ~35 times, and the qualified
+    // form would bury the expressions it appears inside.
     private static IOperation Unwrap(IOperation value)
     {
-        while (value is IConversionOperation conversion)
-        {
-            value = conversion.Operand;
-        }
-
-        return value;
-    }
-
-    private static ISymbol? ReceiverSymbol(IOperation receiver)
-    {
-        return receiver switch
-        {
-            ILocalReferenceOperation local => local.Local,
-            IParameterReferenceOperation parameter => parameter.Parameter,
-            IFieldReferenceOperation field => field.Field,
-            IPropertyReferenceOperation property => property.Property,
-            _ => null,
-        };
+        return ComputationLambdas.Unwrap(value);
     }
 
     private static void InspectCapture(
@@ -880,7 +870,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 yield return resolved;
                 break;
             case IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee }:
-                foreach (var body in ComputationLambdas.OfArgumentValue(ResolveConditionalReceiver(callee), semanticModel))
+                foreach (var body in ComputationLambdas.OfArgumentValue(ComputationLambdas.ResolveConditionalReceiver(callee), semanticModel))
                 {
                     yield return body;
                 }
@@ -1068,7 +1058,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
         {
-            InspectInvokedDelegate(context, classifier, ResolveConditionalReceiver(callee), semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            InspectInvokedDelegate(context, classifier, ComputationLambdas.ResolveConditionalReceiver(callee), semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             return;
         }
 
@@ -1237,7 +1227,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        var variable = ComputationLambdas.ReferencedVariable(unwrapped) ?? (unwrapped as IParameterReferenceOperation)?.Parameter;
+        var variable = ComputationLambdas.ReferencedSymbol(unwrapped);
         if (variable is not null && semanticModel is not null)
         {
             found |= ChaseAssignedDelegates(context, classifier, variable, resolved, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
@@ -1272,27 +1262,24 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
-        if (ComputationLambdas.ReferencedVariable(reference) is not IPropertySymbol property
-            || IsSettable(property) || HasBackingStorage(property)
-            || property.GetMethod is not { } getter
-            || ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } getterBody)
+        if (ComputedGetterBody(reference, semanticModel) is not { } computed)
         {
             return false;
         }
 
         var propertyMap = ComputationLambdas.BuildArgumentMap(reference, argumentMap);
-        if (!visitedCalls.Add((reference.Syntax, getter, ComputationLambdas.ArgumentMapKey(propertyMap))))
+        if (!visitedCalls.Add((reference.Syntax, computed.Property.GetMethod!, ComputationLambdas.ArgumentMapKey(propertyMap))))
         {
             return true;
         }
 
         var found = false;
-        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
+        // Chased, trusted, or reported -- either way a return is accounted for (a silent
+        // dead end like `return null` stays silent by design: nothing runs from it).
+        foreach (var returned in ComputationLambdas.ReturnedValues(computed.Body.Body))
         {
-            if (inner is IReturnOperation { ReturnedValue: { } returned })
-            {
-                found |= ChaseReturnCandidate(context, classifier, returned, semanticModel, visitedCalls, visitedInvokes, propertyMap, reported);
-            }
+            found = true;
+            ChaseReturnCandidate(context, classifier, returned, semanticModel, visitedCalls, visitedInvokes, propertyMap, reported);
         }
 
         return found;
@@ -1327,18 +1314,16 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         var found = false;
-        foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
+        foreach (var returned in ComputationLambdas.ReturnedValues(helper.Body))
         {
-            if (inner is IReturnOperation { ReturnedValue: { } returned })
-            {
-                found |= ChaseReturnCandidate(context, classifier, returned, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
-            }
+            found = true;
+            ChaseReturnCandidate(context, classifier, returned, semanticModel, visitedCalls, visitedInvokes, callMap, reported);
         }
 
         return found;
     }
 
-    private static bool ChaseReturnCandidate(
+    private static void ChaseReturnCandidate(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
         IOperation returned,
@@ -1367,14 +1352,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             ReportUnresolvedInvokedDelegate(
                 context,
                 resolved,
-                ComputationLambdas.ReferencedVariable(unwrapped) ?? (unwrapped as IParameterReferenceOperation)?.Parameter,
+                ComputationLambdas.ReferencedSymbol(unwrapped),
                 semanticModel,
                 reported);
         }
 
-        // Chased, trusted, or reported -- either way this return is accounted for (a silent
-        // dead end like `return null` stays silent by design: nothing runs from it).
-        return true;
     }
 
     // A resolved candidate VALUE that yields no walkable body can still be accounted for: a
@@ -1390,7 +1372,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
-        if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 })
+        if (ResolveMethodReference(resolvedValue, semanticModel) is { Method.DeclaringSyntaxReferences.Length: 0 })
         {
             return true;
         }
@@ -1409,23 +1391,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
-        switch (Unwrap(resolved))
+        if (ComputationLambdas.ConditionalArms(Unwrap(resolved)) is not { } arms)
         {
-            case IConditionalOperation conditional:
-                InspectInvokedDelegate(context, classifier, conditional.WhenTrue, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
-                if (conditional.WhenFalse is { } whenFalse)
-                {
-                    InspectInvokedDelegate(context, classifier, whenFalse, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
-                }
-
-                return true;
-            case ICoalesceOperation coalesce:
-                InspectInvokedDelegate(context, classifier, coalesce.Value, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
-                InspectInvokedDelegate(context, classifier, coalesce.WhenNull, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
-                return true;
-            default:
-                return false;
+            return false;
         }
+
+        foreach (var arm in arms)
+        {
+            InspectInvokedDelegate(context, classifier, arm, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+        }
+
+        return true;
     }
 
     // The invoked reference, collapsed through parameter-to-argument hops (the map) and
@@ -1433,49 +1409,19 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // consume directly (a lambda, a method group, a variable holding one) so no shape is
     // lost, and at any alias or parameter WRITTEN before its read -- there the assignment
     // scan owns the chase, and hopping past the write would resurrect a stale value.
+    // The shared alias collapse, with MZR004's own rebind rule: an alias link written before
+    // its read no longer proves what this call stored -- but the write that STANDS IN for a
+    // missing initializer is initialization, not a rebind.
     private static IOperation ResolveDelegateReference(
         IOperation callee,
         SemanticModel? semanticModel,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        var current = callee;
-        HashSet<ISymbol>? visited = null;
-        while (true)
-        {
-            if (Unwrap(current) is IParameterReferenceOperation rebound
-                && argumentMap?.ContainsKey(rebound.Parameter) == true
-                && ComputationLambdas.IsWrittenBefore(rebound.Parameter, current.Syntax, semanticModel))
-            {
-                return current;
-            }
-
-            if (ComputationLambdas.SubstituteArguments(current, argumentMap) is { } substituted
-                && !ReferenceEquals(substituted, current))
-            {
-                current = substituted;
-                continue;
-            }
-
-            if (ComputationLambdas.ReferencedVariable(Unwrap(current)) is not { } variable)
-            {
-                return current;
-            }
-
-            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-            var initializer = ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel);
-            if (!visited.Add(variable) || initializer is null || !IsReferenceHop(Unwrap(initializer))
-                || IsReassignedBefore(variable, current, semanticModel))
-            {
-                return current;
-            }
-
-            current = initializer;
-        }
-    }
-
-    private static bool IsReferenceHop(IOperation operation)
-    {
-        return operation is IParameterReferenceOperation || ComputationLambdas.ReferencedVariable(operation) is not null;
+        return ComputationLambdas.ResolveDelegateValue(
+            callee,
+            semanticModel,
+            argumentMap,
+            (variable, at) => IsReassignedBefore(variable, at, semanticModel));
     }
 
     // An invoked delegate resolving to NOTHING walkable -- assembled by an out-helper in
@@ -1492,14 +1438,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         if (variable is not null)
         {
-            if (ResolveMethodReference(resolved, semanticModel, visitedVariables: null) is not { Method.DeclaringSyntaxReferences.Length: 0 })
+            if (ResolveMethodReference(resolved, semanticModel) is not { Method.DeclaringSyntaxReferences.Length: 0 })
             {
                 Report(
                     context,
                     resolved,
                     variable,
                     variable.Name,
-                    "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                    UnresolvableHeldDelegate,
                     reported);
             }
 
@@ -1513,18 +1459,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 resolved,
                 sourceMethod,
                 sourceMethod.Name,
-                "the delegate it returns cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (return a lambda or a method declared in this file)",
+                UnresolvableReturnedDelegate,
                 reported);
         }
     }
 
     // `later?.Invoke()` surfaces the invoke receiver as the conditional-access placeholder;
     // the real delegate expression is the enclosing conditional access's Operation.
-    private static IOperation ResolveConditionalReceiver(IOperation callee)
-    {
-        return ComputationLambdas.ResolveConditionalReceiver(callee);
-    }
-
     // A delegate assembled by ASSIGNMENT (`Func<int> later; later = () => hits;`, including
     // through deconstruction or an out-helper) has no initializer to resolve, so every
     // same-tree write that can EXECUTE before the invocation is a CANDIDATE -- and each
@@ -1559,7 +1500,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         {
             // A later straight-line simple assignment on the path to the invoke REPLACES the
             // value: the earlier write's body can never be the one invoked.
-            if (writes.Any(other => other != node && ComputationLambdas.DefinitelyOverwrites(other, node, invokeSite, variable, semanticModel)))
+            if (ComputationLambdas.IsOverwrittenWithin(node, writes, invokeSite, variable, semanticModel))
             {
                 continue;
             }
@@ -1572,7 +1513,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                     writeOperation,
                     variable,
                     variable.Name,
-                    "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                    UnresolvableHeldDelegate,
                     reported);
             }
 
@@ -1604,7 +1545,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             }
 
-            return bodies.Count > 0 || accounted;
+            return accounted;
         }
 
         var resolvedAny = false;
@@ -1767,7 +1708,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         var candidates = writes.Concat<SyntaxNode>(handoffs).ToList();
         foreach (var assignment in writes)
         {
-            if (IsOverwrittenWithin(assignment, candidates, helper.Scope, parameter, semanticModel))
+            if (ComputationLambdas.IsOverwrittenWithin(assignment, candidates, helper.Scope, parameter, semanticModel))
             {
                 continue;
             }
@@ -1780,7 +1721,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // one helper deeper: chased recursively, with an unaccounted chain reported here.
         foreach (var forwarded in handoffs)
         {
-            if (IsOverwrittenWithin(forwarded, candidates, helper.Scope, parameter, semanticModel))
+            if (ComputationLambdas.IsOverwrittenWithin(forwarded, candidates, helper.Scope, parameter, semanticModel))
             {
                 continue;
             }
@@ -1790,11 +1731,6 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         return (bodies, assigned);
-    }
-
-    private static bool IsOverwrittenWithin(SyntaxNode write, List<SyntaxNode> candidates, SyntaxNode scope, ISymbol variable, SemanticModel semanticModel)
-    {
-        return candidates.Any(other => other != write && ComputationLambdas.DefinitelyOverwrites(other, write, scope, variable, semanticModel));
     }
 
     private static List<ArgumentSyntax> ForwardedHandoffs(SyntaxNode scope, IParameterSymbol parameter, SemanticModel semanticModel)
@@ -1841,7 +1777,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 writeOperation,
                 parameter,
                 parameter.Name,
-                "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                UnresolvableHeldDelegate,
                 reported);
         }
     }
@@ -1867,7 +1803,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 forwardOperation,
                 parameter,
                 parameter.Name,
-                "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                UnresolvableHeldDelegate,
                 reported);
         }
     }
@@ -1889,7 +1825,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         // A method-group value stores its RECEIVER in the handed-back delegate, exactly
         // like a method-group patch argument.
-        if (ResolveMethodReference(resolvedValue, semanticModel, visitedVariables: null) is { } assignedReference)
+        if (ResolveMethodReference(resolvedValue, semanticModel) is { } assignedReference)
         {
             InspectMethodGroupReceiver(context, classifier, assignedReference, reported);
         }
@@ -1905,7 +1841,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 writeOperation,
                 parameter,
                 parameter.Name,
-                "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+                UnresolvableHeldDelegate,
                 reported);
         }
     }
@@ -1981,6 +1917,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
+        // Every branch below dedupes on this symbol, so a repeat reference can only redo
+        // the (whole-tree) resolutions to reach the same no-op: ask first.
+        if (reported.Contains(symbol))
+        {
+            return;
+        }
+
         if (IsMutableStruct(type))
         {
             Report(
@@ -2018,21 +1961,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
     private static bool CapturedDelegateArmsResolve(IOperation value, SemanticModel? semanticModel)
     {
-        switch (Unwrap(value))
+        if (ComputationLambdas.ConditionalArms(Unwrap(value)) is { } arms)
         {
-            case IConditionalOperation conditional:
-                return CapturedDelegateArmsResolve(conditional.WhenTrue, semanticModel)
-                    && conditional.WhenFalse is { } whenFalse
-                    && CapturedDelegateArmsResolve(whenFalse, semanticModel);
-            case ICoalesceOperation coalesce:
-                return CapturedDelegateArmsResolve(coalesce.Value, semanticModel)
-                    && CapturedDelegateArmsResolve(coalesce.WhenNull, semanticModel);
-            default:
-                return ComputationLambdas.OfArgumentValue(value, semanticModel).Any()
-                    || ResolveMethodReference(value, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 }
-                    || CapturedFactoryReturnsResolve(value, semanticModel)
-                    || CapturedPropertyReturnsResolve(value, semanticModel);
+            return arms.All(arm => CapturedDelegateArmsResolve(arm, semanticModel));
         }
+
+        return ComputationLambdas.OfArgumentValue(value, semanticModel).Any()
+            || ResolveMethodReference(value, semanticModel) is { Method.DeclaringSyntaxReferences.Length: 0 }
+            || CapturedFactoryReturnsResolve(value, semanticModel)
+            || CapturedPropertyReturnsResolve(value, semanticModel);
     }
 
     // A captured delegate BUILT by a same-tree factory (`var d = Safe();`) stores whatever
@@ -2050,11 +1987,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // returned-body resolution, sourced from the accessor.
     private static bool CapturedPropertyReturnsResolve(IOperation value, SemanticModel? semanticModel)
     {
-        return ComputationLambdas.ReferencedVariable(Unwrap(value)) is IPropertySymbol property
-            && !IsSettable(property) && !HasBackingStorage(property)
-            && property.GetMethod is { } getter
-            && ComputationLambdas.ResolveMethodBody(getter, semanticModel) is { } getterBody
-            && ComputationLambdas.ReturnedBodies(getterBody, semanticModel, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null)).Any();
+        return ComputedGetterBody(Unwrap(value), semanticModel) is { } computed
+            && ComputationLambdas.ReturnedBodies(computed.Body, semanticModel, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null)).Any();
     }
 
     private static void WalkCapturedDelegateArms(
@@ -2064,25 +1998,19 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
-        switch (Unwrap(value))
+        if (ComputationLambdas.ConditionalArms(Unwrap(value)) is { } arms)
         {
-            case IConditionalOperation conditional:
-                WalkCapturedDelegateArms(context, classifier, conditional.WhenTrue, semanticModel, reported);
-                if (conditional.WhenFalse is { } whenFalse)
-                {
-                    WalkCapturedDelegateArms(context, classifier, whenFalse, semanticModel, reported);
-                }
+            foreach (var arm in arms)
+            {
+                WalkCapturedDelegateArms(context, classifier, arm, semanticModel, reported);
+            }
 
-                return;
-            case ICoalesceOperation coalesce:
-                WalkCapturedDelegateArms(context, classifier, coalesce.Value, semanticModel, reported);
-                WalkCapturedDelegateArms(context, classifier, coalesce.WhenNull, semanticModel, reported);
-                return;
+            return;
         }
 
         // A method-group candidate already CAPTURED its receiver: the stored patch shares
         // it across flows even when the target body itself is safe.
-        if (ResolveMethodReference(value, semanticModel, visitedVariables: null) is { } methodReference)
+        if (ResolveMethodReference(value, semanticModel) is { } methodReference)
         {
             InspectMethodGroupReceiver(context, classifier, methodReference, reported);
         }
@@ -2103,12 +2031,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         // The computed-property candidate: the getter's returns, with the same accounting.
-        if (!resolvedAny && ComputationLambdas.ReferencedVariable(Unwrap(value)) is IPropertySymbol patchProperty
-            && !IsSettable(patchProperty) && !HasBackingStorage(patchProperty)
-            && patchProperty.GetMethod is { } propertyGetter
-            && ComputationLambdas.ResolveMethodBody(propertyGetter, semanticModel) is { } propertyBody)
+        if (!resolvedAny && ComputedGetterBody(Unwrap(value), semanticModel) is { } computed)
         {
-            InspectReturnedPatchBodies(context, classifier, propertyBody, patchProperty, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null), semanticModel, reported);
+            InspectReturnedPatchBodies(context, classifier, computed.Body, computed.Property, ComputationLambdas.BuildArgumentMap(Unwrap(value), outer: null), semanticModel, reported);
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -652,11 +652,53 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var body in ComputationLambdas.OfArgumentValue(callee, semanticModel))
         {
-            foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
+            ChaseExecutedBody(context, classifier, body, semanticModel, visited, reported);
+        }
+
+        if (variable is null || semanticModel is null)
+        {
+            return;
+        }
+
+        foreach (var body in AssignedDelegateBodies(variable, semanticModel))
+        {
+            ChaseExecutedBody(context, classifier, body, semanticModel, visited, reported);
+        }
+    }
+
+    // A delegate assembled by ASSIGNMENT (`Func<int> later; later = () => hits;`) has no
+    // initializer to resolve, so every same-tree assignment's right-hand side is a body that
+    // might be the one invoked -- all of them are chased.
+    private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(ISymbol variable, SemanticModel semanticModel)
+    {
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (node is not AssignmentExpressionSyntax assignment
+                || !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, variable)
+                || semanticModel.GetOperation(assignment.Right) is not { } assigned)
             {
-                InspectStaticRead(context, classifier, inner, reported);
-                InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+                continue;
             }
+
+            foreach (var body in ComputationLambdas.OfArgumentValue(assigned, semanticModel))
+            {
+                yield return body;
+            }
+        }
+    }
+
+    private static void ChaseExecutedBody(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        ComputationLambdas.ComputationBody body,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> visited,
+        HashSet<ISymbol> reported)
+    {
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
+        {
+            InspectStaticRead(context, classifier, inner, reported);
+            InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -221,9 +221,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            if (ReassignmentTargets(node) is { } targets
+            if (ComputationLambdas.ReassignmentTargets(node) is { } targets
                 && targets.Any(target => WritesVariable(target, variable, semanticModel))
-                && CanExecuteBefore(node, reference, variable))
+                && ComputationLambdas.CanExecuteBefore(node, reference, variable))
             {
                 return true;
             }
@@ -302,103 +302,6 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
             symbol = semanticModel.GetSymbolInfo(referent).Symbol;
         }
-    }
-
-    // The expressions a node writes: an assignment's left-hand side (deconstruction tuples
-    // flattened, nesting included -- `(patch, _) = ...` writes `patch`) or a ref/out argument.
-    private static IEnumerable<ExpressionSyntax>? ReassignmentTargets(SyntaxNode node)
-    {
-        return node switch
-        {
-            AssignmentExpressionSyntax assignment => FlattenTargets(assignment.Left),
-            // `in` is excluded: a readonly reference cannot rebind the variable.
-            ArgumentSyntax argument when argument.RefOrOutKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword
-                => new[] { argument.Expression },
-            _ => null,
-        };
-    }
-
-    private static IEnumerable<ExpressionSyntax> FlattenTargets(ExpressionSyntax left)
-    {
-        if (left is not TupleExpressionSyntax tuple)
-        {
-            yield return left;
-            yield break;
-        }
-
-        foreach (var element in tuple.Arguments)
-        {
-            foreach (var nested in FlattenTargets(element.Expression))
-            {
-                yield return nested;
-            }
-        }
-    }
-
-    // Execution-order reasoning without dataflow: an assignment in a DIFFERENT function body
-    // (a helper, a lambda, another method) runs whenever that function does -- unknowable, so
-    // it counts. In the same function, one textually before the call obviously precedes it,
-    // and one textually after still reaches the call when a loop encloses both (the next
-    // iteration passes the reassigned delegate).
-    private static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference, ISymbol variable)
-    {
-        if (!ReferenceEquals(EnclosingFunction(assignment), EnclosingFunction(reference)))
-        {
-            return true;
-        }
-
-        if (assignment.SpanStart < reference.SpanStart)
-        {
-            return true;
-        }
-
-        for (var current = assignment.Parent; current is not null; current = current.Parent)
-        {
-            // Loop-carried only when the variable OUTLIVES the iteration: a delegate local
-            // declared inside the loop body is freshly initialized each pass, so a trailing
-            // reassignment dies with its iteration and can never reach a call.
-            if (current is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax
-                && current.Span.Contains(reference.Span)
-                && !DeclaredWithin(variable, current))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    // Only the loop BODY re-declares per iteration: a variable in a for-INITIALIZER is
-    // declared once and carries across iterations like one declared before the loop.
-    private static bool DeclaredWithin(ISymbol variable, SyntaxNode loop)
-    {
-        var body = loop switch
-        {
-            ForStatementSyntax @for => (SyntaxNode)@for.Statement,
-            ForEachStatementSyntax forEach => forEach.Statement,
-            WhileStatementSyntax @while => @while.Statement,
-            DoStatementSyntax @do => @do.Statement,
-            _ => loop,
-        };
-
-        var declaration = variable.DeclaringSyntaxReferences.FirstOrDefault();
-        return declaration is not null
-            && declaration.SyntaxTree == body.SyntaxTree
-            && body.Span.Contains(declaration.Span);
-    }
-
-    private static SyntaxNode? EnclosingFunction(SyntaxNode node)
-    {
-        for (var current = node.Parent; current is not null; current = current.Parent)
-        {
-            if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
-                or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or ArrowExpressionClauseSyntax)
-            {
-                return current;
-            }
-        }
-
-        return null;
     }
 
     private static IOperation Unwrap(IOperation value)
@@ -666,24 +569,49 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // A delegate assembled by ASSIGNMENT (`Func<int> later; later = () => hits;`) has no
-    // initializer to resolve, so every same-tree assignment's right-hand side is a body that
-    // might be the one invoked -- all of them are chased.
+    // A delegate assembled by ASSIGNMENT (`Func<int> later; later = () => hits;`, including
+    // through deconstruction: `(later, _) = (() => hits, 0)`) has no initializer to resolve,
+    // so every same-tree assignment's right-hand side is a body that might be the one invoked
+    // -- all of them are chased, tuple elements included.
     private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(ISymbol variable, SemanticModel semanticModel)
     {
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (node is not AssignmentExpressionSyntax assignment
-                || !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, variable)
-                || semanticModel.GetOperation(assignment.Right) is not { } assigned)
+                || ComputationLambdas.ReassignmentTargets(assignment) is not { } targets
+                || !targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable)))
             {
                 continue;
             }
 
-            foreach (var body in ComputationLambdas.OfArgumentValue(assigned, semanticModel))
+            foreach (var value in RightHandValues(assignment.Right, semanticModel))
             {
-                yield return body;
+                foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
+                {
+                    yield return body;
+                }
             }
+        }
+    }
+
+    private static IEnumerable<IOperation> RightHandValues(ExpressionSyntax right, SemanticModel semanticModel)
+    {
+        if (right is TupleExpressionSyntax tuple)
+        {
+            foreach (var element in tuple.Arguments)
+            {
+                foreach (var value in RightHandValues(element.Expression, semanticModel))
+                {
+                    yield return value;
+                }
+            }
+
+            yield break;
+        }
+
+        if (semanticModel.GetOperation(right) is { } operation)
+        {
+            yield return operation;
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -430,7 +430,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        foreach (var inner in ComputationLambdas.Descend(body.Body))
+        // Direct execution only: the getter body is EXECUTED code, not stored closure -- a
+        // callback it builds and discards is allocated fresh per replay and never runs, so
+        // its captures must not count (unlike the patch's own nested callbacks, which the
+        // stored display chain pins).
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
         {
             InspectCapture(context, classifier, inner, body.Scope, patchScope, semanticModel, reported, visitedGetters);
         }
@@ -706,7 +710,9 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(left).Symbol, variable)
+        // WritesVariable, not plain symbol equality: an assignment through a ref alias
+        // (`ref var alias = ref later; alias = () => hits;`) rebinds the delegate too.
+        if (ComputationLambdas.WritesVariable(left, variable, semanticModel)
             && semanticModel.GetOperation(right) is { } operation)
         {
             yield return operation;

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -207,12 +207,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // Any assignment beyond the declaration initializer (including a ref/out handoff) that can
-    // EXECUTE before this call: a same-tree syntactic scan, so a reassignment in another file
-    // is residual risk like every same-tree-only resolution here. A later straight-line
-    // assignment cannot change the delegate this call already stored -- flagging it would
-    // punish the common rebind-after-use.
-    private static bool IsReassignedBefore(ISymbol variable, SyntaxNode reference, SemanticModel? semanticModel)
+    // Any assignment beyond the declaration initializer (including a ref/out handoff, or a
+    // write through a ref alias) that can EXECUTE before this READ: a same-tree syntactic
+    // scan, so a reassignment in another file is residual risk like every same-tree-only
+    // resolution here. A later straight-line assignment cannot change the delegate this call
+    // already stored -- flagging it would punish the common rebind-after-use.
+    private static bool IsReassignedBefore(ISymbol variable, IOperation readReference, SemanticModel? semanticModel)
     {
         if (semanticModel is null)
         {
@@ -222,14 +222,57 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (ComputationLambdas.ReassignmentTargets(node) is { } targets
-                && targets.Any(target => WritesVariable(target, variable, semanticModel))
-                && ComputationLambdas.CanExecuteBefore(node, reference, variable))
+                && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel)
+                    && WritesReadInstance(target, variable, readReference, semanticModel))
+                && ComputationLambdas.CanExecuteBefore(node, readReference.Syntax, variable))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // A write through a local that provably holds a DIFFERENT instance (initialized with its
+    // own `new`) cannot rebind the member being read through some other receiver:
+    // `other.patch = evil;` says nothing about `this.patch`. Approximation: the receiver's
+    // fresh initializer is the proof; a receiver later re-aliased to the read instance is
+    // accepted residual risk.
+    private static bool WritesReadInstance(ExpressionSyntax target, ISymbol variable, IOperation readReference, SemanticModel semanticModel)
+    {
+        if (variable is not (IFieldSymbol or IPropertySymbol)
+            || target is not MemberAccessExpressionSyntax { Expression: { } receiverExpression })
+        {
+            return true;
+        }
+
+        if (semanticModel.GetSymbolInfo(receiverExpression).Symbol is not ILocalSymbol receiver
+            || !IsFreshInstance(receiver)
+            || IsReceiverOf(readReference, receiver))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsFreshInstance(ILocalSymbol local)
+    {
+        return local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+            is VariableDeclaratorSyntax { Initializer.Value: BaseObjectCreationExpressionSyntax };
+    }
+
+    private static bool IsReceiverOf(IOperation readReference, ILocalSymbol receiver)
+    {
+        var instance = Unwrap(readReference) switch
+        {
+            IFieldReferenceOperation field => field.Instance,
+            IPropertyReferenceOperation property => property.Instance,
+            _ => null,
+        };
+
+        return instance is not null
+            && SymbolEqualityComparer.Default.Equals(ComputationLambdas.ReferencedVariable(Unwrap(instance)), receiver);
     }
 
     // The reassignment check applies to EVERY variable in the alias chain, each against the
@@ -239,11 +282,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     private static ISymbol? FindReassignedLink(IOperation value, SemanticModel? semanticModel)
     {
         var reference = Unwrap(value);
-        var site = value.Syntax;
         HashSet<ISymbol>? visited = null;
         while (ReceiverSymbol(reference) is (ILocalSymbol or IFieldSymbol or IPropertySymbol) and { } variable)
         {
-            if (IsReassignedBefore(variable, site, semanticModel))
+            if (IsReassignedBefore(variable, reference, semanticModel))
             {
                 return variable;
             }
@@ -255,53 +297,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 return null;
             }
 
-            site = initializer.Syntax;
             reference = Unwrap(initializer);
         }
 
         return null;
-    }
-
-    // A ref-local ALIAS writes its referent: `ref var alias = ref patch; alias = ...` rebinds
-    // patch just as directly. The alias chain resolves through `= ref` initializers; the
-    // visited set breaks alias cycles.
-    private static bool WritesVariable(ExpressionSyntax target, ISymbol variable, SemanticModel semanticModel)
-    {
-        var symbol = semanticModel.GetSymbolInfo(target).Symbol;
-        HashSet<ISymbol>? visited = null;
-        while (true)
-        {
-            if (symbol is null)
-            {
-                return false;
-            }
-
-            if (SymbolEqualityComparer.Default.Equals(symbol, variable))
-            {
-                return true;
-            }
-
-            if (symbol is not ILocalSymbol { RefKind: RefKind.Ref })
-            {
-                return false;
-            }
-
-            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-            if (!visited.Add(symbol))
-            {
-                return false;
-            }
-
-            if (symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is not VariableDeclaratorSyntax
-                {
-                    Initializer.Value: RefExpressionSyntax { Expression: { } referent }
-                })
-            {
-                return false;
-            }
-
-            symbol = semanticModel.GetSymbolInfo(referent).Symbol;
-        }
     }
 
     private static IOperation Unwrap(IOperation value)
@@ -405,9 +404,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                     writable: !staticField.Field.IsReadOnly, "it is writable static state", reported);
                 break;
             case IPropertyReferenceOperation { Property.IsStatic: true } staticProperty:
-                InspectStateRead(
-                    context, classifier, operation, staticProperty.Property, staticProperty.Property.Type,
-                    writable: IsSettable(staticProperty.Property), "it is writable static state", reported);
+                InspectStaticProperty(context, classifier, operation, staticProperty.Property, reported);
                 break;
 
             // An event's backing delegate is writable storage by construction: any subscriber
@@ -419,6 +416,39 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                     "it is writable static state (subscribing mutates the event's backing delegate)", reported);
                 break;
         }
+    }
+
+    private static void InspectStaticProperty(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        IPropertySymbol property,
+        HashSet<ISymbol> reported)
+    {
+        if (IsSettable(property))
+        {
+            Report(context, operation, property, property.Name, "it is writable static state", reported);
+            return;
+        }
+
+        // Only BACKING STORAGE holds a shared object: a computed getter may hand out a fresh
+        // value on every replay (`static List<int> Items => new();`), and what it actually
+        // returns is covered by the executed chase walking its body. Auto-properties and
+        // metadata properties (no walkable body) keep the type verdict.
+        if (HasBackingStorage(property))
+        {
+            ReportIfNotSendable(context, classifier, operation, property, property.Type, reported);
+        }
+    }
+
+    private static bool HasBackingStorage(IPropertySymbol property)
+    {
+        return property.GetMethod?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() switch
+        {
+            AccessorDeclarationSyntax { Body: null, ExpressionBody: null } => true, // auto-property
+            null => true,                                                          // metadata: unwalkable
+            _ => false,                                                            // computed: chased instead
+        };
     }
 
     // Two walks with different reach. Closure CONTENTS (captures, receivers, `this`) are
@@ -496,7 +526,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
         {
-            InspectInvokedDelegate(context, classifier, callee, semanticModel, visited, reported);
+            InspectInvokedDelegate(context, classifier, ResolveConditionalReceiver(callee), semanticModel, visited, reported);
             return;
         }
 
@@ -563,28 +593,46 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        foreach (var body in AssignedDelegateBodies(variable, semanticModel))
+        foreach (var body in AssignedDelegateBodies(variable, callee.Syntax, semanticModel))
         {
             ChaseExecutedBody(context, classifier, body, semanticModel, visited, reported);
         }
     }
 
+    // `later?.Invoke()` surfaces the invoke receiver as the conditional-access placeholder;
+    // the real delegate expression is the enclosing conditional access's Operation.
+    private static IOperation ResolveConditionalReceiver(IOperation callee)
+    {
+        if (callee is IConditionalAccessInstanceOperation placeholder)
+        {
+            for (var current = placeholder.Parent; current is not null; current = current.Parent)
+            {
+                if (current is IConditionalAccessOperation conditional)
+                {
+                    return conditional.Operation;
+                }
+            }
+        }
+
+        return callee;
+    }
+
     // A delegate assembled by ASSIGNMENT (`Func<int> later; later = () => hits;`, including
-    // through deconstruction: `(later, _) = (() => hits, 0)`) has no initializer to resolve,
-    // so every same-tree assignment's right-hand side is a body that might be the one invoked
-    // -- all of them are chased, tuple elements included.
-    private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(ISymbol variable, SemanticModel semanticModel)
+    // through deconstruction) has no initializer to resolve, so every same-tree assignment's
+    // right-hand side that can EXECUTE before the invocation is a body that might be the one
+    // invoked. Deconstructions pair positionally: `(other, later) = (a, b)` assigns only `b`
+    // to `later`, so `a` must not be chased.
+    private static IEnumerable<ComputationLambdas.ComputationBody> AssignedDelegateBodies(ISymbol variable, SyntaxNode invokeSite, SemanticModel semanticModel)
     {
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (node is not AssignmentExpressionSyntax assignment
-                || ComputationLambdas.ReassignmentTargets(assignment) is not { } targets
-                || !targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable)))
+                || !ComputationLambdas.CanExecuteBefore(assignment, invokeSite, variable))
             {
                 continue;
             }
 
-            foreach (var value in RightHandValues(assignment.Right, semanticModel))
+            foreach (var value in AssignedValuesFor(assignment.Left, assignment.Right, variable, semanticModel))
             {
                 foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
                 {
@@ -594,13 +642,14 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static IEnumerable<IOperation> RightHandValues(ExpressionSyntax right, SemanticModel semanticModel)
+    private static IEnumerable<IOperation> AssignedValuesFor(ExpressionSyntax left, ExpressionSyntax right, ISymbol variable, SemanticModel semanticModel)
     {
-        if (right is TupleExpressionSyntax tuple)
+        if (left is TupleExpressionSyntax leftTuple && right is TupleExpressionSyntax rightTuple
+            && leftTuple.Arguments.Count == rightTuple.Arguments.Count)
         {
-            foreach (var element in tuple.Arguments)
+            for (var i = 0; i < leftTuple.Arguments.Count; i++)
             {
-                foreach (var value in RightHandValues(element.Expression, semanticModel))
+                foreach (var value in AssignedValuesFor(leftTuple.Arguments[i].Expression, rightTuple.Arguments[i].Expression, variable, semanticModel))
                 {
                     yield return value;
                 }
@@ -609,7 +658,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        if (semanticModel.GetOperation(right) is { } operation)
+        if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(left).Symbol, variable)
+            && semanticModel.GetOperation(right) is { } operation)
         {
             yield return operation;
         }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -85,7 +85,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         if (value.Type is { TypeKind: TypeKind.Delegate }
             && ReceiverSymbol(Unwrap(value)) is { } variable
             && variable is ILocalSymbol or IFieldSymbol or IPropertySymbol
-            && IsReassigned(variable, semanticModel))
+            && IsReassignedBefore(variable, value.Syntax, semanticModel))
         {
             Report(
                 context,
@@ -215,10 +215,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // Any assignment beyond the declaration initializer, anywhere in the tree (including a
-    // ref/out handoff): a same-tree syntactic scan, so a reassignment in another file is
-    // residual risk like every same-tree-only resolution here.
-    private static bool IsReassigned(ISymbol variable, SemanticModel? semanticModel)
+    // Any assignment beyond the declaration initializer (including a ref/out handoff) that can
+    // EXECUTE before this call: a same-tree syntactic scan, so a reassignment in another file
+    // is residual risk like every same-tree-only resolution here. A later straight-line
+    // assignment cannot change the delegate this call already stored -- flagging it would
+    // punish the common rebind-after-use.
+    private static bool IsReassignedBefore(ISymbol variable, SyntaxNode reference, SemanticModel? semanticModel)
     {
         if (semanticModel is null)
         {
@@ -235,13 +237,57 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             };
 
             if (target is not null
-                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable))
+                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable)
+                && CanExecuteBefore(node, reference))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // Execution-order reasoning without dataflow: an assignment in a DIFFERENT function body
+    // (a helper, a lambda, another method) runs whenever that function does -- unknowable, so
+    // it counts. In the same function, one textually before the call obviously precedes it,
+    // and one textually after still reaches the call when a loop encloses both (the next
+    // iteration passes the reassigned delegate).
+    private static bool CanExecuteBefore(SyntaxNode assignment, SyntaxNode reference)
+    {
+        if (!ReferenceEquals(EnclosingFunction(assignment), EnclosingFunction(reference)))
+        {
+            return true;
+        }
+
+        if (assignment.SpanStart < reference.SpanStart)
+        {
+            return true;
+        }
+
+        for (var current = assignment.Parent; current is not null; current = current.Parent)
+        {
+            if (current is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax
+                && current.Span.Contains(reference.Span))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static SyntaxNode? EnclosingFunction(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
+                or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or ArrowExpressionClauseSyntax)
+            {
+                return current;
+            }
+        }
+
+        return null;
     }
 
     private static IOperation Unwrap(IOperation value)
@@ -496,7 +542,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         string problem,
         HashSet<ISymbol> reported)
     {
-        if (!reported.Add(dedupeKey))
+        if (IsInsideNameOf(operation) || !reported.Add(dedupeKey))
         {
             return;
         }
@@ -506,5 +552,21 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             operation.Syntax.GetLocation(),
             name,
             problem));
+    }
+
+    // A symbol used only inside nameof() is a compile-time string: the built delegate neither
+    // captures nor reads it, so nothing crosses flows. Checked at the single report choke
+    // point (before the dedupe add, so a real use elsewhere still reports).
+    private static bool IsInsideNameOf(IOperation operation)
+    {
+        for (var current = operation.Parent; current is not null; current = current.Parent)
+        {
+            if (current is INameOfOperation)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -530,37 +530,28 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Only what EXECUTES is chased: a call; a property READ, which runs its getter exactly
-        // like a call (`static int Hits => hits;` is the helper-method evasion with property
-        // syntax); a constructor; or a user-defined operator/conversion -- each runs on every
-        // replay of the stored patch. A method group the patch stores builds a delegate
-        // without running it -- the same deferred shape as a built lambda, which this walk
-        // already prunes. (The capture chase above keeps method references: a lifted local
-        // function's closure is pinned either way.)
-        var method = operation switch
-        {
-            IInvocationOperation invocation => invocation.TargetMethod,
-            IPropertyReferenceOperation property => property.Property.GetMethod,
-            IObjectCreationOperation creation => creation.Constructor,
-            IBinaryOperation { OperatorMethod: { } binaryOperator } => binaryOperator,
-            IUnaryOperation { OperatorMethod: { } unaryOperator } => unaryOperator,
-            IConversionOperation { OperatorMethod: { } conversionOperator } => conversionOperator,
-            _ => null,
-        };
-
-        // The nameof check runs BEFORE the visited add: a property mentioned only in nameof is
+        // Only what EXECUTES is chased -- calls, property accessors by usage (an assignment
+        // target runs the SETTER, where a hidden static read replays too), constructors,
+        // user-defined operators -- each runs on every replay of the stored patch. A method
+        // group the patch stores builds a delegate without running it -- the same deferred
+        // shape as a built lambda, which this walk already prunes. (The capture chase above
+        // keeps method references: a lifted local function's closure is pinned either way.
+        // The nameof check runs BEFORE the visited add: a member mentioned only in nameof is
         // neither executed nor captured, and it must not poison the visited set for a later
-        // real read of the same member.
-        if (method is null || ComputationLambdas.IsInsideNameOf(operation) || !visited.Add(method)
-            || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+        // real use.)
+        foreach (var method in ComputationLambdas.ExecutedMethods(operation))
         {
-            return;
-        }
+            if (ComputationLambdas.IsInsideNameOf(operation) || !visited.Add(method)
+                || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
+            {
+                continue;
+            }
 
-        foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
-        {
-            InspectStaticRead(context, classifier, inner, reported);
-            InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+            foreach (var inner in ComputationLambdas.DescendDirectExecution(helper.Body))
+            {
+                InspectStaticRead(context, classifier, inner, reported);
+                InspectExecutedHelper(context, classifier, inner, semanticModel, visited, reported);
+            }
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -279,6 +279,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             resolvedAny = InspectReturnedPatchBodies(context, classifier, factoryBody, factoryCall.TargetMethod, ComputationLambdas.BuildArgumentMap(factoryCall, outer: null), semanticModel, reported);
         }
 
+        // A surviving write can store a computed PROPERTY's delegate too (`patch = Safe;`):
+        // its getter returns are the stored closure, like any other patch source.
+        if (!resolvedAny && ComputedGetterBody(Unwrap(resolvedValue), semanticModel) is { } computed)
+        {
+            resolvedAny = InspectReturnedPatchBodies(context, classifier, computed.Body, computed.Property, ComputationLambdas.BuildArgumentMap(Unwrap(resolvedValue), outer: null), semanticModel, reported);
+        }
+
         return resolvedAny || methodReference is { Method.DeclaringSyntaxReferences.Length: 0 };
     }
 
@@ -417,7 +424,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         foreach (var patch in ComputationLambdas.OfArgumentValue(resolvedValue, semanticModel))
         {
             resolvedAny = true;
-            InspectPatchBody(context, classifier, patch, semanticModel, reported);
+            InspectPatchBody(context, classifier, patch, semanticModel, reported, argumentMap);
         }
 
         // `return Make();` assembles one factory deeper: the nested call's returns get this
@@ -714,15 +721,23 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SyntaxNode patchScope,
         SemanticModel? semanticModel,
         HashSet<ISymbol> reported,
-        HashSet<IMethodSymbol>? visitedGetters = null)
+        HashSet<IMethodSymbol>? visitedGetters = null,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
         switch (operation)
         {
             case ILocalReferenceOperation local when IsSharedCapture(local.Local, scope, patchScope):
                 ReportCapturedVariable(context, classifier, operation, local.Local, local.Local.Type, semanticModel, reported);
                 break;
+            // A factory PARAMETER captured by the returned patch holds the CALL-SITE value:
+            // `Make<T>(T p) => x => p.GetHashCode()` stores whatever `Make(new List<int>())`
+            // handed in, so the argument's type is what must be Sendable -- the declared one
+            // can be a type parameter the classifier would wave through.
             case IParameterReferenceOperation parameter when IsSharedCapture(parameter.Parameter, scope, patchScope):
-                ReportCapturedVariable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, semanticModel, reported);
+                var captured = ComputationLambdas.MappedValue(argumentMap, parameter.Parameter) is { } handed
+                    ? ComputationLambdas.Unwrap(handed).Type ?? parameter.Parameter.Type
+                    : parameter.Parameter.Type;
+                ReportCapturedVariable(context, classifier, operation, parameter.Parameter, captured, semanticModel, reported);
                 break;
 
             // A member access on the enclosing object captures `this`. The per-member verdicts
@@ -987,12 +1002,13 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         SendableSymbolClassifier classifier,
         ComputationLambdas.ComputationBody patch,
         SemanticModel? semanticModel,
-        HashSet<ISymbol> reported)
+        HashSet<ISymbol> reported,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
         var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         foreach (var operation in ComputationLambdas.DescendStoredClosure(patch.Body))
         {
-            InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, semanticModel, reported);
+            InspectCapture(context, classifier, operation, patch.Scope, patch.Scope, semanticModel, reported, argumentMap: argumentMap);
             InspectCapturedLocalFunction(context, classifier, operation, patch.Scope, semanticModel, visitedLocalFunctions, reported);
         }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -310,6 +310,17 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        // A two-step initialization whose initializing write stands only RELATIVE to this
+        // read (`patch = safe; await Apply(state, patch); patch = other;` -- the later
+        // rebind makes the global scan ambiguous, but cannot change what this call stored)
+        // resolves to that write's value, walked like a surviving reassignment write.
+        if (semanticModel is not null
+            && ReceiverSymbol(Unwrap(value)) is { } stepwise
+            && ComputationLambdas.EffectiveInitializerWrite(stepwise, semanticModel, Unwrap(value).Syntax) is AssignmentExpressionSyntax stepwiseWrite)
+        {
+            return InspectSurvivingWrite(context, classifier, stepwiseWrite, stepwise, semanticModel, reported);
+        }
+
         // A same-tree computed get-only delegate PROPERTY resolves through its getter's
         // returns, like a delegate-returning helper: each return is walked as a patch body,
         // with unresolvable returns reported.
@@ -341,7 +352,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         if (semanticModel is null
             || ReceiverSymbol(Unwrap(value)) is not { } assembled
-            || ComputationLambdas.EffectiveInitializerWrite(assembled, semanticModel) is not ArgumentSyntax outWrite)
+            || ComputationLambdas.EffectiveInitializerWrite(assembled, semanticModel, Unwrap(value).Syntax) is not ArgumentSyntax outWrite)
         {
             return false;
         }
@@ -558,15 +569,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // The sole WRITE standing in for a missing initializer is initialization, not a
         // rebind (`Func<int,int> patch; patch = static x => x;` -- or `Provide(out patch)`,
         // whose bodies the out-helper machinery resolves -- is the declaration in two
-        // steps) -- but only when it can actually RUN before this read: a future write proves
-        // nothing about the value read here (a constructor- or externally-supplied delegate
-        // would slip through on its strength).
-        var effectiveInitializer = ComputationLambdas.EffectiveInitializerWrite(variable, semanticModel);
-        if (effectiveInitializer is not null
-            && !ComputationLambdas.CanExecuteBefore(effectiveInitializer, readReference.Syntax, variable, semanticModel))
-        {
-            return true;
-        }
+        // steps). The synthesis itself is READ-relative: writes that cannot run before this
+        // read neither initialize nor disqualify what it observes, and a member write must
+        // provably reach the read -- so a write that fails those tests falls through to the
+        // rebind scan below instead of excusing anything.
+        var effectiveInitializer = ComputationLambdas.EffectiveInitializerWrite(variable, semanticModel, readReference.Syntax);
 
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
@@ -937,6 +944,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return property.GetMethod?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() switch
         {
             AccessorDeclarationSyntax { Body: null, ExpressionBody: null } => true, // auto-property
+            ParameterSyntax => true,                                               // positional record: synthesized auto
             null => true,                                                          // metadata: unwalkable
             _ => false,                                                            // computed: chased instead
         };
@@ -1076,7 +1084,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         IMethodSymbol method,
         HashSet<ISymbol> reported)
     {
-        if ((!IsUnverifiableExecutedShape(operation) && !IsExecutedSetter(operation, method))
+        if ((!IsUnverifiableExecutedShape(operation) && !IsUnverdictedAccessor(operation, method))
             || method.DeclaringSyntaxReferences.Length == 0)
         {
             return;
@@ -1108,13 +1116,28 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             or IUsingOperation;
     }
 
-    // A SETTER an assignment runs is executed code like a call: on a receiver the capture
-    // walk gives no verdict for (a computation-local object, a Sendable-trusted type), this
-    // fallback is the only look a cross-file setter body ever gets. Getters stay with their
-    // own member/type/getter verdicts.
-    private static bool IsExecutedSetter(IOperation operation, IMethodSymbol method)
+    // An ACCESSOR the patch runs is executed code like a call. Setters always land here: on
+    // a receiver the capture walk gives no verdict for (a computation-local object, a
+    // Sendable-trusted type), this fallback is the only look a cross-file setter body ever
+    // gets. GETTERS land here on those same unverdicted receivers -- enclosing-instance and
+    // static reads keep their own member/type/getter verdicts from the capture walk, but
+    // `new Box().P` with the getter in another file is checked by nothing else.
+    private static bool IsUnverdictedAccessor(IOperation operation, IMethodSymbol method)
     {
-        return operation is IPropertyReferenceOperation && method.MethodKind == MethodKind.PropertySet;
+        if (operation is not IPropertyReferenceOperation property)
+        {
+            return false;
+        }
+
+        if (method.MethodKind == MethodKind.PropertySet)
+        {
+            return true;
+        }
+
+        return method.MethodKind == MethodKind.PropertyGet
+            && property.Property is { IsStatic: false }
+            && !HasBackingStorage(property.Property)
+            && property.Instance is not (null or IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance });
     }
 
     // A delegate the patch builds AND synchronously invokes runs its body on every replay:
@@ -1912,8 +1935,19 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                     && CapturedDelegateArmsResolve(coalesce.WhenNull, semanticModel);
             default:
                 return ComputationLambdas.OfArgumentValue(value, semanticModel).Any()
-                    || ResolveMethodReference(value, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 };
+                    || ResolveMethodReference(value, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 }
+                    || CapturedFactoryReturnsResolve(value, semanticModel);
         }
+    }
+
+    // A captured delegate BUILT by a same-tree factory (`var d = Safe();`) stores whatever
+    // the factory returned, so it resolves through the factory's returns exactly like a
+    // factory-built patch argument -- instead of being rejected wholesale for its type.
+    private static bool CapturedFactoryReturnsResolve(IOperation value, SemanticModel? semanticModel)
+    {
+        return Unwrap(value) is IInvocationOperation call
+            && ComputationLambdas.ResolveMethodBody(call.TargetMethod, semanticModel) is { } factoryBody
+            && ComputationLambdas.ReturnedBodies(factoryBody, semanticModel, ComputationLambdas.BuildArgumentMap(call, outer: null)).Any();
     }
 
     private static void WalkCapturedDelegateArms(
@@ -1946,9 +1980,19 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectMethodGroupReceiver(context, classifier, methodReference, reported);
         }
 
+        var resolvedAny = false;
         foreach (var body in ComputationLambdas.OfArgumentValue(value, semanticModel))
         {
+            resolvedAny = true;
             InspectPatchBody(context, classifier, body, semanticModel, reported);
+        }
+
+        // The factory-built candidate: each of the factory's returns is a patch body of its
+        // own, with unresolvable returns reported by the per-return accounting.
+        if (!resolvedAny && Unwrap(value) is IInvocationOperation factoryCall
+            && ComputationLambdas.ResolveMethodBody(factoryCall.TargetMethod, semanticModel) is { } factoryBody)
+        {
+            InspectReturnedPatchBodies(context, classifier, factoryBody, factoryCall.TargetMethod, ComputationLambdas.BuildArgumentMap(factoryCall, outer: null), semanticModel, reported);
         }
     }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace MemoizR.Analyzers;
+
+// MZR004, the closure-capture mirror of MZR001 (ADR 0007 phase 5): an optimistic patch is
+// stored in the overlay and re-executed by the view's computation on whichever flow pulls the
+// optimistic state, so everything its closure captures crosses flows exactly like a node value.
+// A capture whose type is not Sendable (a List<int> local), or a read of writable state on the
+// enclosing object (a non-readonly field, a settable property), is therefore unsynchronized
+// cross-flow sharing. Reads of Sendable-typed captures stay unflagged -- capturing the action
+// payload or other immutable snapshots is the idiomatic pattern. This rule exists because the
+// RUNTIME cannot check it: closure display classes always carry writable fields, so a
+// structural runtime check would reject every capturing lambda. Captured-state WRITES inside a
+// patch are MZR002's territory (Apply is a computation host), and a Set inside one is MZR003's.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.NonSendablePatchCapture);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // The classifier caches verdicts per type symbol, so it must be scoped to one
+        // compilation: symbols cached across compilations would be both wrong and a leak.
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var classifier = new SendableSymbolClassifier();
+            compilationStart.RegisterOperationAction(
+                operationContext => Analyze(operationContext, classifier),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, SendableSymbolClassifier classifier)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        if (!FactoryMethods.IsOptimisticPatchHost(invocation.TargetMethod))
+        {
+            return;
+        }
+
+        foreach (var patch in ComputationLambdas.OfInvocation(invocation))
+        {
+            // One report per captured symbol per patch: a capture is a property of the closure,
+            // not of each of its reads.
+            var reported = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            foreach (var operation in ComputationLambdas.Descend(patch.Body))
+            {
+                InspectCapture(context, classifier, operation, patch.Scope, reported);
+            }
+        }
+    }
+
+    private static void InspectCapture(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        SyntaxNode scope,
+        HashSet<ISymbol> reported)
+    {
+        switch (operation)
+        {
+            case ILocalReferenceOperation local when ComputationLambdas.IsDeclaredOutside(local.Local, scope):
+                ReportIfNotSendable(context, classifier, operation, local.Local, local.Local.Type, reported);
+                break;
+            case IParameterReferenceOperation parameter when ComputationLambdas.IsDeclaredOutside(parameter.Parameter, scope):
+                ReportIfNotSendable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, reported);
+                break;
+
+            // A member access on the enclosing object captures `this`. Writable storage is
+            // flagged outright -- the patch re-reads it on other flows while the owner mutates
+            // it freely; readonly/get-only members are held to the member TYPE's sendability
+            // (the object handed out is what gets shared). A computed get-only property's body
+            // is not chased: like type parameters elsewhere, it gets the benefit of the doubt.
+            case IFieldReferenceOperation { Field.IsStatic: false } field when IsOnEnclosingInstance(field.Instance):
+                if (!field.Field.IsReadOnly)
+                {
+                    Report(context, operation, field.Field, "it is writable state of the enclosing object", reported);
+                }
+                else
+                {
+                    ReportIfNotSendable(context, classifier, operation, field.Field, field.Field.Type, reported);
+                }
+
+                break;
+            case IPropertyReferenceOperation { Property.IsStatic: false } property when IsOnEnclosingInstance(property.Instance):
+                if (property.Property.SetMethod is not null)
+                {
+                    Report(context, operation, property.Property, "it is writable state of the enclosing object", reported);
+                }
+                else
+                {
+                    ReportIfNotSendable(context, classifier, operation, property.Property, property.Property.Type, reported);
+                }
+
+                break;
+        }
+    }
+
+    private static bool IsOnEnclosingInstance(IOperation? receiver)
+    {
+        return receiver is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance };
+    }
+
+    private static void ReportIfNotSendable(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        ISymbol symbol,
+        ITypeSymbol type,
+        HashSet<ISymbol> reported)
+    {
+        var reason = classifier.GetNotSendableReason(type);
+        if (reason is null)
+        {
+            return;
+        }
+
+        Report(
+            context,
+            operation,
+            symbol,
+            $"its type '{SendableSymbolClassifier.Display(type)}' is not Sendable ({reason})",
+            reported);
+    }
+
+    private static void Report(
+        OperationAnalysisContext context,
+        IOperation operation,
+        ISymbol symbol,
+        string problem,
+        HashSet<ISymbol> reported)
+    {
+        if (!reported.Add(symbol))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.NonSendablePatchCapture,
+            operation.Syntax.GetLocation(),
+            symbol.Name,
+            problem));
+    }
+}

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -457,9 +457,63 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         // callback it builds and discards is allocated fresh per replay and never runs, so
         // its captures must not count (unlike the patch's own nested callbacks, which the
         // stored display chain pins).
+        var visitedCallbacks = new HashSet<SyntaxNode>();
         foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
         {
             InspectCapture(context, classifier, inner, body.Scope, patchScope, semanticModel, reported, visitedGetters);
+            InspectGetterCallback(context, classifier, inner, patchScope, semanticModel, reported, visitedGetters, visitedCallbacks);
+        }
+    }
+
+    // A getter-local callback the getter itself INVOKES runs on every replay like the
+    // getter's own statements -- `int Read() => counter; return Read();` re-reads the field
+    // exactly as the direct form would -- so invoked local functions and getter-built
+    // delegates get the same member verdicts, against their own scope. Merely-BUILT callbacks
+    // stay pruned like the rest of this walk: fresh per replay, not executed here. (Statics
+    // inside these bodies need nothing extra: the executed-helper chase resolves getters and
+    // their invoked callees on its own.)
+    private static void InspectGetterCallback(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        SyntaxNode patchScope,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported,
+        HashSet<IMethodSymbol> visitedGetters,
+        HashSet<SyntaxNode> visitedCallbacks)
+    {
+        foreach (var body in InvokedCalleeBodies(operation, semanticModel))
+        {
+            if (!visitedCallbacks.Add(body.Scope))
+            {
+                continue;
+            }
+
+            foreach (var inner in ComputationLambdas.DescendDirectExecution(body.Body))
+            {
+                InspectCapture(context, classifier, inner, body.Scope, patchScope, semanticModel, reported, visitedGetters);
+                InspectGetterCallback(context, classifier, inner, patchScope, semanticModel, reported, visitedGetters, visitedCallbacks);
+            }
+        }
+    }
+
+    // What a getter-body operation synchronously runs: a local function called directly, or
+    // the bodies an invoked delegate reference resolves to.
+    private static IEnumerable<ComputationLambdas.ComputationBody> InvokedCalleeBodies(IOperation operation, SemanticModel? semanticModel)
+    {
+        switch (operation)
+        {
+            case IInvocationOperation { TargetMethod: { MethodKind: MethodKind.LocalFunction } local }
+                when ComputationLambdas.ResolveMethodBody(local, semanticModel) is { } resolved:
+                yield return resolved;
+                break;
+            case IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee }:
+                foreach (var body in ComputationLambdas.OfArgumentValue(ResolveConditionalReceiver(callee), semanticModel))
+                {
+                    yield return body;
+                }
+
+                break;
         }
     }
 
@@ -609,10 +663,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
         {
-            // A delegate PARAMETER invoked by a chased helper resolves through the call-site
-            // arguments: `Run(() => hits)` with `Run(Func<int> f) => f()` executes the lambda.
-            var resolvedCallee = ComputationLambdas.SubstituteArguments(ResolveConditionalReceiver(callee), argumentMap) ?? callee;
-            InspectInvokedDelegate(context, classifier, resolvedCallee, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            InspectInvokedDelegate(context, classifier, ResolveConditionalReceiver(callee), semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
             return;
         }
 
@@ -646,9 +697,15 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // the built-but-deferred shape stays pruned, but `Func<int> later = () => hits; later()`
     // executes now, and unlike MZR003's identical prune there is no runtime backstop. The
     // callee resolves like a computation argument (same-tree lambda or method group, through
-    // variable initializers). The guard is per INVOCATION SITE: a delegate reassigned between
-    // two invokes executes a different closure at each, while a self-recursive delegate
-    // re-reaches the same site inside its own body and stops there.
+    // variable initializers and assignments), plus two hop kinds of its own: a delegate
+    // PARAMETER hops to the call-site argument, and a variable-to-variable ALIAS hops through
+    // its initializer -- `Run(() => hits)` with `int Run(Func<int> f) { var g = f; return
+    // g(); }` reaches the lambda only through both. The guard keys on the RESOLVED reference:
+    // the same inner invoke reached from different call sites resolves to different caller
+    // operations and each gets its own chase, while a self-recursive delegate re-reaches the
+    // same resolution and stops. A callee resolving to NOTHING walkable gets the same
+    // unverifiable-means-flagged fallback as an unresolvable patch argument -- this walk is
+    // the only check that closure will ever get.
     private static void InspectInvokedDelegate(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
@@ -659,26 +716,104 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         Dictionary<IParameterSymbol, IOperation>? argumentMap,
         HashSet<ISymbol> reported)
     {
-        if (!visitedInvokes.Add(callee.Syntax))
+        var resolved = ResolveDelegateReference(callee, semanticModel, argumentMap);
+        if (!visitedInvokes.Add(resolved.Syntax))
         {
             return;
         }
 
-        foreach (var body in ComputationLambdas.OfArgumentValue(callee, semanticModel))
+        var found = false;
+        foreach (var body in ComputationLambdas.OfArgumentValue(resolved, semanticModel))
         {
+            found = true;
             ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
         }
 
-        var variable = ComputationLambdas.ReferencedVariable(Unwrap(callee));
-        if (variable is null || semanticModel is null)
+        var variable = ComputationLambdas.ReferencedVariable(Unwrap(resolved));
+        if (variable is not null && semanticModel is not null)
+        {
+            foreach (var body in AssignedDelegateBodies(variable, resolved.Syntax, semanticModel))
+            {
+                found = true;
+                ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
+            }
+        }
+
+        if (!found)
+        {
+            ReportUnresolvedInvokedDelegate(context, resolved, variable, semanticModel, reported);
+        }
+    }
+
+    // The invoked reference, collapsed through parameter-to-argument hops (the map) and
+    // variable-to-variable alias initializers. Hops stop at anything the body resolution can
+    // consume directly (a lambda, a method group, a variable holding one) so no shape is
+    // lost, and at any alias REASSIGNED before its read -- there the assignment scan owns
+    // the chase, and hopping past it would resurrect the stale initializer.
+    private static IOperation ResolveDelegateReference(
+        IOperation callee,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        var current = callee;
+        HashSet<ISymbol>? visited = null;
+        while (true)
+        {
+            if (ComputationLambdas.SubstituteArguments(current, argumentMap) is { } substituted
+                && !ReferenceEquals(substituted, current))
+            {
+                current = substituted;
+                continue;
+            }
+
+            if (ComputationLambdas.ReferencedVariable(Unwrap(current)) is not { } variable)
+            {
+                return current;
+            }
+
+            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            var initializer = ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel);
+            if (!visited.Add(variable) || initializer is null || !IsReferenceHop(Unwrap(initializer))
+                || IsReassignedBefore(variable, current, semanticModel))
+            {
+                return current;
+            }
+
+            current = initializer;
+        }
+    }
+
+    private static bool IsReferenceHop(IOperation operation)
+    {
+        return operation is IParameterReferenceOperation || ComputationLambdas.ReferencedVariable(operation) is not null;
+    }
+
+    // An invoked delegate resolving to NOTHING walkable -- assembled by an out-helper in
+    // another file, an opaque factory return, a dead-end alias -- executes an arbitrary
+    // closure on every replay: unverifiable means flagged, mirroring the patch-argument
+    // rule. A METADATA method-group target (Math.Abs) stays trusted like every external
+    // contract, and a non-variable dead end (an invoked call-result chain) is left to the
+    // argument-level rules rather than guessed at.
+    private static void ReportUnresolvedInvokedDelegate(
+        OperationAnalysisContext context,
+        IOperation resolved,
+        ISymbol? variable,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        if (variable is null
+            || ResolveMethodReference(resolved, semanticModel, visitedVariables: null) is { Method.DeclaringSyntaxReferences.Length: 0 })
         {
             return;
         }
 
-        foreach (var body in AssignedDelegateBodies(variable, callee.Syntax, semanticModel))
-        {
-            ChaseExecutedBody(context, classifier, body, semanticModel, visitedCalls, visitedInvokes, argumentMap, reported);
-        }
+        Report(
+            context,
+            resolved,
+            variable,
+            variable.Name,
+            "the delegate it holds cannot be resolved from this call site, and a delegate can capture arbitrary mutable state (assemble the patch's callees from lambdas or same-tree methods)",
+            reported);
     }
 
     // `later?.Invoke()` surfaces the invoke receiver as the conditional-access placeholder;
@@ -749,20 +884,23 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     }
 
     // "Straight-line" = the killer sits in plain block statements between itself and wherever
-    // the invoke lives; a killer inside an if/loop may not run, so it kills nothing.
-    private static bool DefinitelyOverwrites(SyntaxNode killer, SyntaxNode victim, SyntaxNode invokeSite, ISymbol variable, SemanticModel semanticModel)
+    // the value is observed (an invoke site, or an out-helper's own scope end); a killer
+    // inside an if/loop may not run, so it kills nothing -- and an exit statement between the
+    // two writes can leave the earlier value observable, so nothing is definite past one.
+    private static bool DefinitelyOverwrites(SyntaxNode killer, SyntaxNode victim, SyntaxNode reference, ISymbol variable, SemanticModel semanticModel)
     {
         if (killer is not AssignmentExpressionSyntax assignment
             || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
             || assignment.Left is TupleExpressionSyntax
             || !ComputationLambdas.WritesVariable(assignment.Left, variable, semanticModel)
             || killer.SpanStart <= victim.SpanStart
-            || killer.SpanStart >= invokeSite.SpanStart)
+            || killer.SpanStart >= reference.Span.End
+            || ExitsBetween(victim, killer))
         {
             return false;
         }
 
-        for (var current = killer.Parent; current is not null && !current.Span.Contains(invokeSite.Span); current = current.Parent)
+        for (var current = killer.Parent; current is not null && !current.Span.Contains(reference.Span); current = current.Parent)
         {
             if (current is not (BlockSyntax or ExpressionStatementSyntax))
             {
@@ -771,6 +909,33 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         return true;
+    }
+
+    // A return/throw/goto/break/continue/yield starting between the two writes diverts
+    // control past the killer with the victim's value still bound (an early return in an
+    // out-helper hands that delegate to the caller). Only the killer's OWN function counts:
+    // an exit inside a nested lambda -- e.g. a `return` in the victim's own delegate body --
+    // diverts nothing here.
+    private static bool ExitsBetween(SyntaxNode victim, SyntaxNode killer)
+    {
+        var function = killer.Ancestors().FirstOrDefault(IsFunctionBoundary) ?? killer.SyntaxTree.GetRoot();
+        foreach (var node in function.DescendantNodes(descendIntoChildren: n => ReferenceEquals(n, function) || !IsFunctionBoundary(n)))
+        {
+            if (node is ReturnStatementSyntax or ThrowStatementSyntax or GotoStatementSyntax
+                    or BreakStatementSyntax or ContinueStatementSyntax or YieldStatementSyntax
+                && victim.SpanStart < node.SpanStart && node.SpanStart < killer.SpanStart)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsFunctionBoundary(SyntaxNode node)
+    {
+        return node is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax
+            or BaseMethodDeclarationSyntax or AccessorDeclarationSyntax;
     }
 
     private static IEnumerable<ComputationLambdas.ComputationBody> NodeAssignedBodies(SyntaxNode node, ISymbol variable, SemanticModel semanticModel)
@@ -811,10 +976,22 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
+        var writes = new List<AssignmentExpressionSyntax>();
         foreach (var node in helper.Scope.DescendantNodes())
         {
-            if (node is not AssignmentExpressionSyntax assignment
-                || !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, parameter)
+            if (node is AssignmentExpressionSyntax assignment
+                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, parameter))
+            {
+                writes.Add(assignment);
+            }
+        }
+
+        foreach (var assignment in writes)
+        {
+            // What the caller receives is the delegate bound when the helper RETURNS: a later
+            // straight-line overwrite inside the helper kills this body exactly like one
+            // before an invoke, with the helper's scope end as the observation point.
+            if (writes.Any(other => other != assignment && DefinitelyOverwrites(other, assignment, helper.Scope, parameter, semanticModel))
                 || semanticModel.GetOperation(assignment.Right) is not { } assigned)
             {
                 continue;

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -60,7 +60,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
         foreach (var argument in invocation.Arguments)
         {
-            InspectPatchArgument(context, classifier, argument.Value, invocation.SemanticModel, reported);
+            // Only the PATCH parameter stores a delegate: the state argument (possibly a
+            // computed property) must not run the delegate-shaped fallbacks.
+            if (argument.Parameter?.Type is { TypeKind: TypeKind.Delegate })
+            {
+                InspectPatchArgument(context, classifier, argument.Value, invocation.SemanticModel, reported);
+            }
         }
     }
 
@@ -130,25 +135,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             InspectPatchBody(context, classifier, patch, semanticModel, reported);
         }
 
-        // A patch definitely ASSEMBLED by a same-tree out-helper (`Provide(out patch)` as
-        // the sole dominating write) resolves to the helper's assignments -- each walked
-        // like an inline patch body, with unresolvable branches reported by the helper
-        // accounting itself; an unwalkable helper falls through to the unverifiable report
-        // below.
+        // Patch shapes assembled elsewhere -- an out-helper, a computed delegate property's
+        // returns, a same-tree delegate factory's returns -- resolve through their own
+        // chases before anything is called unverifiable.
         if (!bodyResolved)
         {
-            bodyResolved = InspectOutAssembledPatch(context, classifier, value, semanticModel, reported);
-        }
-
-        // A same-tree computed get-only delegate PROPERTY resolves through its getter's
-        // returns, like a delegate-returning helper: each return is walked as a patch body,
-        // with unresolvable returns reported.
-        if (!bodyResolved && ReceiverSymbol(Unwrap(value)) is IPropertySymbol patchProperty
-            && !IsSettable(patchProperty) && !HasBackingStorage(patchProperty)
-            && patchProperty.GetMethod is { } patchGetter
-            && ComputationLambdas.ResolveMethodBody(patchGetter, semanticModel) is { } getterBody)
-        {
-            bodyResolved = InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, argumentMap: null, semanticModel, reported);
+            bodyResolved = InspectAssembledPatchSources(context, classifier, value, semanticModel, reported);
         }
 
         // A SOURCE-declared method group whose body lives in another file cannot be walked:
@@ -302,6 +294,44 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return bodies.Count > 0 || accounted;
     }
 
+    private static bool InspectAssembledPatchSources(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        SemanticModel? semanticModel,
+        HashSet<ISymbol> reported)
+    {
+        // A patch definitely ASSEMBLED by a same-tree out-helper (`Provide(out patch)` as
+        // the sole dominating write) resolves to the helper's assignments -- each walked
+        // like an inline patch body, with unresolvable branches reported by the helper
+        // accounting itself; an unwalkable helper falls back to the caller's reports.
+        if (InspectOutAssembledPatch(context, classifier, value, semanticModel, reported))
+        {
+            return true;
+        }
+
+        // A same-tree computed get-only delegate PROPERTY resolves through its getter's
+        // returns, like a delegate-returning helper: each return is walked as a patch body,
+        // with unresolvable returns reported.
+        if (ReceiverSymbol(Unwrap(value)) is IPropertySymbol patchProperty
+            && !IsSettable(patchProperty) && !HasBackingStorage(patchProperty)
+            && patchProperty.GetMethod is { } patchGetter
+            && ComputationLambdas.ResolveMethodBody(patchGetter, semanticModel) is { } getterBody)
+        {
+            return InspectReturnedPatchBodies(context, classifier, getterBody, patchProperty, argumentMap: null, semanticModel, reported);
+        }
+
+        // A patch produced by a same-tree delegate FACTORY -- called inline, or stored
+        // through a variable initializer -- resolves through the factory's returns.
+        if (FactoryCallOf(value, semanticModel) is { } factoryCall
+            && ComputationLambdas.ResolveMethodBody(factoryCall.TargetMethod, semanticModel) is { } factoryBody)
+        {
+            return InspectReturnedPatchBodies(context, classifier, factoryBody, factoryCall.TargetMethod, ComputationLambdas.BuildArgumentMap(factoryCall, outer: null), semanticModel, reported);
+        }
+
+        return false;
+    }
+
     private static bool InspectOutAssembledPatch(
         OperationAnalysisContext context,
         SendableSymbolClassifier classifier,
@@ -371,6 +401,22 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         return accounted;
+    }
+
+    // The invocation producing this patch value: the argument itself, or the variable's
+    // same-tree initializer.
+    private static IInvocationOperation? FactoryCallOf(IOperation value, SemanticModel? semanticModel)
+    {
+        if (Unwrap(value) is IInvocationOperation direct)
+        {
+            return direct;
+        }
+
+        return ReceiverSymbol(Unwrap(value)) is { } variable
+            && ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel) is { } initializer
+            && Unwrap(initializer) is IInvocationOperation stored
+            ? stored
+            : null;
     }
 
     private static bool InspectConditionalInitializer(
@@ -642,10 +688,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         switch (operation)
         {
             case ILocalReferenceOperation local when IsSharedCapture(local.Local, scope, patchScope):
-                ReportCapturedVariable(context, classifier, operation, local.Local, local.Local.Type, reported);
+                ReportCapturedVariable(context, classifier, operation, local.Local, local.Local.Type, semanticModel, reported);
                 break;
             case IParameterReferenceOperation parameter when IsSharedCapture(parameter.Parameter, scope, patchScope):
-                ReportCapturedVariable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, reported);
+                ReportCapturedVariable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, semanticModel, reported);
                 break;
 
             // A member access on the enclosing object captures `this`. The per-member verdicts
@@ -1601,7 +1647,8 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     // control past the killer with the victim's value still bound (an early return in an
     // out-helper hands that delegate to the caller). Only the killer's OWN function counts:
     // an exit inside a nested lambda -- e.g. a `return` in the victim's own delegate body --
-    // diverts nothing here.
+    // diverts nothing here, and neither does a break/continue/case-goto whose OWN construct
+    // ends before the killer (control leaves the switch/loop and still reaches it).
     private static bool ExitsBetween(SyntaxNode victim, SyntaxNode killer)
     {
         var function = killer.Ancestors().FirstOrDefault(IsFunctionBoundary) ?? killer.SyntaxTree.GetRoot();
@@ -1609,13 +1656,31 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         {
             if (node is ReturnStatementSyntax or ThrowStatementSyntax or GotoStatementSyntax
                     or BreakStatementSyntax or ContinueStatementSyntax or YieldStatementSyntax
-                && victim.SpanStart < node.SpanStart && node.SpanStart < killer.SpanStart)
+                && victim.SpanStart < node.SpanStart && node.SpanStart < killer.SpanStart
+                && !(ExitTarget(node) is { } target && target.Span.End <= killer.SpanStart))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // The construct a contained exit leaves: the nearest switch/loop for `break`, the
+    // nearest loop for `continue`, the nearest switch for `goto case`/`goto default`.
+    // Returns null for the truly divergent exits (return/throw/yield, labeled goto).
+    private static SyntaxNode? ExitTarget(SyntaxNode exit)
+    {
+        return exit switch
+        {
+            BreakStatementSyntax => exit.Ancestors().FirstOrDefault(static ancestor =>
+                ancestor is SwitchStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax),
+            ContinueStatementSyntax => exit.Ancestors().FirstOrDefault(static ancestor =>
+                ancestor is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax),
+            GotoStatementSyntax @goto when @goto.IsKind(SyntaxKind.GotoCaseStatement) || @goto.IsKind(SyntaxKind.GotoDefaultStatement)
+                => exit.Ancestors().FirstOrDefault(static ancestor => ancestor is SwitchStatementSyntax),
+            _ => null,
+        };
     }
 
     private static bool IsFunctionBoundary(SyntaxNode node)
@@ -1882,6 +1947,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         IOperation operation,
         ISymbol symbol,
         ITypeSymbol type,
+        SemanticModel? semanticModel,
         HashSet<ISymbol> reported)
     {
         if (IsMutableStruct(type))
@@ -1893,6 +1959,26 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
                 symbol.Name,
                 $"its type '{SendableSymbolClassifier.Display(type)}' is a mutable struct, and the stored closure shares the captured variable's storage rather than a copy",
                 reported);
+            return;
+        }
+
+        // A captured DELEGATE whose same-tree bodies resolve is verified by WALKING those
+        // bodies as patch code -- their own captures included -- instead of rejected
+        // wholesale for its type: the stored closure is fully visible. Reassigned or
+        // unresolvable delegate captures keep the type verdict, and the reported-set add
+        // both dedupes and bounds self-referential delegate cycles.
+        if (type.TypeKind == TypeKind.Delegate
+            && !IsReassignedBefore(symbol, operation, semanticModel)
+            && ComputationLambdas.OfArgumentValue(operation, semanticModel).Any())
+        {
+            if (reported.Add(symbol))
+            {
+                foreach (var body in ComputationLambdas.OfArgumentValue(operation, semanticModel))
+                {
+                    InspectPatchBody(context, classifier, body, semanticModel, reported);
+                }
+            }
+
             return;
         }
 

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -46,16 +46,71 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // One report per captured symbol: a capture is a property of the closure, not of each
+        // of its reads.
+        var reported = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+        // A method-group patch (`ctx.Apply(state, helper.Patch)`) captures its RECEIVER into
+        // the stored delegate -- shared across pull flows even when the method body lives in
+        // metadata or another file and cannot be walked.
+        foreach (var argument in invocation.Arguments)
+        {
+            InspectMethodGroupReceiver(context, classifier, argument.Value, reported);
+        }
+
         foreach (var patch in ComputationLambdas.OfInvocation(invocation))
         {
-            // One report per captured symbol per patch: a capture is a property of the closure,
-            // not of each of its reads.
-            var reported = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
             foreach (var operation in ComputationLambdas.Descend(patch.Body))
             {
                 InspectCapture(context, classifier, operation, patch.Scope, reported);
             }
         }
+    }
+
+    private static void InspectMethodGroupReceiver(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation value,
+        HashSet<ISymbol> reported)
+    {
+        while (value is IConversionOperation conversion)
+        {
+            value = conversion.Operand;
+        }
+
+        if (value is not IDelegateCreationOperation { Target: IMethodReferenceOperation { Instance: { } receiver } }
+            || receiver.Type is not { } receiverType)
+        {
+            return;
+        }
+
+        var reason = classifier.GetNotSendableReason(receiverType);
+        if (reason is null)
+        {
+            return;
+        }
+
+        var symbol = ReceiverSymbol(receiver);
+        var name = receiver is IInstanceReferenceOperation ? "this" : symbol?.Name ?? SendableSymbolClassifier.Display(receiverType);
+        Report(
+            context,
+            receiver,
+            symbol ?? receiverType,
+            name,
+            $"its type '{SendableSymbolClassifier.Display(receiverType)}' is not Sendable ({reason})",
+            reported);
+    }
+
+    private static ISymbol? ReceiverSymbol(IOperation receiver)
+    {
+        return receiver switch
+        {
+            ILocalReferenceOperation local => local.Local,
+            IParameterReferenceOperation parameter => parameter.Parameter,
+            IFieldReferenceOperation field => field.Field,
+            IPropertyReferenceOperation property => property.Property,
+            _ => null,
+        };
     }
 
     private static void InspectCapture(
@@ -82,7 +137,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             case IFieldReferenceOperation { Field.IsStatic: false } field when IsOnEnclosingInstance(field.Instance):
                 if (!field.Field.IsReadOnly)
                 {
-                    Report(context, operation, field.Field, "it is writable state of the enclosing object", reported);
+                    Report(context, operation, field.Field, field.Field.Name, "it is writable state of the enclosing object", reported);
                 }
                 else
                 {
@@ -91,9 +146,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
                 break;
             case IPropertyReferenceOperation { Property.IsStatic: false } property when IsOnEnclosingInstance(property.Instance):
-                if (property.Property.SetMethod is not null)
+                // An init accessor surfaces as SetMethod but cannot run after construction:
+                // `{ get; init; }` is immutable state, held (like readonly fields) only to its
+                // TYPE's sendability -- the same verdict the runtime SendableChecker gives it.
+                if (property.Property.SetMethod is { IsInitOnly: false })
                 {
-                    Report(context, operation, property.Property, "it is writable state of the enclosing object", reported);
+                    Report(context, operation, property.Property, property.Property.Name, "it is writable state of the enclosing object", reported);
                 }
                 else
                 {
@@ -127,6 +185,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
             context,
             operation,
             symbol,
+            symbol.Name,
             $"its type '{SendableSymbolClassifier.Display(type)}' is not Sendable ({reason})",
             reported);
     }
@@ -134,11 +193,12 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     private static void Report(
         OperationAnalysisContext context,
         IOperation operation,
-        ISymbol symbol,
+        ISymbol dedupeKey,
+        string name,
         string problem,
         HashSet<ISymbol> reported)
     {
-        if (!reported.Add(symbol))
+        if (!reported.Add(dedupeKey))
         {
             return;
         }
@@ -146,7 +206,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         context.ReportDiagnostic(Diagnostic.Create(
             DiagnosticDescriptors.NonSendablePatchCapture,
             operation.Syntax.GetLocation(),
-            symbol.Name,
+            name,
             problem));
     }
 }

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -1616,6 +1616,11 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
 
     private static bool WritesDelegateBeforeInvoke(SyntaxNode node, ISymbol variable, IOperation readReference, SemanticModel semanticModel)
     {
+        if (!ComputationLambdas.IsReachable(node, semanticModel))
+        {
+            return false;
+        }
+
         return node switch
         {
             // WritesReadInstance keeps writes on provably-different instances out: a fresh
@@ -1740,6 +1745,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         {
             if (node is ArgumentSyntax forwarded
                 && forwarded.RefOrOutKeyword.IsKind(SyntaxKind.OutKeyword)
+                && ComputationLambdas.IsReachable(forwarded, semanticModel)
                 && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(forwarded.Expression).Symbol, parameter))
             {
                 handoffs.Add(forwarded);
@@ -1855,6 +1861,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         foreach (var node in scope.DescendantNodes())
         {
             if (node is AssignmentExpressionSyntax assignment
+                && ComputationLambdas.IsReachable(assignment, semanticModel)
                 && ComputationLambdas.ReassignmentTargets(assignment) is { } targets
                 && targets.Any(target => ComputationLambdas.WritesVariable(target, parameter, semanticModel)))
             {

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -298,12 +298,23 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool DeclaredWithin(ISymbol variable, SyntaxNode node)
+    // Only the loop BODY re-declares per iteration: a variable in a for-INITIALIZER is
+    // declared once and carries across iterations like one declared before the loop.
+    private static bool DeclaredWithin(ISymbol variable, SyntaxNode loop)
     {
+        var body = loop switch
+        {
+            ForStatementSyntax @for => (SyntaxNode)@for.Statement,
+            ForEachStatementSyntax forEach => forEach.Statement,
+            WhileStatementSyntax @while => @while.Statement,
+            DoStatementSyntax @do => @do.Statement,
+            _ => loop,
+        };
+
         var declaration = variable.DeclaringSyntaxReferences.FirstOrDefault();
         return declaration is not null
-            && declaration.SyntaxTree == node.SyntaxTree
-            && node.Span.Contains(declaration.Span);
+            && declaration.SyntaxTree == body.SyntaxTree
+            && body.Span.Contains(declaration.Span);
     }
 
     private static SyntaxNode? EnclosingFunction(SyntaxNode node)
@@ -353,10 +364,10 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         switch (operation)
         {
             case ILocalReferenceOperation local when IsSharedCapture(local.Local, scope, patchScope):
-                ReportIfNotSendable(context, classifier, operation, local.Local, local.Local.Type, reported);
+                ReportCapturedVariable(context, classifier, operation, local.Local, local.Local.Type, reported);
                 break;
             case IParameterReferenceOperation parameter when IsSharedCapture(parameter.Parameter, scope, patchScope):
-                ReportIfNotSendable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, reported);
+                ReportCapturedVariable(context, classifier, operation, parameter.Parameter, parameter.Parameter.Type, reported);
                 break;
 
             // A member access on the enclosing object captures `this`. The per-member verdicts
@@ -500,11 +511,19 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<IMethodSymbol> visited,
         HashSet<ISymbol> reported)
     {
-        // Only a CALL executes the helper: a method group the patch stores builds a delegate
-        // without running it -- the same deferred shape as a built lambda, which this walk
-        // already prunes. (The capture chase above keeps method references: a lifted local
-        // function's closure is pinned either way.)
-        var method = operation is IInvocationOperation invocation ? invocation.TargetMethod : null;
+        // Only what EXECUTES is chased: a call, or a property READ, which runs its getter
+        // exactly like a call -- `static int Hits => hits;` is the helper-method evasion with
+        // property syntax. A method group the patch stores builds a delegate without running
+        // it -- the same deferred shape as a built lambda, which this walk already prunes.
+        // (The capture chase above keeps method references: a lifted local function's closure
+        // is pinned either way.)
+        var method = operation switch
+        {
+            IInvocationOperation invocation => invocation.TargetMethod,
+            IPropertyReferenceOperation property => property.Property.GetMethod,
+            _ => null,
+        };
+
         if (method is null || !visited.Add(method)
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
@@ -537,6 +556,49 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
     {
         return ComputationLambdas.IsDeclaredOutside(symbol, scope)
             && ComputationLambdas.DeclaredInFunctionEnclosing(symbol, patchScope);
+    }
+
+    // A captured VARIABLE is shared storage, not a copy: the closure hoists the variable
+    // itself into the display class. A mutable struct -- which the classifier accepts for node
+    // VALUES precisely because those are copied -- is therefore writable shared state here:
+    // the owner mutates `counter.Value` in place while re-executions re-read the same storage.
+    // Immutable structs and Sendable reference types stay accepted as before.
+    private static void ReportCapturedVariable(
+        OperationAnalysisContext context,
+        SendableSymbolClassifier classifier,
+        IOperation operation,
+        ISymbol symbol,
+        ITypeSymbol type,
+        HashSet<ISymbol> reported)
+    {
+        if (IsMutableStruct(type))
+        {
+            Report(
+                context,
+                operation,
+                symbol,
+                symbol.Name,
+                $"its type '{SendableSymbolClassifier.Display(type)}' is a mutable struct, and the stored closure shares the captured variable's storage rather than a copy",
+                reported);
+            return;
+        }
+
+        ReportIfNotSendable(context, classifier, operation, symbol, type, reported);
+    }
+
+    // A value type with directly writable instance state. Enums have no user state (their
+    // synthesized backing field must not count), and a metadata struct's private fields are
+    // not imported -- benefit of the doubt, like everywhere else.
+    private static bool IsMutableStruct(ITypeSymbol type)
+    {
+        if (!type.IsValueType || type.TypeKind == TypeKind.Enum || type is not INamedTypeSymbol named)
+        {
+            return false;
+        }
+
+        return named.GetMembers().Any(member =>
+            member is IFieldSymbol { IsStatic: false, IsReadOnly: false, IsConst: false }
+            || (member is IPropertySymbol { IsStatic: false } property && IsSettable(property)));
     }
 
     // The shared verdict for a state read: writable storage is flagged outright; immutable

--- a/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
+++ b/MemoizR.Analyzers/OptimisticPatchCaptureAnalyzer.cs
@@ -224,7 +224,7 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (ReassignmentTargets(node) is { } targets
-                && targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable))
+                && targets.Any(target => WritesVariable(target, variable, semanticModel))
                 && CanExecuteBefore(node, reference, variable))
             {
                 return true;
@@ -232,6 +232,48 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    // A ref-local ALIAS writes its referent: `ref var alias = ref patch; alias = ...` rebinds
+    // patch just as directly. The alias chain resolves through `= ref` initializers; the
+    // visited set breaks alias cycles.
+    private static bool WritesVariable(ExpressionSyntax target, ISymbol variable, SemanticModel semanticModel)
+    {
+        var symbol = semanticModel.GetSymbolInfo(target).Symbol;
+        HashSet<ISymbol>? visited = null;
+        while (true)
+        {
+            if (symbol is null)
+            {
+                return false;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(symbol, variable))
+            {
+                return true;
+            }
+
+            if (symbol is not ILocalSymbol { RefKind: RefKind.Ref })
+            {
+                return false;
+            }
+
+            visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visited.Add(symbol))
+            {
+                return false;
+            }
+
+            if (symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is not VariableDeclaratorSyntax
+                {
+                    Initializer.Value: RefExpressionSyntax { Expression: { } referent }
+                })
+            {
+                return false;
+            }
+
+            symbol = semanticModel.GetSymbolInfo(referent).Symbol;
+        }
     }
 
     // The expressions a node writes: an assignment's left-hand side (deconstruction tuples
@@ -511,20 +553,28 @@ public sealed class OptimisticPatchCaptureAnalyzer : DiagnosticAnalyzer
         HashSet<IMethodSymbol> visited,
         HashSet<ISymbol> reported)
     {
-        // Only what EXECUTES is chased: a call, or a property READ, which runs its getter
-        // exactly like a call -- `static int Hits => hits;` is the helper-method evasion with
-        // property syntax. A method group the patch stores builds a delegate without running
-        // it -- the same deferred shape as a built lambda, which this walk already prunes.
-        // (The capture chase above keeps method references: a lifted local function's closure
-        // is pinned either way.)
+        // Only what EXECUTES is chased: a call; a property READ, which runs its getter exactly
+        // like a call (`static int Hits => hits;` is the helper-method evasion with property
+        // syntax); a constructor; or a user-defined operator/conversion -- each runs on every
+        // replay of the stored patch. A method group the patch stores builds a delegate
+        // without running it -- the same deferred shape as a built lambda, which this walk
+        // already prunes. (The capture chase above keeps method references: a lifted local
+        // function's closure is pinned either way.)
         var method = operation switch
         {
             IInvocationOperation invocation => invocation.TargetMethod,
             IPropertyReferenceOperation property => property.Property.GetMethod,
+            IObjectCreationOperation creation => creation.Constructor,
+            IBinaryOperation { OperatorMethod: { } binaryOperator } => binaryOperator,
+            IUnaryOperation { OperatorMethod: { } unaryOperator } => unaryOperator,
+            IConversionOperation { OperatorMethod: { } conversionOperator } => conversionOperator,
             _ => null,
         };
 
-        if (method is null || !visited.Add(method)
+        // The nameof check runs BEFORE the visited add: a property mentioned only in nameof is
+        // neither executed nor captured, and it must not poison the visited set for a later
+        // real read of the same member.
+        if (method is null || ComputationLambdas.IsInsideNameOf(operation) || !visited.Add(method)
             || ComputationLambdas.ResolveMethodBody(method, semanticModel) is not { } helper)
         {
             return;

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -25,6 +25,11 @@ internal static class ReceiverChains
     // creation or a dead end -- the visited set breaks initializer cycles.
     public static ISymbol? ResolveCreatingFactorySymbol(IOperation? nodeReference, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
+        return ResolveCreatingFactorySymbol(nodeReference, semanticModel, argumentMap, visitedGetters: null);
+    }
+
+    private static ISymbol? ResolveCreatingFactorySymbol(IOperation? nodeReference, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap, HashSet<IMethodSymbol>? visitedGetters)
+    {
         var reference = nodeReference;
         var site = nodeReference?.Syntax;
         HashSet<ISymbol>? visited = null;
@@ -59,13 +64,60 @@ internal static class ReceiverChains
                     }
 
                     var initializer = InitializerOf(symbol, semanticModel);
-                    site = initializer?.Syntax ?? site;
+                    if (initializer is null)
+                    {
+                        // A get-only COMPUTED node property has no initializer: its getter's
+                        // returns are the provenance instead.
+                        return ResolveComputedGetterFactory(reference, symbol, semanticModel, argumentMap, visitedGetters);
+                    }
+
+                    site = initializer.Syntax;
                     reference = initializer;
                     continue;
                 default:
                     return null;
             }
         }
+    }
+
+    // A get-only computed node property (`Signal<int> Other => f2.CreateSignal(1);`, indexers
+    // included via the reference's argument map) resolves through its getter's returns --
+    // accepted only when EVERY return agrees on the creating factory: a getter that can hand
+    // back nodes from different factories stays unprovable, which keeps the diagnostic. The
+    // visited set bounds mutually recursive getters.
+    private static ISymbol? ResolveComputedGetterFactory(IOperation reference, ISymbol symbol, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap, HashSet<IMethodSymbol>? visitedGetters)
+    {
+        if (symbol is not IPropertySymbol { GetMethod: { } getter, SetMethod: null }
+            || ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } getterBody)
+        {
+            return null;
+        }
+
+        visitedGetters ??= new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        if (!visitedGetters.Add(getter))
+        {
+            return null;
+        }
+
+        var propertyMap = ComputationLambdas.BuildArgumentMap(reference, argumentMap);
+        ISymbol? factory = null;
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
+        {
+            if (inner is not IReturnOperation { ReturnedValue: { } returned })
+            {
+                continue;
+            }
+
+            var resolved = ResolveCreatingFactorySymbol(returned, semanticModel, propertyMap, visitedGetters);
+            if (resolved is null || (factory is not null && !SymbolEqualityComparer.Default.Equals(factory, resolved)))
+            {
+                return null;
+            }
+
+            factory = resolved;
+        }
+
+        return factory;
     }
 
     // A node variable REASSIGNED where the assignment can execute before this READ no longer

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -13,9 +13,9 @@ namespace MemoizR.Analyzers;
 // computation host's: null means "unprovable", and callers must treat it as such.
 internal static class ReceiverChains
 {
-    public static ISymbol? ResolveFactorySymbol(IInvocationOperation invocation, SemanticModel? semanticModel)
+    public static ISymbol? ResolveFactorySymbol(IInvocationOperation invocation, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
-        return ResolveReceiverSymbol(ReceiverOf(invocation), semanticModel, depth: 0);
+        return ResolveReceiverSymbol(ReceiverOf(invocation), semanticModel, depth: 0, argumentMap);
     }
 
     // A node reference (the signal a Set is invoked on) resolves through its same-tree
@@ -36,7 +36,7 @@ internal static class ReceiverChains
                     reference = conversion.Operand;
                     continue;
                 case IInvocationOperation creation:
-                    return ResolveKnownCreationFactory(creation, semanticModel);
+                    return ResolveKnownCreationFactory(creation, semanticModel, argumentMap);
                 // A chased helper's PARAMETER hops to the call-site argument: `var a = s;
                 // a.Set(...)` inside `Write(other)` is `other`'s provenance. Not when the
                 // helper WROTE the parameter first, though -- a parameter binds the caller's
@@ -135,10 +135,10 @@ internal static class ReceiverChains
     // Only a RECOGNIZED creation proves provenance: an arbitrary helper that merely RETURNS a
     // node (`f1.MakeState()`) says nothing about which factory created what it returns, so
     // resolving its receiver would claim f1 and enable a suppression the runtime contradicts.
-    private static ISymbol? ResolveKnownCreationFactory(IInvocationOperation creation, SemanticModel? semanticModel)
+    private static ISymbol? ResolveKnownCreationFactory(IInvocationOperation creation, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         return FactoryMethods.IsValueBearingCreation(creation.TargetMethod)
-            ? ResolveFactorySymbol(creation, semanticModel)
+            ? ResolveFactorySymbol(creation, semanticModel, argumentMap)
             : null;
     }
 
@@ -156,7 +156,7 @@ internal static class ReceiverChains
             : null;
     }
 
-    private static ISymbol? ResolveReceiverSymbol(IOperation? receiver, SemanticModel? semanticModel, int depth)
+    private static ISymbol? ResolveReceiverSymbol(IOperation? receiver, SemanticModel? semanticModel, int depth, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
         if (depth > 8 || receiver is null)
         {
@@ -166,9 +166,18 @@ internal static class ReceiverChains
         switch (receiver)
         {
             case IInvocationOperation chained:
-                return ResolveReceiverSymbol(ReceiverOf(chained), semanticModel, depth + 1);
+                return ResolveReceiverSymbol(ReceiverOf(chained), semanticModel, depth + 1, argumentMap);
             case IConversionOperation conversion:
-                return ResolveReceiverSymbol(conversion.Operand, semanticModel, depth + 1);
+                return ResolveReceiverSymbol(conversion.Operand, semanticModel, depth + 1, argumentMap);
+
+            // A chased helper's FACTORY parameter hops to the call-site argument, like the
+            // node-reference hop above: `f.CreateSignal(0)` inside `Write(f2)` is created
+            // by f2. Same rebind guard: a parameter overwritten before this use resolves
+            // through the effective-initializer machinery below instead.
+            case IParameterReferenceOperation parameterReference
+                when argumentMap?.TryGetValue(parameterReference.Parameter, out var mapped) == true
+                    && !IsWrittenBefore(parameterReference.Parameter, receiver.Syntax, semanticModel):
+                return ResolveReceiverSymbol(mapped, semanticModel, depth + 1, argumentMap);
             case ILocalReferenceOperation or IFieldReferenceOperation or IParameterReferenceOperation or IPropertyReferenceOperation:
                 // An intermediate (a stored ReactionBuilder, a factory alias) resolves through
                 // its initializer; when that gives out, the reference symbol itself is the

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -72,7 +72,7 @@ internal static class ReceiverChains
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (ComputationLambdas.ReassignmentTargets(node) is { } targets
-                && targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable))
+                && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel))
                 && ComputationLambdas.CanExecuteBefore(node, reference, variable))
             {
                 return true;

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -69,11 +69,16 @@ internal static class ReceiverChains
             return false;
         }
 
+        // The sole assignment standing in for a missing initializer is initialization, not a
+        // rebind (`OptimisticState<int> state; state = f1.CreateOptimistic(...);` still proves
+        // provenance -- the same assignment is what InitializerOf resolves through).
+        var effectiveInitializer = ComputationLambdas.EffectiveInitializerAssignment(variable, semanticModel);
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            if (ComputationLambdas.ReassignmentTargets(node) is { } targets
+            if (!ReferenceEquals(node, effectiveInitializer)
+                && ComputationLambdas.ReassignmentTargets(node) is { } targets
                 && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel))
-                && ComputationLambdas.CanExecuteBefore(node, reference, variable))
+                && ComputationLambdas.CanExecuteBefore(node, reference, variable, semanticModel))
             {
                 return true;
             }

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -84,15 +84,10 @@ internal static class ReceiverChains
 
         // The sole assignment standing in for a missing initializer is initialization, not a
         // rebind (`OptimisticState<int> state; state = f1.CreateOptimistic(...);` still proves
-        // provenance -- the same assignment is what InitializerOf resolves through) -- but
-        // only when it can actually RUN before this read: a future write proves nothing about
-        // the value read here.
-        var effectiveInitializer = ComputationLambdas.EffectiveInitializerAssignment(variable, semanticModel);
-        if (effectiveInitializer is not null
-            && !ComputationLambdas.CanExecuteBefore(effectiveInitializer, reference, variable, semanticModel))
-        {
-            return true;
-        }
+        // provenance -- the same assignment is what InitializerOf resolves through). The
+        // synthesis is READ-relative: a write that cannot run before this read, or a member
+        // write that does not provably reach it, excuses nothing and falls to the scan below.
+        var effectiveInitializer = ComputationLambdas.EffectiveInitializerAssignment(variable, semanticModel, reference);
 
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -30,12 +30,22 @@ internal static class ReceiverChains
 
         if (reference is IInvocationOperation inlineCreation)
         {
-            return ResolveFactorySymbol(inlineCreation, semanticModel);
+            return ResolveKnownCreationFactory(inlineCreation, semanticModel);
         }
 
         var creation = InitializerOf(SymbolOf(reference), semanticModel);
         return creation is IInvocationOperation invocation
-            ? ResolveFactorySymbol(invocation, semanticModel)
+            ? ResolveKnownCreationFactory(invocation, semanticModel)
+            : null;
+    }
+
+    // Only a RECOGNIZED creation proves provenance: an arbitrary helper that merely RETURNS a
+    // node (`f1.MakeState()`) says nothing about which factory created what it returns, so
+    // resolving its receiver would claim f1 and enable a suppression the runtime contradicts.
+    private static ISymbol? ResolveKnownCreationFactory(IInvocationOperation creation, SemanticModel? semanticModel)
+    {
+        return FactoryMethods.IsValueBearingCreation(creation.TargetMethod)
+            ? ResolveFactorySymbol(creation, semanticModel)
             : null;
     }
 

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -39,7 +39,7 @@ internal static class ReceiverChains
                 case ILocalReferenceOperation or IFieldReferenceOperation or IParameterReferenceOperation or IPropertyReferenceOperation:
                     visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                     var symbol = SymbolOf(reference);
-                    if (symbol is null || !visited.Add(symbol))
+                    if (symbol is null || !visited.Add(symbol) || IsAssignedOutsideDeclaration(symbol, semanticModel))
                     {
                         return null;
                     }
@@ -50,6 +50,29 @@ internal static class ReceiverChains
                     return null;
             }
         }
+    }
+
+    // A node variable REASSIGNED after its initializer no longer proves provenance: the value
+    // at the call may come from any factory, and a suppression resting on the stale
+    // initializer would drop a diagnostic the runtime contradicts -- unprovable keeps it.
+    // Same-tree syntactic scan, like every resolution here.
+    private static bool IsAssignedOutsideDeclaration(ISymbol variable, SemanticModel? semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            return false;
+        }
+
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (node is AssignmentExpressionSyntax assignment
+                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, variable))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // Only a RECOGNIZED creation proves provenance: an arbitrary helper that merely RETURNS a

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -71,8 +71,16 @@ internal static class ReceiverChains
 
         // The sole assignment standing in for a missing initializer is initialization, not a
         // rebind (`OptimisticState<int> state; state = f1.CreateOptimistic(...);` still proves
-        // provenance -- the same assignment is what InitializerOf resolves through).
+        // provenance -- the same assignment is what InitializerOf resolves through) -- but
+        // only when it can actually RUN before this read: a future write proves nothing about
+        // the value read here.
         var effectiveInitializer = ComputationLambdas.EffectiveInitializerAssignment(variable, semanticModel);
+        if (effectiveInitializer is not null
+            && !ComputationLambdas.CanExecuteBefore(effectiveInitializer, reference, variable, semanticModel))
+        {
+            return true;
+        }
+
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
             if (!ReferenceEquals(node, effectiveInitializer)

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -57,13 +57,13 @@ internal static class ReceiverChains
                     continue;
                 case ILocalReferenceOperation or IFieldReferenceOperation or IParameterReferenceOperation or IPropertyReferenceOperation:
                     visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-                    var symbol = SymbolOf(reference);
+                    var symbol = ComputationLambdas.ReferencedSymbol(reference);
                     if (symbol is null || !visited.Add(symbol) || site is null || IsReassignedBefore(symbol, site, semanticModel))
                     {
                         return null;
                     }
 
-                    var initializer = InitializerOf(symbol, semanticModel);
+                    var initializer = ComputationLambdas.SameTreeInitializerOperation(symbol, semanticModel);
                     if (initializer is null)
                     {
                         // A get-only COMPUTED node property has no initializer: its getter's
@@ -101,13 +101,8 @@ internal static class ReceiverChains
 
         var propertyMap = ComputationLambdas.BuildArgumentMap(reference, argumentMap);
         ISymbol? factory = null;
-        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
+        foreach (var returned in ComputationLambdas.ReturnedValues(getterBody.Body))
         {
-            if (inner is not IReturnOperation { ReturnedValue: { } returned })
-            {
-                continue;
-            }
-
             var resolved = ResolveCreatingFactorySymbol(returned, semanticModel, propertyMap, visitedGetters);
             if (resolved is null || (factory is not null && !SymbolEqualityComparer.Default.Equals(factory, resolved)))
             {
@@ -208,13 +203,13 @@ internal static class ReceiverChains
                 // factory by construction. A variable REASSIGNED before this use proves
                 // nothing (`var host = f1; host = f2; host.CreateOptimistic(...)` holds f2,
                 // not its initializer) -- unprovable keeps the diagnostic.
-                var symbol = SymbolOf(receiver);
+                var symbol = ComputationLambdas.ReferencedSymbol(receiver);
                 if (symbol is null || IsReassignedBefore(symbol, receiver.Syntax, semanticModel))
                 {
                     return null;
                 }
 
-                var initialized = InitializerOf(symbol, semanticModel);
+                var initialized = ComputationLambdas.SameTreeInitializerOperation(symbol, semanticModel);
                 if (initialized is not null && ResolveReceiverSymbol(initialized, semanticModel, depth + 1, argumentMap) is { } through)
                 {
                     return through;
@@ -232,13 +227,9 @@ internal static class ReceiverChains
     // visible creation, or a non-constant key).
     public static (bool Resolved, object? ContextKey) ResolveFactoryContextKey(ISymbol factorySymbol, SemanticModel? semanticModel)
     {
-        var initializer = InitializerOf(factorySymbol, semanticModel);
-        while (initializer is IConversionOperation conversion)
-        {
-            initializer = conversion.Operand;
-        }
+        var declared = ComputationLambdas.SameTreeInitializerOperation(factorySymbol, semanticModel);
 
-        if (initializer is not IObjectCreationOperation creation
+        if (declared is null || ComputationLambdas.Unwrap(declared) is not IObjectCreationOperation creation
             || creation.Type is not INamedTypeSymbol { Name: "MemoFactory" } named
             || named.ContainingNamespace?.ToDisplayString() != "MemoizR")
         {
@@ -268,23 +259,4 @@ internal static class ReceiverChains
         return (true, null);
     }
 
-    private static ISymbol? SymbolOf(IOperation? reference)
-    {
-        return reference switch
-        {
-            ILocalReferenceOperation local => local.Local,
-            IFieldReferenceOperation field => field.Field,
-            IParameterReferenceOperation parameter => parameter.Parameter,
-            IPropertyReferenceOperation property => property.Property,
-            _ => null,
-        };
-    }
-
-    // The shared resolver covers ordinary variable/property initializers AND deconstruction
-    // designations (`var (state, _) = (f1.CreateOptimistic(...), 0)`), so provenance chases
-    // the same shapes the delegate resolution does.
-    private static IOperation? InitializerOf(ISymbol? variable, SemanticModel? semanticModel)
-    {
-        return ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel);
-    }
 }

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -23,7 +23,7 @@ internal static class ReceiverChains
     // creation (`f.CreateSignal(0).Set(1)`) is its own provenance and resolves directly, and a
     // variable-to-variable ALIAS (`var state = s0;`) resolves through initializers until a
     // creation or a dead end -- the visited set breaks initializer cycles.
-    public static ISymbol? ResolveCreatingFactorySymbol(IOperation? nodeReference, SemanticModel? semanticModel)
+    public static ISymbol? ResolveCreatingFactorySymbol(IOperation? nodeReference, SemanticModel? semanticModel, Dictionary<IParameterSymbol, IOperation>? argumentMap = null)
     {
         var reference = nodeReference;
         var site = nodeReference?.Syntax;
@@ -37,6 +37,19 @@ internal static class ReceiverChains
                     continue;
                 case IInvocationOperation creation:
                     return ResolveKnownCreationFactory(creation, semanticModel);
+                // A chased helper's PARAMETER hops to the call-site argument: `var a = s;
+                // a.Set(...)` inside `Write(other)` is `other`'s provenance. Not when the
+                // helper WROTE the parameter first, though -- a parameter binds the caller's
+                // argument at entry, so any same-tree write that can run before this read is
+                // a rebind (there is no missing initializer to stand in for), and the case
+                // below resolves what was actually assigned instead.
+                case IParameterReferenceOperation parameterReference
+                    when argumentMap?.TryGetValue(parameterReference.Parameter, out var mapped) == true
+                        && site is not null
+                        && !IsWrittenBefore(parameterReference.Parameter, site, semanticModel):
+                    reference = mapped;
+                    site = mapped.Syntax;
+                    continue;
                 case ILocalReferenceOperation or IFieldReferenceOperation or IParameterReferenceOperation or IPropertyReferenceOperation:
                     visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                     var symbol = SymbolOf(reference);
@@ -85,6 +98,30 @@ internal static class ReceiverChains
         {
             if (!ReferenceEquals(node, effectiveInitializer)
                 && ComputationLambdas.ReassignmentTargets(node) is { } targets
+                && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel))
+                && ComputationLambdas.CanExecuteBefore(node, reference, variable, semanticModel))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Any same-tree write to the symbol that can execute before the read -- unlike
+    // IsReassignedBefore, WITHOUT the effective-initializer excuse, because the caller uses
+    // this for parameters, whose declaration itself binds the value. Unverifiable (no model)
+    // counts as written: the hop must rest on proof.
+    private static bool IsWrittenBefore(ISymbol variable, SyntaxNode reference, SemanticModel? semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            return true;
+        }
+
+        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
+        {
+            if (ComputationLambdas.ReassignmentTargets(node) is { } targets
                 && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel))
                 && ComputationLambdas.CanExecuteBefore(node, reference, variable, semanticModel))
             {

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -26,6 +26,7 @@ internal static class ReceiverChains
     public static ISymbol? ResolveCreatingFactorySymbol(IOperation? nodeReference, SemanticModel? semanticModel)
     {
         var reference = nodeReference;
+        var site = nodeReference?.Syntax;
         HashSet<ISymbol>? visited = null;
         while (true)
         {
@@ -39,12 +40,14 @@ internal static class ReceiverChains
                 case ILocalReferenceOperation or IFieldReferenceOperation or IParameterReferenceOperation or IPropertyReferenceOperation:
                     visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                     var symbol = SymbolOf(reference);
-                    if (symbol is null || !visited.Add(symbol) || IsAssignedOutsideDeclaration(symbol, semanticModel))
+                    if (symbol is null || !visited.Add(symbol) || site is null || IsReassignedBefore(symbol, site, semanticModel))
                     {
                         return null;
                     }
 
-                    reference = InitializerOf(symbol, semanticModel);
+                    var initializer = InitializerOf(symbol, semanticModel);
+                    site = initializer?.Syntax ?? site;
+                    reference = initializer;
                     continue;
                 default:
                     return null;
@@ -52,11 +55,14 @@ internal static class ReceiverChains
         }
     }
 
-    // A node variable REASSIGNED after its initializer no longer proves provenance: the value
-    // at the call may come from any factory, and a suppression resting on the stale
-    // initializer would drop a diagnostic the runtime contradicts -- unprovable keeps it.
-    // Same-tree syntactic scan, like every resolution here.
-    private static bool IsAssignedOutsideDeclaration(ISymbol variable, SemanticModel? semanticModel)
+    // A node variable REASSIGNED where the assignment can execute before this READ no longer
+    // proves provenance: the value may come from any factory, and a suppression resting on the
+    // stale initializer would drop a diagnostic the runtime contradicts -- unprovable keeps
+    // it. A later straight-line reassignment cannot change the value already read, so it stays
+    // trusted; deconstruction targets are flattened, like MZR004's delegate scan. Same-tree
+    // syntactic, like every resolution here; each alias link checks against the site where its
+    // value is read (the previous link's initializer).
+    private static bool IsReassignedBefore(ISymbol variable, SyntaxNode reference, SemanticModel? semanticModel)
     {
         if (semanticModel is null)
         {
@@ -65,8 +71,9 @@ internal static class ReceiverChains
 
         foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
         {
-            if (node is AssignmentExpressionSyntax assignment
-                && SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, variable))
+            if (ComputationLambdas.ReassignmentTargets(node) is { } targets
+                && targets.Any(target => SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(target).Symbol, variable))
+                && ComputationLambdas.CanExecuteBefore(node, reference, variable))
             {
                 return true;
             }

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -46,7 +46,7 @@ internal static class ReceiverChains
                 case IParameterReferenceOperation parameterReference
                     when argumentMap?.TryGetValue(parameterReference.Parameter, out var mapped) == true
                         && site is not null
-                        && !IsWrittenBefore(parameterReference.Parameter, site, semanticModel):
+                        && !ComputationLambdas.IsWrittenBefore(parameterReference.Parameter, site, semanticModel):
                     reference = mapped;
                     site = mapped.Syntax;
                     continue;
@@ -108,30 +108,6 @@ internal static class ReceiverChains
         return false;
     }
 
-    // Any same-tree write to the symbol that can execute before the read -- unlike
-    // IsReassignedBefore, WITHOUT the effective-initializer excuse, because the caller uses
-    // this for parameters, whose declaration itself binds the value. Unverifiable (no model)
-    // counts as written: the hop must rest on proof.
-    private static bool IsWrittenBefore(ISymbol variable, SyntaxNode reference, SemanticModel? semanticModel)
-    {
-        if (semanticModel is null)
-        {
-            return true;
-        }
-
-        foreach (var node in semanticModel.SyntaxTree.GetRoot().DescendantNodes())
-        {
-            if (ComputationLambdas.ReassignmentTargets(node) is { } targets
-                && targets.Any(target => ComputationLambdas.WritesVariable(target, variable, semanticModel))
-                && ComputationLambdas.CanExecuteBefore(node, reference, variable, semanticModel))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     // Only a RECOGNIZED creation proves provenance: an arbitrary helper that merely RETURNS a
     // node (`f1.MakeState()`) says nothing about which factory created what it returns, so
     // resolving its receiver would claim f1 and enable a suppression the runtime contradicts.
@@ -176,7 +152,7 @@ internal static class ReceiverChains
             // through the effective-initializer machinery below instead.
             case IParameterReferenceOperation parameterReference
                 when argumentMap?.TryGetValue(parameterReference.Parameter, out var mapped) == true
-                    && !IsWrittenBefore(parameterReference.Parameter, receiver.Syntax, semanticModel):
+                    && !ComputationLambdas.IsWrittenBefore(parameterReference.Parameter, receiver.Syntax, semanticModel):
                 return ResolveReceiverSymbol(mapped, semanticModel, depth + 1, argumentMap);
             case ILocalReferenceOperation or IFieldReferenceOperation or IParameterReferenceOperation or IPropertyReferenceOperation:
                 // An intermediate (a stored ReactionBuilder, a factory alias) resolves through
@@ -192,7 +168,7 @@ internal static class ReceiverChains
                 }
 
                 var initialized = InitializerOf(symbol, semanticModel);
-                if (initialized is not null && ResolveReceiverSymbol(initialized, semanticModel, depth + 1) is { } through)
+                if (initialized is not null && ResolveReceiverSymbol(initialized, semanticModel, depth + 1, argumentMap) is { } through)
                 {
                     return through;
                 }

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -123,8 +123,15 @@ internal static class ReceiverChains
                 // An intermediate (a stored ReactionBuilder, a factory alias) resolves through
                 // its initializer; when that gives out, the reference symbol itself is the
                 // identity -- two creations hanging off the same local/field/parameter share a
-                // factory by construction.
+                // factory by construction. A variable REASSIGNED before this use proves
+                // nothing (`var host = f1; host = f2; host.CreateOptimistic(...)` holds f2,
+                // not its initializer) -- unprovable keeps the diagnostic.
                 var symbol = SymbolOf(receiver);
+                if (symbol is null || IsReassignedBefore(symbol, receiver.Syntax, semanticModel))
+                {
+                    return null;
+                }
+
                 var initialized = InitializerOf(symbol, semanticModel);
                 if (initialized is not null && ResolveReceiverSymbol(initialized, semanticModel, depth + 1) is { } through)
                 {
@@ -191,29 +198,11 @@ internal static class ReceiverChains
         };
     }
 
+    // The shared resolver covers ordinary variable/property initializers AND deconstruction
+    // designations (`var (state, _) = (f1.CreateOptimistic(...), 0)`), so provenance chases
+    // the same shapes the delegate resolution does.
     private static IOperation? InitializerOf(ISymbol? variable, SemanticModel? semanticModel)
     {
-        if (variable is null || semanticModel is null)
-        {
-            return null;
-        }
-
-        var declaration = variable.DeclaringSyntaxReferences.FirstOrDefault();
-        if (declaration is null || declaration.SyntaxTree != semanticModel.SyntaxTree)
-        {
-            return null;
-        }
-
-        // Locals and fields declare through VariableDeclaratorSyntax; auto-properties with an
-        // initializer (`MemoFactory F { get; } = new MemoFactory();`) through
-        // PropertyDeclarationSyntax. Computed properties have no initializer and stay
-        // unresolvable, as they should.
-        var initializer = declaration.GetSyntax() switch
-        {
-            VariableDeclaratorSyntax { Initializer.Value: { } value } => value,
-            PropertyDeclarationSyntax { Initializer.Value: { } value } => value,
-            _ => null,
-        };
-        return initializer is null ? null : semanticModel.GetOperation(initializer);
+        return ComputationLambdas.SameTreeInitializerOperation(variable, semanticModel);
     }
 }

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -42,6 +42,11 @@ internal static class ReceiverChains
                     continue;
                 case IInvocationOperation creation:
                     return ResolveKnownCreationFactory(creation, semanticModel, argumentMap);
+                // A conditional node (`flag ? f.CreateSignal(1) : other`) is provable only
+                // when every arm agrees on the factory -- the same all-must-agree rule the
+                // computed getters below apply to their returns.
+                case IConditionalOperation or ICoalesceOperation:
+                    return AgreedFactory(ComputationLambdas.ConditionalArms(reference)!, semanticModel, argumentMap, visitedGetters);
                 // A chased helper's PARAMETER hops to the call-site argument: `var a = s;
                 // a.Set(...)` inside `Write(other)` is `other`'s provenance. Not when the
                 // helper WROTE the parameter first, though -- a parameter binds the caller's
@@ -99,11 +104,26 @@ internal static class ReceiverChains
             return null;
         }
 
-        var propertyMap = ComputationLambdas.BuildArgumentMap(reference, argumentMap);
+        return AgreedFactory(
+            ComputationLambdas.ReturnedValues(getterBody.Body),
+            semanticModel,
+            ComputationLambdas.BuildArgumentMap(reference, argumentMap),
+            visitedGetters);
+    }
+
+    // The one factory every candidate resolves to, or null when any is unprovable or they
+    // disagree: a value that can come from two factories proves nothing about the context a
+    // Set would lock, and unprovable keeps the diagnostic.
+    private static ISymbol? AgreedFactory(
+        IEnumerable<IOperation> candidates,
+        SemanticModel? semanticModel,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap,
+        HashSet<IMethodSymbol>? visitedGetters)
+    {
         ISymbol? factory = null;
-        foreach (var returned in ComputationLambdas.ReturnedValues(getterBody.Body))
+        foreach (var candidate in candidates)
         {
-            var resolved = ResolveCreatingFactorySymbol(returned, semanticModel, propertyMap, visitedGetters);
+            var resolved = ResolveCreatingFactorySymbol(candidate, semanticModel, argumentMap, visitedGetters);
             if (resolved is null || (factory is not null && !SymbolEqualityComparer.Default.Equals(factory, resolved)))
             {
                 return null;

--- a/MemoizR.Analyzers/ReceiverChains.cs
+++ b/MemoizR.Analyzers/ReceiverChains.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -19,24 +20,36 @@ internal static class ReceiverChains
 
     // A node reference (the signal a Set is invoked on) resolves through its same-tree
     // initializer to the creating invocation, then to that creation's factory. An INLINE
-    // creation (`f.CreateSignal(0).Set(1)`) is its own provenance and resolves directly.
+    // creation (`f.CreateSignal(0).Set(1)`) is its own provenance and resolves directly, and a
+    // variable-to-variable ALIAS (`var state = s0;`) resolves through initializers until a
+    // creation or a dead end -- the visited set breaks initializer cycles.
     public static ISymbol? ResolveCreatingFactorySymbol(IOperation? nodeReference, SemanticModel? semanticModel)
     {
         var reference = nodeReference;
-        while (reference is IConversionOperation conversion)
+        HashSet<ISymbol>? visited = null;
+        while (true)
         {
-            reference = conversion.Operand;
-        }
+            switch (reference)
+            {
+                case IConversionOperation conversion:
+                    reference = conversion.Operand;
+                    continue;
+                case IInvocationOperation creation:
+                    return ResolveKnownCreationFactory(creation, semanticModel);
+                case ILocalReferenceOperation or IFieldReferenceOperation or IParameterReferenceOperation or IPropertyReferenceOperation:
+                    visited ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                    var symbol = SymbolOf(reference);
+                    if (symbol is null || !visited.Add(symbol))
+                    {
+                        return null;
+                    }
 
-        if (reference is IInvocationOperation inlineCreation)
-        {
-            return ResolveKnownCreationFactory(inlineCreation, semanticModel);
+                    reference = InitializerOf(symbol, semanticModel);
+                    continue;
+                default:
+                    return null;
+            }
         }
-
-        var creation = InitializerOf(SymbolOf(reference), semanticModel);
-        return creation is IInvocationOperation invocation
-            ? ResolveKnownCreationFactory(invocation, semanticModel)
-            : null;
     }
 
     // Only a RECOGNIZED creation proves provenance: an arbitrary helper that merely RETURNS a

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -120,12 +120,50 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        var resolved = ComputationLambdas.ResolveDelegateValue(callee, host.SemanticModel, argumentMap);
+        var resolved = ComputationLambdas.ResolveDelegateValue(ComputationLambdas.ResolveConditionalReceiver(callee), host.SemanticModel, argumentMap);
+        var found = false;
         foreach (var body in ComputationLambdas.OfArgumentValue(resolved, host.SemanticModel))
         {
+            found = true;
             if (visitedCalls.Add((body.Scope, host.TargetMethod, ComputationLambdas.ArgumentMapKey(argumentMap))))
             {
                 InspectExecutedBody(context, host, body.Body, actorHost, visitedCalls, argumentMap);
+            }
+        }
+
+        if (!found)
+        {
+            InspectInvokedFactoryResult(context, host, resolved, actorHost, visitedCalls, argumentMap);
+        }
+    }
+
+    // `Get()(x)` executes whatever the same-tree factory returned, immediately and under
+    // the same lock: the returns are walked with their own maps, cycles bounded by the
+    // per-body visited guard.
+    private static void InspectInvokedFactoryResult(
+        OperationAnalysisContext context,
+        IInvocationOperation host,
+        IOperation resolved,
+        bool actorHost,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        while (resolved is IConversionOperation conversion)
+        {
+            resolved = conversion.Operand;
+        }
+
+        if (resolved is not IInvocationOperation call
+            || ComputationLambdas.ResolveMethodBody(call.TargetMethod, host.SemanticModel) is not { } factory)
+        {
+            return;
+        }
+
+        foreach (var (body, map) in ComputationLambdas.ReturnedBodies(factory, host.SemanticModel, ComputationLambdas.BuildArgumentMap(call, argumentMap)))
+        {
+            if (visitedCalls.Add((body.Scope, host.TargetMethod, ComputationLambdas.ArgumentMapKey(map))))
+            {
+                InspectExecutedBody(context, host, body.Body, actorHost, visitedCalls, map);
             }
         }
     }
@@ -202,10 +240,50 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         if (FactoryMethods.IsOptimisticPatchHost(host.TargetMethod))
         {
             var stateArgument = host.Arguments.FirstOrDefault(a => a.Parameter?.Ordinal == 0)?.Value;
-            return ReceiverChains.ResolveCreatingFactorySymbol(stateArgument, host.SemanticModel);
+            return ReceiverChains.ResolveCreatingFactorySymbol(stateArgument, host.SemanticModel)
+                ?? ResolveComputedStateFactory(stateArgument, host.SemanticModel);
         }
 
         return ReceiverChains.ResolveFactorySymbol(host, host.SemanticModel);
+    }
+
+    // A get-only computed STATE property (`OptimisticState<int> State => f1.CreateOptimistic(...)`)
+    // resolves through its getter's returns -- and only when EVERY return agrees on the
+    // creating factory: a getter that can hand back states from different factories keeps
+    // the host unprovable, which keeps the diagnostic.
+    private static ISymbol? ResolveComputedStateFactory(IOperation? stateArgument, SemanticModel? semanticModel)
+    {
+        var reference = stateArgument;
+        while (reference is IConversionOperation conversion)
+        {
+            reference = conversion.Operand;
+        }
+
+        if (reference is null
+            || ComputationLambdas.ReferencedVariable(reference) is not IPropertySymbol { GetMethod: { } getter, SetMethod: null }
+            || ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } getterBody)
+        {
+            return null;
+        }
+
+        ISymbol? factory = null;
+        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
+        {
+            if (inner is not IReturnOperation { ReturnedValue: { } returned })
+            {
+                continue;
+            }
+
+            var resolved = ReceiverChains.ResolveCreatingFactorySymbol(returned, semanticModel);
+            if (resolved is null || (factory is not null && !SymbolEqualityComparer.Default.Equals(factory, resolved)))
+            {
+                return null;
+            }
+
+            factory = resolved;
+        }
+
+        return factory;
     }
 
     // A write API that throws in THIS host's engine: ActorSignal.Set inside an actor

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -37,13 +38,33 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
 
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
-            // Direct execution path only: a Set inside a callback the computation merely BUILDS
-            // (the diagnostic's suggested escape) runs later, off the evaluation's flow.
-            foreach (var operation in ComputationLambdas.DescendDirectExecution(computation.Body))
+            var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+            InspectExecutedBody(context, invocation, computation.Body, actorHost, visitedHelpers);
+        }
+    }
+
+    // Direct execution path only: a Set inside a callback the computation merely BUILDS (the
+    // diagnostic's suggested escape) runs later, off the evaluation's flow -- but a same-tree
+    // helper the computation CALLS executes its Set under the same evaluation lock and throws
+    // identically, so called bodies are chased (the visited set bounds call cycles; metadata
+    // bodies stay unwalkable, and the runtime exception still covers those).
+    private static void InspectExecutedBody(
+        OperationAnalysisContext context,
+        IInvocationOperation host,
+        IOperation body,
+        bool actorHost,
+        HashSet<IMethodSymbol> visitedHelpers)
+    {
+        foreach (var operation in ComputationLambdas.DescendDirectExecution(body))
+        {
+            if (operation is not IInvocationOperation inner)
             {
-                if (operation is IInvocationOperation inner
-                    && IsSameEngineSet(inner.TargetMethod, actorHost)
-                    && !IsProvablyCrossFactory(invocation, inner, actorHost))
+                continue;
+            }
+
+            if (IsSameEngineSet(inner.TargetMethod, actorHost))
+            {
+                if (!IsProvablyCrossFactory(host, inner, actorHost))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.SetInsideComputation,
@@ -51,6 +72,14 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                         SendableSymbolClassifier.Display(inner.TargetMethod.ContainingType),
                         inner.TargetMethod.Name));
                 }
+
+                continue;
+            }
+
+            if (visitedHelpers.Add(inner.TargetMethod)
+                && ComputationLambdas.ResolveMethodBody(inner.TargetMethod, host.SemanticModel) is { } helper)
+            {
+                InspectExecutedBody(context, host, helper.Body, actorHost, visitedHelpers);
             }
         }
     }

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -70,7 +71,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        var hostFactory = ReceiverChains.ResolveFactorySymbol(host, host.SemanticModel);
+        var hostFactory = ResolveHostFactory(host);
         var targetFactory = ReceiverChains.ResolveCreatingFactorySymbol(setInvocation.Instance, setInvocation.SemanticModel);
         if (hostFactory is null
             || targetFactory is null
@@ -91,6 +92,21 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         return hostContext.ContextKey is null
             || targetContext.ContextKey is null
             || !Equals(hostContext.ContextKey, targetContext.ContextKey);
+    }
+
+    // The factory whose context the HOST's evaluation flow locks. For an optimistic patch the
+    // Apply receiver is the action context, which resolves to nothing -- the patch runs inside
+    // the STATE's view computation, so its host factory is whatever created the OptimisticState
+    // argument (resolved like any node reference, through same-tree initializers).
+    private static ISymbol? ResolveHostFactory(IInvocationOperation host)
+    {
+        if (FactoryMethods.IsOptimisticPatchHost(host.TargetMethod))
+        {
+            var stateArgument = host.Arguments.FirstOrDefault(a => a.Parameter?.Ordinal == 0)?.Value;
+            return ReceiverChains.ResolveCreatingFactorySymbol(stateArgument, host.SemanticModel);
+        }
+
+        return ReceiverChains.ResolveFactorySymbol(host, host.SemanticModel);
     }
 
     // A write API that throws in THIS host's engine: ActorSignal.Set inside an actor

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -39,7 +39,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
             var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-            InspectExecutedBody(context, invocation, computation.Body, actorHost, visitedHelpers);
+            InspectExecutedBody(context, invocation, computation.Body, actorHost, visitedHelpers, argumentMap: null);
         }
     }
 
@@ -53,13 +53,14 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         IInvocationOperation host,
         IOperation body,
         bool actorHost,
-        HashSet<IMethodSymbol> visitedHelpers)
+        HashSet<IMethodSymbol> visitedHelpers,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         foreach (var operation in ComputationLambdas.DescendDirectExecution(body))
         {
             if (operation is IInvocationOperation inner && IsSameEngineSet(inner.TargetMethod, actorHost))
             {
-                if (!IsProvablyCrossFactory(host, inner, actorHost))
+                if (!IsProvablyCrossFactory(host, inner, SubstituteArguments(inner.Instance, argumentMap), actorHost))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.SetInsideComputation,
@@ -77,10 +78,58 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                     && visitedHelpers.Add(method)
                     && ComputationLambdas.ResolveMethodBody(method, host.SemanticModel) is { } helper)
                 {
-                    InspectExecutedBody(context, host, helper.Body, actorHost, visitedHelpers);
+                    InspectExecutedBody(context, host, helper.Body, actorHost, visitedHelpers, BuildArgumentMap(operation, argumentMap));
                 }
             }
         }
+    }
+
+    // Call-site arguments substitute for the helper's parameters when judging a chased Set's
+    // target provenance: in `void Write(Signal<int> s) => s.Set(2);` called as `Write(other)`,
+    // the target is `other`, exactly as the inline form -- a bare parameter would resolve to
+    // nothing and lose a legitimate cross-factory suppression. Maps are built pre-substituted,
+    // so nested helper calls resolve through to the original computation's operations. (One
+    // map per helper -- the visited set keeps the FIRST call site's arguments; re-walking per
+    // call site is not worth the cost for the precision it would buy.)
+    private static Dictionary<IParameterSymbol, IOperation>? BuildArgumentMap(IOperation operation, Dictionary<IParameterSymbol, IOperation>? outer)
+    {
+        var arguments = operation switch
+        {
+            IInvocationOperation invocation => invocation.Arguments,
+            IObjectCreationOperation creation => creation.Arguments,
+            _ => default,
+        };
+
+        if (arguments.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        Dictionary<IParameterSymbol, IOperation>? map = null;
+        foreach (var argument in arguments)
+        {
+            if (argument.Parameter is { } parameter && SubstituteArguments(argument.Value, outer) is { } value)
+            {
+                map ??= new Dictionary<IParameterSymbol, IOperation>(SymbolEqualityComparer.Default);
+                map[parameter] = value;
+            }
+        }
+
+        return map;
+    }
+
+    private static IOperation? SubstituteArguments(IOperation? reference, Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        var current = reference;
+        while (current is IConversionOperation conversion)
+        {
+            current = conversion.Operand;
+        }
+
+        return current is IParameterReferenceOperation parameterReference
+            && argumentMap?.TryGetValue(parameterReference.Parameter, out var argument) == true
+            ? argument
+            : reference;
     }
 
     // A cross-CONTEXT lock-engine Set does not throw at runtime: the Set locks the target
@@ -92,7 +141,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
     // diagnostic, because the overwhelmingly common case is one shared context and the runtime
     // exception is deterministic there. Actor hosts are exempt from the check: ActorSignal.Set
     // rejects on the flow's frame, which any actor computation carries regardless of context.
-    private static bool IsProvablyCrossFactory(IInvocationOperation host, IInvocationOperation setInvocation, bool actorHost)
+    private static bool IsProvablyCrossFactory(IInvocationOperation host, IInvocationOperation setInvocation, IOperation? targetReference, bool actorHost)
     {
         if (actorHost)
         {
@@ -100,7 +149,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         }
 
         var hostFactory = ResolveHostFactory(host);
-        var targetFactory = ReceiverChains.ResolveCreatingFactorySymbol(setInvocation.Instance, setInvocation.SemanticModel);
+        var targetFactory = ReceiverChains.ResolveCreatingFactorySymbol(targetReference ?? setInvocation.Instance, setInvocation.SemanticModel);
         if (hostFactory is null
             || targetFactory is null
             || SymbolEqualityComparer.Default.Equals(hostFactory, targetFactory))

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -96,9 +96,9 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
+            if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke } invoke)
             {
-                InspectInvokedDelegate(context, host, callee, actorHost, visitedCalls, argumentMap);
+                InspectInvokedDelegate(context, host, invoke, actorHost, visitedCalls, argumentMap);
                 continue;
             }
 
@@ -114,12 +114,12 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
     private static void InspectInvokedDelegate(
         OperationAnalysisContext context,
         IInvocationOperation host,
-        IOperation callee,
+        IInvocationOperation invoke,
         bool actorHost,
         HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        foreach (var (body, map) in ComputationLambdas.InvokedDelegateBodies(callee, host.SemanticModel, argumentMap))
+        foreach (var (body, map) in ComputationLambdas.InvokedDelegateBodies(invoke, host.SemanticModel, argumentMap))
         {
             if (visitedCalls.Add((body.Scope, host.TargetMethod, ComputationLambdas.ArgumentMapKey(map))))
             {

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -96,7 +96,37 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
+            if (operation is IInvocationOperation { TargetMethod.MethodKind: MethodKind.DelegateInvoke, Instance: { } callee })
+            {
+                InspectInvokedDelegate(context, host, callee, actorHost, visitedCalls, argumentMap);
+                continue;
+            }
+
             InspectExecutedCalls(context, host, operation, actorHost, visitedCalls, argumentMap);
+        }
+    }
+
+    // A delegate the computation synchronously INVOKES executes its body under the same
+    // evaluation lock: `d()` with a same-tree `Func<int> d = () => { _ = v.Set(1); ... };`
+    // throws exactly like the inline Set -- while a merely BUILT callback stays pruned
+    // (deferred execution holds no lock, and building one is this rule's own fix guidance).
+    // Aliases and parameter bindings resolve like the executed-call chase; anything
+    // unresolvable keeps the runtime backstop.
+    private static void InspectInvokedDelegate(
+        OperationAnalysisContext context,
+        IInvocationOperation host,
+        IOperation callee,
+        bool actorHost,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        var resolved = ComputationLambdas.ResolveDelegateValue(callee, host.SemanticModel, argumentMap);
+        foreach (var body in ComputationLambdas.OfArgumentValue(resolved, host.SemanticModel))
+        {
+            if (visitedCalls.Add((body.Scope, host.TargetMethod, ComputationLambdas.ArgumentMapKey(argumentMap))))
+            {
+                InspectExecutedBody(context, host, body.Body, actorHost, visitedCalls, argumentMap);
+            }
         }
     }
 

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -71,7 +71,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var method in ExecutedMethods(operation))
+            foreach (var method in ComputationLambdas.ExecutedMethods(operation))
             {
                 if (!ComputationLambdas.IsInsideNameOf(operation)
                     && visitedHelpers.Add(method)
@@ -81,58 +81,6 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
-    }
-
-    // Same-tree code the computation EXECUTES, whatever the syntax: a call, a property access
-    // (a read runs the getter, an assignment target runs the setter, compound forms run
-    // both), a constructor, or a user-defined operator/conversion -- `new Writer(v)` whose
-    // constructor Sets throws under the same evaluation lock as an inline Set. (A property
-    // mentioned only in nameof is not executed and must not be chased.)
-    private static IEnumerable<IMethodSymbol> ExecutedMethods(IOperation operation)
-    {
-        switch (operation)
-        {
-            case IInvocationOperation invocation:
-                yield return invocation.TargetMethod;
-                break;
-            case IPropertyReferenceOperation property:
-                var (reads, writes) = PropertyUsage(property);
-                if (reads && property.Property.GetMethod is { } getter)
-                {
-                    yield return getter;
-                }
-
-                if (writes && property.Property.SetMethod is { } setter)
-                {
-                    yield return setter;
-                }
-
-                break;
-            case IObjectCreationOperation { Constructor: { } constructor }:
-                yield return constructor;
-                break;
-            case IBinaryOperation { OperatorMethod: { } binaryOperator }:
-                yield return binaryOperator;
-                break;
-            case IUnaryOperation { OperatorMethod: { } unaryOperator }:
-                yield return unaryOperator;
-                break;
-            case IConversionOperation { OperatorMethod: { } conversionOperator }:
-                yield return conversionOperator;
-                break;
-        }
-    }
-
-    private static (bool Reads, bool Writes) PropertyUsage(IPropertyReferenceOperation property)
-    {
-        return property.Parent switch
-        {
-            ISimpleAssignmentOperation assignment when ReferenceEquals(assignment.Target, property) => (false, true),
-            ICompoundAssignmentOperation compound when ReferenceEquals(compound.Target, property) => (true, true),
-            ICoalesceAssignmentOperation coalesce when ReferenceEquals(coalesce.Target, property) => (true, true),
-            IIncrementOrDecrementOperation increment when ReferenceEquals(increment.Target, property) => (true, true),
-            _ => (true, false),
-        };
     }
 
     // A cross-CONTEXT lock-engine Set does not throw at runtime: the Set locks the target

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -53,10 +53,15 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         {
             foreach (var argument in invocation.Arguments)
             {
-                foreach (var body in ComputationLambdas.AssembledPatchBodies(argument.Value, invocation.SemanticModel))
+                if (argument.Parameter?.Type is not { TypeKind: TypeKind.Delegate })
+                {
+                    continue;
+                }
+
+                foreach (var (body, map) in ComputationLambdas.AssembledPatchBodies(argument.Value, invocation.SemanticModel))
                 {
                     var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
-                    InspectExecutedBody(context, invocation, body.Body, actorHost, visitedCalls, argumentMap: null);
+                    InspectExecutedBody(context, invocation, body.Body, actorHost, visitedCalls, map);
                 }
             }
         }

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -38,8 +38,11 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
 
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
-            var visitedHelpers = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-            InspectExecutedBody(context, invocation, computation.Body, actorHost, visitedHelpers, argumentMap: null);
+            // Keyed per CALL SITE, not per method: the same helper called with different
+            // signal arguments has different target provenance at each call, and a recursive
+            // helper re-reaches its own call site and stops there.
+            var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol)>();
+            InspectExecutedBody(context, invocation, computation.Body, actorHost, visitedCalls, argumentMap: null);
         }
     }
 
@@ -53,14 +56,14 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         IInvocationOperation host,
         IOperation body,
         bool actorHost,
-        HashSet<IMethodSymbol> visitedHelpers,
+        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         foreach (var operation in ComputationLambdas.DescendDirectExecution(body))
         {
             if (operation is IInvocationOperation inner && IsSameEngineSet(inner.TargetMethod, actorHost))
             {
-                if (!IsProvablyCrossFactory(host, inner, SubstituteArguments(inner.Instance, argumentMap), actorHost))
+                if (!IsProvablyCrossFactory(host, inner, ComputationLambdas.SubstituteArguments(inner.Instance, argumentMap), actorHost))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.SetInsideComputation,
@@ -75,61 +78,13 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
             foreach (var method in ComputationLambdas.ExecutedMethods(operation))
             {
                 if (!ComputationLambdas.IsInsideNameOf(operation)
-                    && visitedHelpers.Add(method)
+                    && visitedCalls.Add((operation.Syntax, method))
                     && ComputationLambdas.ResolveMethodBody(method, host.SemanticModel) is { } helper)
                 {
-                    InspectExecutedBody(context, host, helper.Body, actorHost, visitedHelpers, BuildArgumentMap(operation, argumentMap));
+                    InspectExecutedBody(context, host, helper.Body, actorHost, visitedCalls, ComputationLambdas.BuildArgumentMap(operation, argumentMap));
                 }
             }
         }
-    }
-
-    // Call-site arguments substitute for the helper's parameters when judging a chased Set's
-    // target provenance: in `void Write(Signal<int> s) => s.Set(2);` called as `Write(other)`,
-    // the target is `other`, exactly as the inline form -- a bare parameter would resolve to
-    // nothing and lose a legitimate cross-factory suppression. Maps are built pre-substituted,
-    // so nested helper calls resolve through to the original computation's operations. (One
-    // map per helper -- the visited set keeps the FIRST call site's arguments; re-walking per
-    // call site is not worth the cost for the precision it would buy.)
-    private static Dictionary<IParameterSymbol, IOperation>? BuildArgumentMap(IOperation operation, Dictionary<IParameterSymbol, IOperation>? outer)
-    {
-        var arguments = operation switch
-        {
-            IInvocationOperation invocation => invocation.Arguments,
-            IObjectCreationOperation creation => creation.Arguments,
-            _ => default,
-        };
-
-        if (arguments.IsDefaultOrEmpty)
-        {
-            return null;
-        }
-
-        Dictionary<IParameterSymbol, IOperation>? map = null;
-        foreach (var argument in arguments)
-        {
-            if (argument.Parameter is { } parameter && SubstituteArguments(argument.Value, outer) is { } value)
-            {
-                map ??= new Dictionary<IParameterSymbol, IOperation>(SymbolEqualityComparer.Default);
-                map[parameter] = value;
-            }
-        }
-
-        return map;
-    }
-
-    private static IOperation? SubstituteArguments(IOperation? reference, Dictionary<IParameterSymbol, IOperation>? argumentMap)
-    {
-        var current = reference;
-        while (current is IConversionOperation conversion)
-        {
-            current = conversion.Operand;
-        }
-
-        return current is IParameterReferenceOperation parameterReference
-            && argumentMap?.TryGetValue(parameterReference.Parameter, out var argument) == true
-            ? argument
-            : reference;
     }
 
     // A cross-CONTEXT lock-engine Set does not throw at runtime: the Set locks the target

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -38,10 +38,11 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
 
         foreach (var computation in ComputationLambdas.OfInvocation(invocation))
         {
-            // Keyed per CALL SITE, not per method: the same helper called with different
-            // signal arguments has different target provenance at each call, and a recursive
-            // helper re-reaches its own call site and stops there.
-            var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol)>();
+            // Keyed per CALL SITE and ARGUMENT BINDING, not per method: the same helper (or
+            // the same nested call inside it) reached with different signal arguments has
+            // different target provenance each time, while a recursive helper -- whose
+            // rebuilt map carries the same substituted values -- stops.
+            var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
             InspectExecutedBody(context, invocation, computation.Body, actorHost, visitedCalls, argumentMap: null);
         }
     }
@@ -56,7 +57,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         IInvocationOperation host,
         IOperation body,
         bool actorHost,
-        HashSet<(SyntaxNode, IMethodSymbol)> visitedCalls,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
         foreach (var operation in ComputationLambdas.DescendDirectExecution(body))
@@ -75,14 +76,30 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var method in ComputationLambdas.ExecutedMethods(operation))
+            InspectExecutedCalls(context, host, operation, actorHost, visitedCalls, argumentMap);
+        }
+    }
+
+    private static void InspectExecutedCalls(
+        OperationAnalysisContext context,
+        IInvocationOperation host,
+        IOperation operation,
+        bool actorHost,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
+        Dictionary<IParameterSymbol, IOperation>? argumentMap)
+    {
+        foreach (var method in ComputationLambdas.ExecutedMethods(operation))
+        {
+            if (ComputationLambdas.IsInsideNameOf(operation)
+                || ComputationLambdas.ResolveMethodBody(method, host.SemanticModel) is not { } helper)
             {
-                if (!ComputationLambdas.IsInsideNameOf(operation)
-                    && visitedCalls.Add((operation.Syntax, method))
-                    && ComputationLambdas.ResolveMethodBody(method, host.SemanticModel) is { } helper)
-                {
-                    InspectExecutedBody(context, host, helper.Body, actorHost, visitedCalls, ComputationLambdas.BuildArgumentMap(operation, argumentMap));
-                }
+                continue;
+            }
+
+            var nestedMap = ComputationLambdas.BuildArgumentMap(operation, argumentMap);
+            if (visitedCalls.Add((operation.Syntax, method, ComputationLambdas.ArgumentMapKey(nestedMap))))
+            {
+                InspectExecutedBody(context, host, helper.Body, actorHost, visitedCalls, nestedMap);
             }
         }
     }

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -63,7 +63,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         {
             if (operation is IInvocationOperation inner && IsSameEngineSet(inner.TargetMethod, actorHost))
             {
-                if (!IsProvablyCrossFactory(host, inner, ComputationLambdas.SubstituteArguments(inner.Instance, argumentMap), actorHost))
+                if (!IsProvablyCrossFactory(host, inner, argumentMap, actorHost))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.SetInsideComputation,
@@ -96,7 +96,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
     // diagnostic, because the overwhelmingly common case is one shared context and the runtime
     // exception is deterministic there. Actor hosts are exempt from the check: ActorSignal.Set
     // rejects on the flow's frame, which any actor computation carries regardless of context.
-    private static bool IsProvablyCrossFactory(IInvocationOperation host, IInvocationOperation setInvocation, IOperation? targetReference, bool actorHost)
+    private static bool IsProvablyCrossFactory(IInvocationOperation host, IInvocationOperation setInvocation, Dictionary<IParameterSymbol, IOperation>? argumentMap, bool actorHost)
     {
         if (actorHost)
         {
@@ -104,7 +104,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         }
 
         var hostFactory = ResolveHostFactory(host);
-        var targetFactory = ReceiverChains.ResolveCreatingFactorySymbol(targetReference ?? setInvocation.Instance, setInvocation.SemanticModel);
+        var targetFactory = ReceiverChains.ResolveCreatingFactorySymbol(setInvocation.Instance, setInvocation.SemanticModel, argumentMap);
         if (hostFactory is null
             || targetFactory is null
             || SymbolEqualityComparer.Default.Equals(hostFactory, targetFactory))

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -57,12 +57,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
     {
         foreach (var operation in ComputationLambdas.DescendDirectExecution(body))
         {
-            if (operation is not IInvocationOperation inner)
-            {
-                continue;
-            }
-
-            if (IsSameEngineSet(inner.TargetMethod, actorHost))
+            if (operation is IInvocationOperation inner && IsSameEngineSet(inner.TargetMethod, actorHost))
             {
                 if (!IsProvablyCrossFactory(host, inner, actorHost))
                 {
@@ -76,12 +71,33 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (visitedHelpers.Add(inner.TargetMethod)
-                && ComputationLambdas.ResolveMethodBody(inner.TargetMethod, host.SemanticModel) is { } helper)
+            if (ExecutedMethod(operation) is { } method
+                && !ComputationLambdas.IsInsideNameOf(operation)
+                && visitedHelpers.Add(method)
+                && ComputationLambdas.ResolveMethodBody(method, host.SemanticModel) is { } helper)
             {
                 InspectExecutedBody(context, host, helper.Body, actorHost, visitedHelpers);
             }
         }
+    }
+
+    // Same-tree code the computation EXECUTES, whatever the syntax: a call, a property read
+    // (its getter runs like a call), a constructor, or a user-defined operator/conversion --
+    // `new Writer(v)` whose constructor Sets throws under the same evaluation lock as an
+    // inline Set. (A property mentioned only in nameof is not executed and must not be
+    // chased.)
+    private static IMethodSymbol? ExecutedMethod(IOperation operation)
+    {
+        return operation switch
+        {
+            IInvocationOperation invocation => invocation.TargetMethod,
+            IPropertyReferenceOperation property => property.Property.GetMethod,
+            IObjectCreationOperation creation => creation.Constructor,
+            IBinaryOperation { OperatorMethod: { } binaryOperator } => binaryOperator,
+            IUnaryOperation { OperatorMethod: { } unaryOperator } => unaryOperator,
+            IConversionOperation { OperatorMethod: { } conversionOperator } => conversionOperator,
+            _ => null,
+        };
     }
 
     // A cross-CONTEXT lock-engine Set does not throw at runtime: the Set locks the target

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -110,8 +110,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
     // evaluation lock: `d()` with a same-tree `Func<int> d = () => { _ = v.Set(1); ... };`
     // throws exactly like the inline Set -- while a merely BUILT callback stays pruned
     // (deferred execution holds no lock, and building one is this rule's own fix guidance).
-    // Aliases and parameter bindings resolve like the executed-call chase; anything
-    // unresolvable keeps the runtime backstop.
+    // Anything the shared resolution cannot reach keeps the runtime backstop.
     private static void InspectInvokedDelegate(
         OperationAnalysisContext context,
         IInvocationOperation host,
@@ -120,62 +119,7 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
         Dictionary<IParameterSymbol, IOperation>? argumentMap)
     {
-        var resolved = ComputationLambdas.ResolveDelegateValue(ComputationLambdas.ResolveConditionalReceiver(callee), host.SemanticModel, argumentMap);
-        var found = false;
-        foreach (var body in ComputationLambdas.OfArgumentValue(resolved, host.SemanticModel))
-        {
-            found = true;
-            if (visitedCalls.Add((body.Scope, host.TargetMethod, ComputationLambdas.ArgumentMapKey(argumentMap))))
-            {
-                InspectExecutedBody(context, host, body.Body, actorHost, visitedCalls, argumentMap);
-            }
-        }
-
-        if (!found)
-        {
-            InspectInvokedFactoryResult(context, host, resolved, actorHost, visitedCalls, argumentMap);
-        }
-    }
-
-    // `Get()(x)` executes whatever the same-tree factory returned -- and `Step()` whatever
-    // the computed property's getter returned -- immediately and under the same lock: the
-    // returns are walked with their own maps, cycles bounded by the per-body visited guard.
-    private static void InspectInvokedFactoryResult(
-        OperationAnalysisContext context,
-        IInvocationOperation host,
-        IOperation resolved,
-        bool actorHost,
-        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls,
-        Dictionary<IParameterSymbol, IOperation>? argumentMap)
-    {
-        while (resolved is IConversionOperation conversion)
-        {
-            resolved = conversion.Operand;
-        }
-
-        if (resolved is IInvocationOperation call
-            && ComputationLambdas.ResolveMethodBody(call.TargetMethod, host.SemanticModel) is { } factory)
-        {
-            InspectReturnedInvokedBodies(context, host, factory, ComputationLambdas.BuildArgumentMap(call, argumentMap), actorHost, visitedCalls);
-            return;
-        }
-
-        if (ComputationLambdas.ReferencedVariable(resolved) is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
-            && ComputationLambdas.ResolveMethodBody(getter, host.SemanticModel) is { } getterBody)
-        {
-            InspectReturnedInvokedBodies(context, host, getterBody, ComputationLambdas.BuildArgumentMap(resolved, argumentMap), actorHost, visitedCalls);
-        }
-    }
-
-    private static void InspectReturnedInvokedBodies(
-        OperationAnalysisContext context,
-        IInvocationOperation host,
-        ComputationLambdas.ComputationBody source,
-        Dictionary<IParameterSymbol, IOperation>? sourceMap,
-        bool actorHost,
-        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls)
-    {
-        foreach (var (body, map) in ComputationLambdas.ReturnedBodies(source, host.SemanticModel, sourceMap))
+        foreach (var (body, map) in ComputationLambdas.InvokedDelegateBodies(callee, host.SemanticModel, argumentMap))
         {
             if (visitedCalls.Add((body.Scope, host.TargetMethod, ComputationLambdas.ArgumentMapKey(map))))
             {
@@ -224,18 +168,28 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        // Each resolution walks alias chains, so the chain is ordered to stop at the first
+        // unprovable link rather than resolving both sides and then discarding one.
         var hostFactory = ResolveHostFactory(host);
+        if (hostFactory is null)
+        {
+            return false;
+        }
+
         var targetFactory = ReceiverChains.ResolveCreatingFactorySymbol(setInvocation.Instance, setInvocation.SemanticModel, argumentMap);
-        if (hostFactory is null
-            || targetFactory is null
-            || SymbolEqualityComparer.Default.Equals(hostFactory, targetFactory))
+        if (targetFactory is null || SymbolEqualityComparer.Default.Equals(hostFactory, targetFactory))
         {
             return false;
         }
 
         var hostContext = ReceiverChains.ResolveFactoryContextKey(hostFactory, host.SemanticModel);
+        if (!hostContext.Resolved)
+        {
+            return false;
+        }
+
         var targetContext = ReceiverChains.ResolveFactoryContextKey(targetFactory, setInvocation.SemanticModel);
-        if (!hostContext.Resolved || !targetContext.Resolved)
+        if (!targetContext.Resolved)
         {
             return false;
         }

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -71,32 +71,67 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (ExecutedMethod(operation) is { } method
-                && !ComputationLambdas.IsInsideNameOf(operation)
-                && visitedHelpers.Add(method)
-                && ComputationLambdas.ResolveMethodBody(method, host.SemanticModel) is { } helper)
+            foreach (var method in ExecutedMethods(operation))
             {
-                InspectExecutedBody(context, host, helper.Body, actorHost, visitedHelpers);
+                if (!ComputationLambdas.IsInsideNameOf(operation)
+                    && visitedHelpers.Add(method)
+                    && ComputationLambdas.ResolveMethodBody(method, host.SemanticModel) is { } helper)
+                {
+                    InspectExecutedBody(context, host, helper.Body, actorHost, visitedHelpers);
+                }
             }
         }
     }
 
-    // Same-tree code the computation EXECUTES, whatever the syntax: a call, a property read
-    // (its getter runs like a call), a constructor, or a user-defined operator/conversion --
-    // `new Writer(v)` whose constructor Sets throws under the same evaluation lock as an
-    // inline Set. (A property mentioned only in nameof is not executed and must not be
-    // chased.)
-    private static IMethodSymbol? ExecutedMethod(IOperation operation)
+    // Same-tree code the computation EXECUTES, whatever the syntax: a call, a property access
+    // (a read runs the getter, an assignment target runs the setter, compound forms run
+    // both), a constructor, or a user-defined operator/conversion -- `new Writer(v)` whose
+    // constructor Sets throws under the same evaluation lock as an inline Set. (A property
+    // mentioned only in nameof is not executed and must not be chased.)
+    private static IEnumerable<IMethodSymbol> ExecutedMethods(IOperation operation)
     {
-        return operation switch
+        switch (operation)
         {
-            IInvocationOperation invocation => invocation.TargetMethod,
-            IPropertyReferenceOperation property => property.Property.GetMethod,
-            IObjectCreationOperation creation => creation.Constructor,
-            IBinaryOperation { OperatorMethod: { } binaryOperator } => binaryOperator,
-            IUnaryOperation { OperatorMethod: { } unaryOperator } => unaryOperator,
-            IConversionOperation { OperatorMethod: { } conversionOperator } => conversionOperator,
-            _ => null,
+            case IInvocationOperation invocation:
+                yield return invocation.TargetMethod;
+                break;
+            case IPropertyReferenceOperation property:
+                var (reads, writes) = PropertyUsage(property);
+                if (reads && property.Property.GetMethod is { } getter)
+                {
+                    yield return getter;
+                }
+
+                if (writes && property.Property.SetMethod is { } setter)
+                {
+                    yield return setter;
+                }
+
+                break;
+            case IObjectCreationOperation { Constructor: { } constructor }:
+                yield return constructor;
+                break;
+            case IBinaryOperation { OperatorMethod: { } binaryOperator }:
+                yield return binaryOperator;
+                break;
+            case IUnaryOperation { OperatorMethod: { } unaryOperator }:
+                yield return unaryOperator;
+                break;
+            case IConversionOperation { OperatorMethod: { } conversionOperator }:
+                yield return conversionOperator;
+                break;
+        }
+    }
+
+    private static (bool Reads, bool Writes) PropertyUsage(IPropertyReferenceOperation property)
+    {
+        return property.Parent switch
+        {
+            ISimpleAssignmentOperation assignment when ReferenceEquals(assignment.Target, property) => (false, true),
+            ICompoundAssignmentOperation compound when ReferenceEquals(compound.Target, property) => (true, true),
+            ICoalesceAssignmentOperation coalesce when ReferenceEquals(coalesce.Target, property) => (true, true),
+            IIncrementOrDecrementOperation increment when ReferenceEquals(increment.Target, property) => (true, true),
+            _ => (true, false),
         };
     }
 

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -137,9 +137,9 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // `Get()(x)` executes whatever the same-tree factory returned, immediately and under
-    // the same lock: the returns are walked with their own maps, cycles bounded by the
-    // per-body visited guard.
+    // `Get()(x)` executes whatever the same-tree factory returned -- and `Step()` whatever
+    // the computed property's getter returned -- immediately and under the same lock: the
+    // returns are walked with their own maps, cycles bounded by the per-body visited guard.
     private static void InspectInvokedFactoryResult(
         OperationAnalysisContext context,
         IInvocationOperation host,
@@ -153,13 +153,29 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
             resolved = conversion.Operand;
         }
 
-        if (resolved is not IInvocationOperation call
-            || ComputationLambdas.ResolveMethodBody(call.TargetMethod, host.SemanticModel) is not { } factory)
+        if (resolved is IInvocationOperation call
+            && ComputationLambdas.ResolveMethodBody(call.TargetMethod, host.SemanticModel) is { } factory)
         {
+            InspectReturnedInvokedBodies(context, host, factory, ComputationLambdas.BuildArgumentMap(call, argumentMap), actorHost, visitedCalls);
             return;
         }
 
-        foreach (var (body, map) in ComputationLambdas.ReturnedBodies(factory, host.SemanticModel, ComputationLambdas.BuildArgumentMap(call, argumentMap)))
+        if (ComputationLambdas.ReferencedVariable(resolved) is IPropertySymbol { GetMethod: { } getter, SetMethod: null }
+            && ComputationLambdas.ResolveMethodBody(getter, host.SemanticModel) is { } getterBody)
+        {
+            InspectReturnedInvokedBodies(context, host, getterBody, ComputationLambdas.BuildArgumentMap(resolved, argumentMap), actorHost, visitedCalls);
+        }
+    }
+
+    private static void InspectReturnedInvokedBodies(
+        OperationAnalysisContext context,
+        IInvocationOperation host,
+        ComputationLambdas.ComputationBody source,
+        Dictionary<IParameterSymbol, IOperation>? sourceMap,
+        bool actorHost,
+        HashSet<(SyntaxNode, IMethodSymbol, string)> visitedCalls)
+    {
+        foreach (var (body, map) in ComputationLambdas.ReturnedBodies(source, host.SemanticModel, sourceMap))
         {
             if (visitedCalls.Add((body.Scope, host.TargetMethod, ComputationLambdas.ArgumentMapKey(map))))
             {
@@ -239,51 +255,13 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
     {
         if (FactoryMethods.IsOptimisticPatchHost(host.TargetMethod))
         {
+            // Computed state properties (indexers included) resolve inside the node
+            // resolver, through their getter's agreeing returns.
             var stateArgument = host.Arguments.FirstOrDefault(a => a.Parameter?.Ordinal == 0)?.Value;
-            return ReceiverChains.ResolveCreatingFactorySymbol(stateArgument, host.SemanticModel)
-                ?? ResolveComputedStateFactory(stateArgument, host.SemanticModel);
+            return ReceiverChains.ResolveCreatingFactorySymbol(stateArgument, host.SemanticModel);
         }
 
         return ReceiverChains.ResolveFactorySymbol(host, host.SemanticModel);
-    }
-
-    // A get-only computed STATE property (`OptimisticState<int> State => f1.CreateOptimistic(...)`)
-    // resolves through its getter's returns -- and only when EVERY return agrees on the
-    // creating factory: a getter that can hand back states from different factories keeps
-    // the host unprovable, which keeps the diagnostic.
-    private static ISymbol? ResolveComputedStateFactory(IOperation? stateArgument, SemanticModel? semanticModel)
-    {
-        var reference = stateArgument;
-        while (reference is IConversionOperation conversion)
-        {
-            reference = conversion.Operand;
-        }
-
-        if (reference is null
-            || ComputationLambdas.ReferencedVariable(reference) is not IPropertySymbol { GetMethod: { } getter, SetMethod: null }
-            || ComputationLambdas.ResolveMethodBody(getter, semanticModel) is not { } getterBody)
-        {
-            return null;
-        }
-
-        ISymbol? factory = null;
-        foreach (var inner in ComputationLambdas.DescendDirectExecution(getterBody.Body))
-        {
-            if (inner is not IReturnOperation { ReturnedValue: { } returned })
-            {
-                continue;
-            }
-
-            var resolved = ReceiverChains.ResolveCreatingFactorySymbol(returned, semanticModel);
-            if (resolved is null || (factory is not null && !SymbolEqualityComparer.Default.Equals(factory, resolved)))
-            {
-                return null;
-            }
-
-            factory = resolved;
-        }
-
-        return factory;
     }
 
     // A write API that throws in THIS host's engine: ActorSignal.Set inside an actor

--- a/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
+++ b/MemoizR.Analyzers/SetInsideComputationAnalyzer.cs
@@ -45,6 +45,21 @@ public sealed class SetInsideComputationAnalyzer : DiagnosticAnalyzer
             var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
             InspectExecutedBody(context, invocation, computation.Body, actorHost, visitedCalls, argumentMap: null);
         }
+
+        // Patch shapes resolved beyond plain arguments -- assembled by an out-helper, or
+        // returned by a computed delegate property -- still run under the evaluation lock,
+        // so their Sets throw exactly like an inline patch's.
+        if (FactoryMethods.IsOptimisticPatchHost(invocation.TargetMethod))
+        {
+            foreach (var argument in invocation.Arguments)
+            {
+                foreach (var body in ComputationLambdas.AssembledPatchBodies(argument.Value, invocation.SemanticModel))
+                {
+                    var visitedCalls = new HashSet<(SyntaxNode, IMethodSymbol, string)>();
+                    InspectExecutedBody(context, invocation, body.Body, actorHost, visitedCalls, argumentMap: null);
+                }
+            }
+        }
     }
 
     // Direct execution path only: a Set inside a callback the computation merely BUILDS (the

--- a/MemoizR.Blazor/MemoizR.Blazor.csproj
+++ b/MemoizR.Blazor/MemoizR.Blazor.csproj
@@ -4,6 +4,15 @@
     <ProjectReference Include="..\MemoizR.Reactive\MemoizR.Reactive.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- NuGet does not flow analyzer assets through package dependencies, so a consumer
+         installing only this package would write actions, patches and reactions with no MZR
+         diagnostics. Same packing as MemoizR.csproj; identical analyzer assemblies are
+         deduplicated by MVID when several MemoizR packages are referenced. -->
+    <ProjectReference Include="..\MemoizR.Analyzers\MemoizR.Analyzers.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <None Include="$(ArtifactsPath)\bin\MemoizR.Analyzers\$(Configuration.ToLowerInvariant())\MemoizR.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>MemoizR.Blazor</PackageId>

--- a/MemoizR.Reactive/MemoizR.Reactive.csproj
+++ b/MemoizR.Reactive/MemoizR.Reactive.csproj
@@ -4,6 +4,17 @@
     <ProjectReference Include="..\MemoizR\MemoizR.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- NuGet does not flow analyzer assets through package dependencies (the dependency on
+         MemoizR is packed with the default exclude="Build,Analyzers"), so a consumer
+         installing only this package would build the very APIs the MZR rules cover (Apply
+         patches, CreateAction/CreateOptimistic) with no diagnostics. Same packing as
+         MemoizR.csproj; when both packages are referenced the compiler deduplicates the
+         identical analyzer assembly by MVID. -->
+    <ProjectReference Include="..\MemoizR.Analyzers\MemoizR.Analyzers.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <None Include="$(ArtifactsPath)\bin\MemoizR.Analyzers\$(Configuration.ToLowerInvariant())\MemoizR.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>MemoizR.Reactive</PackageId>

--- a/MemoizR.StructuredConcurrency/MemoizR.StructuredConcurrency.csproj
+++ b/MemoizR.StructuredConcurrency/MemoizR.StructuredConcurrency.csproj
@@ -2,7 +2,16 @@
   <ItemGroup>
     <ProjectReference Include="..\MemoizR\MemoizR.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <!-- NuGet does not flow analyzer assets through package dependencies, so a consumer
+         installing only this package would build the structured-concurrency factories the MZR
+         rules cover with no diagnostics. Same packing as MemoizR.csproj; identical analyzer
+         assemblies are deduplicated by MVID when several MemoizR packages are referenced. -->
+    <ProjectReference Include="..\MemoizR.Analyzers\MemoizR.Analyzers.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <None Include="$(ArtifactsPath)\bin\MemoizR.Analyzers\$(Configuration.ToLowerInvariant())\MemoizR.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>MemoizR.StructuredConcurrency</PackageId>

--- a/MemoizR.Wpf/MemoizR.Wpf.csproj
+++ b/MemoizR.Wpf/MemoizR.Wpf.csproj
@@ -4,6 +4,15 @@
     <ProjectReference Include="..\MemoizR.Reactive\MemoizR.Reactive.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- NuGet does not flow analyzer assets through package dependencies, so a consumer
+         installing only this package would write actions, patches and reactions with no MZR
+         diagnostics. Same packing as MemoizR.csproj; identical analyzer assemblies are
+         deduplicated by MVID when several MemoizR packages are referenced. -->
+    <ProjectReference Include="..\MemoizR.Analyzers\MemoizR.Analyzers.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <None Include="$(ArtifactsPath)\bin\MemoizR.Analyzers\$(Configuration.ToLowerInvariant())\MemoizR.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ The same discipline is checked at **build time** by analyzers bundled in the NuG
 |------|-------|
 | `MZR001` | A non-Sendable value type at a `Create*` call — the compile-time mirror of strict mode |
 | `MZR002` | A computation writing captured locals, fields, or statics — lift that state into a `Signal` |
-| `MZR003` | `Signal.Set` inside a computation, which throws `InvalidOperationException` at runtime |
+| `MZR003` | `Signal.Set` or `memo.Invalidate()` inside a computation, which throws `InvalidOperationException` at runtime |
+| `MZR004` | An optimistic patch capturing non-Sendable state — the patch re-runs inside the view's computation on whichever flow pulls it |
 
 Reaction side effects can be pinned to an **executor** — the analog of Swift's custom actor
 executors (SE-0392). `AddSynchronizationContext(uiContext)` covers UI threads;

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -136,6 +136,31 @@ lock. (The cost is a false negative for a nested function invoked synchronously 
 computation; the runtime exception still guards that path. MZR002 keeps the full walk: a
 captured-state write is a data race whenever the callback runs, deferred or not.)
 
+### MZR004 — optimistic patch captures non-Sendable state
+
+The closure-capture mirror of MZR001, closing the strict-mode gap recorded in ADR 0007: a patch
+passed to `OptimisticActionContext.Apply` is stored in the overlay and **re-executed by the
+view's computation on whichever flow pulls** the optimistic state, so everything the patch's
+closure captures crosses flows exactly like a node value — but the *runtime* cannot check it
+(closure display classes always carry writable fields, so a structural runtime check would
+reject every capturing lambda, immutable captures included).
+
+Flagged, once per captured symbol per patch:
+
+- a **captured local or parameter whose type is not Sendable** (the same classifier verdicts as
+  MZR001; type parameters keep the benefit of the doubt);
+- a read of **writable state on the enclosing object** (a non-readonly field, a settable
+  property) — the patch re-reads it on other flows while the owner mutates it freely;
+- a read of a **readonly/get-only member whose type is not Sendable** — the object handed out
+  is what gets shared. Computed get-only property bodies are not chased.
+
+Reads of Sendable-typed captures stay unflagged: capturing the action payload or other
+immutable snapshots is the idiomatic pattern. Captured-state **writes** inside a patch are
+MZR002's territory — `Apply` is classified as a computation host (the patch is genuinely
+engine-executed, unlike action *bodies*, which are user-driven process code and deliberately
+not hosts) — and a `Set` inside a patch is MZR003's, since the patch runs inside the view
+memo's recompute whose flow holds the evaluation lock.
+
 ### Testing strategy
 
 The analyzer tests compile snippets in-memory **against the real MemoizR assemblies**

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -174,12 +174,15 @@ Flagged, once per captured symbol per patch:
   deliberately ignores statics, meaning a Sendable `this` says nothing about them);
 - the **closure of a local function** the patch calls that is declared *outside* the patch —
   no receiver/`this` verdict covers it, so its body is inspected for captures against its own
-  declaration scope (one declared inside the patch is already walked under the patch's scope,
-  and its reads of patch-locals are patch-internal);
+  declaration scope. Only captures declared in a function *enclosing the patch* count: one
+  declared inside the patch is patch-internal, and a local of a *called helper* (captured by a
+  local function nested in that helper) is recreated on every execution, not stored in the
+  delegate;
 - an **already-built delegate that resolves to nothing walkable** (a `Func<T,T>`
-  field/parameter with no same-tree initializer) — the overlay stores it all the same, this
-  rule is the only check a patch ever gets, and a delegate can capture arbitrary mutable
-  state: unverifiable means flagged, like the classifier's unverifiable categories.
+  field/parameter with no same-tree initializer, or a variable *reassigned* after its
+  initializer — the overlay may store the second closure) — the overlay stores it all the
+  same, this rule is the only check a patch ever gets, and a delegate can capture arbitrary
+  mutable state: unverifiable means flagged, like the classifier's unverifiable categories.
 
 Reads of Sendable-typed captures stay unflagged: capturing the action payload or other
 immutable snapshots is the idiomatic pattern. Captured-state **writes** inside a patch are

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -187,7 +187,9 @@ Flagged, once per captured symbol per patch:
   same-tree code the patch *executes* is chased for them transitively: helper methods,
   property getters, constructors, user-defined operators/conversions, and delegates the patch
   builds *and* invokes (the classifier deliberately ignores statics, meaning a Sendable `this`
-  says nothing about them). Static
+  says nothing about them). Only *backing storage* gets the type verdict: a computed static
+  getter may hand out a fresh value per replay, so its body is chased instead of its return
+  type being judged. Static
   verdicts follow MZR003's *direct-execution* pruning: a read inside a callback the patch
   merely builds runs later, off the overlay's re-execution (closure captures keep the full
   walk — a built callback still pins them in the stored display chain);

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -180,7 +180,8 @@ Flagged, once per captured symbol per patch:
   sendability: hiding the read behind a helper must not evade the rule;
 - a read of **static state** that is writable or of a non-Sendable type (`const` is a
   compile-time value) — statics are shared across every flow without any capture at all, so
-  same-tree helper methods the patch calls are chased for them transitively (the classifier
+  same-tree code the patch *executes* is chased for them transitively: helper methods,
+  property getters, constructors, and user-defined operators/conversions (the classifier
   deliberately ignores statics, meaning a Sendable `this` says nothing about them). Static
   verdicts follow MZR003's *direct-execution* pruning: a read inside a callback the patch
   merely builds runs later, off the overlay's re-execution (closure captures keep the full

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -139,9 +139,12 @@ The walk is likewise scoped to the lock semantics: only the computation's **dire
 path** is inspected. Nested anonymous functions and local-function declarations are pruned,
 because a callback the computation merely *builds* — the diagnostic's own fix guidance,
 "schedule the write outside the evaluation" — runs later on a flow that holds no evaluation
-lock. (The cost is a false negative for a nested function invoked synchronously inside the
-computation; the runtime exception still guards that path. MZR002 keeps the full walk: a
-captured-state write is a data race whenever the callback runs, deferred or not.)
+lock. Same-tree helpers the computation **calls** on that path are chased, though: their `Set`
+executes under the same evaluation lock and throws identically, so hiding the write behind a
+local function does not evade the rule. (The remaining cost is a false negative for a
+*delegate* invoked synchronously inside the computation; the runtime exception still guards
+that path. MZR002 keeps the full walk: a captured-state write is a data race whenever the
+callback runs, deferred or not.)
 
 ### MZR004 — optimistic patch captures non-Sendable state
 

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -91,7 +91,11 @@ deconstructions (flattened through nested tuples: `(a, (b, c)) = ...` writes eve
 `ref`/`out` arguments, and non-`readonly` instance-method calls on value-type receivers that
 resolve to shared storage (`counter.Increment()` mutates the captured local exactly like
 `counter.Value++`; `readonly` members — which includes most BCL structs — and the
-object-virtual overrides stay exempt).
+object-virtual overrides stay exempt). A **local function** the computation calls (declared
+outside it, same tree) is chased for the same writes: its closure is the computation's
+environment, so `int Next() { applied++; ... }` is the inline `applied++` behind a name — while
+the helper's own per-call locals stay exempt (only storage declared in a function *enclosing
+the computation* counts).
 
 Deliberately **not** flagged:
 
@@ -174,7 +178,10 @@ Flagged, once per captured symbol per patch:
 - a read of **static state** that is writable or of a non-Sendable type (`const` is a
   compile-time value) — statics are shared across every flow without any capture at all, so
   same-tree helper methods the patch calls are chased for them transitively (the classifier
-  deliberately ignores statics, meaning a Sendable `this` says nothing about them);
+  deliberately ignores statics, meaning a Sendable `this` says nothing about them). Static
+  verdicts follow MZR003's *direct-execution* pruning: a read inside a callback the patch
+  merely builds runs later, off the overlay's re-execution (closure captures keep the full
+  walk — a built callback still pins them in the stored display chain);
 - the **closure of a local function** the patch calls that is declared *outside* the patch —
   no receiver/`this` verdict covers it, so its body is inspected for captures against its own
   declaration scope. Only captures declared in a function *enclosing the patch* count: one
@@ -182,10 +189,12 @@ Flagged, once per captured symbol per patch:
   local function nested in that helper) is recreated on every execution, not stored in the
   delegate;
 - an **already-built delegate that resolves to nothing walkable** (a `Func<T,T>`
-  field/parameter with no same-tree initializer, or a variable *reassigned* after its
-  initializer — the overlay may store the second closure) — the overlay stores it all the
-  same, this rule is the only check a patch ever gets, and a delegate can capture arbitrary
-  mutable state: unverifiable means flagged, like the classifier's unverifiable categories.
+  field/parameter with no same-tree initializer, or a variable *reassigned* — including
+  through deconstruction — where the assignment can execute before the call: a different
+  function body, textually earlier, or loop-carried into a variable that outlives the
+  iteration) — the overlay stores it all the same, this rule is the only check a patch ever
+  gets, and a delegate can capture arbitrary mutable state: unverifiable means flagged, like
+  the classifier's unverifiable categories.
 
 Reads of Sendable-typed captures stay unflagged: capturing the action payload or other
 immutable snapshots is the idiomatic pattern. Captured-state **writes** inside a patch are

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -150,8 +150,9 @@ Flagged, once per captured symbol per patch:
 - a **captured local or parameter whose type is not Sendable** (the same classifier verdicts as
   MZR001; type parameters keep the benefit of the doubt);
 - a read of **writable state on the enclosing object** (a non-readonly field, a settable
-  property; `init` counts as immutable) — the patch re-reads it on other flows while the owner
-  mutates it freely;
+  property; `init` counts as immutable, and a ref-returning property counts as writable — no
+  setter, but it hands out assignable live storage) — the patch re-reads it on other flows
+  while the owner mutates it freely;
 - a read of a **readonly/get-only member whose type is not Sendable** — the object handed out
   is what gets shared. Computed get-only property bodies are not chased. Both member verdicts
   refine a *non-Sendable* enclosing object only: an enclosing type the classifier accepts
@@ -162,14 +163,23 @@ Flagged, once per captured symbol per patch:
   method body lives in metadata and cannot be walked. A *mutable struct* receiver is flagged
   when the referenced method is non-readonly: the Sendable verdict for a value type rests on
   copy semantics, but the delegate stores one boxed copy that a non-readonly method mutates in
-  place;
+  place (extension methods never reach this verdict — CS1113 forbids creating a delegate from
+  a value-type extension receiver);
 - a **bare `this`** handed to a helper (`x => ReadCounter()`, `Use(this)`) — the whole
   enclosing object is captured with no member to inspect, so it is held to its type's
   sendability: hiding the read behind a helper must not evade the rule;
 - a read of **static state** that is writable or of a non-Sendable type (`const` is a
   compile-time value) — statics are shared across every flow without any capture at all, so
   same-tree helper methods the patch calls are chased for them transitively (the classifier
-  deliberately ignores statics, meaning a Sendable `this` says nothing about them).
+  deliberately ignores statics, meaning a Sendable `this` says nothing about them);
+- the **closure of a local function** the patch calls that is declared *outside* the patch —
+  no receiver/`this` verdict covers it, so its body is inspected for captures against its own
+  declaration scope (one declared inside the patch is already walked under the patch's scope,
+  and its reads of patch-locals are patch-internal);
+- an **already-built delegate that resolves to nothing walkable** (a `Func<T,T>`
+  field/parameter with no same-tree initializer) — the overlay stores it all the same, this
+  rule is the only check a patch ever gets, and a delegate can capture arbitrary mutable
+  state: unverifiable means flagged, like the classifier's unverifiable categories.
 
 Reads of Sendable-typed captures stay unflagged: capturing the action payload or other
 immutable snapshots is the idiomatic pattern. Captured-state **writes** inside a patch are

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -18,7 +18,10 @@ deliberately does and does not flag, and the constraints Roslyn imposes.
 ## Decision
 
 A new `MemoizR.Analyzers` project (netstandard2.0, Roslyn 4.8 floor so any SDK ≥ 8 can load it)
-ships **inside the MemoizR NuGet package** (`analyzers/dotnet/cs`), so every consumer gets the
+ships **inside every graph-facing MemoizR NuGet package** (`analyzers/dotnet/cs` in MemoizR,
+MemoizR.Reactive, MemoizR.StructuredConcurrency, MemoizR.Blazor and MemoizR.Wpf — NuGet does
+not flow analyzer assets through package dependencies, and the compiler deduplicates the
+identical assembly by MVID when several are referenced), so every consumer gets the
 rules on build with no extra reference. All rules default to **Warning** — the Swift 5.x
 "strict concurrency warnings" migration posture — and are configurable per project via
 `.editorconfig` (`dotnet_diagnostic.MZR001.severity = error|suggestion|none`).

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -150,9 +150,18 @@ Flagged, once per captured symbol per patch:
 - a **captured local or parameter whose type is not Sendable** (the same classifier verdicts as
   MZR001; type parameters keep the benefit of the doubt);
 - a read of **writable state on the enclosing object** (a non-readonly field, a settable
-  property) — the patch re-reads it on other flows while the owner mutates it freely;
+  property; `init` counts as immutable) — the patch re-reads it on other flows while the owner
+  mutates it freely;
 - a read of a **readonly/get-only member whose type is not Sendable** — the object handed out
-  is what gets shared. Computed get-only property bodies are not chased.
+  is what gets shared. Computed get-only property bodies are not chased;
+- a **method-group patch's receiver** (`ctx.Apply(state, helper.Patch)`, directly or stored in
+  a delegate variable first) — the receiver is captured into the stored delegate even when the
+  method body lives in metadata and cannot be walked;
+- a **bare `this`** handed to a helper (`x => ReadCounter()`, `Use(this)`) — the whole
+  enclosing object is captured with no member to inspect, so it is held to its type's
+  sendability: hiding the read behind a helper must not evade the rule;
+- a read of **static state** that is writable or of a non-Sendable type (`const` is a
+  compile-time value) — statics are shared across every flow without any capture at all.
 
 Reads of Sendable-typed captures stay unflagged: capturing the action payload or other
 immutable snapshots is the idiomatic pattern. Captured-state **writes** inside a patch are

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -155,7 +155,10 @@ reject every capturing lambda, immutable captures included).
 Flagged, once per captured symbol per patch:
 
 - a **captured local or parameter whose type is not Sendable** (the same classifier verdicts as
-  MZR001; type parameters keep the benefit of the doubt);
+  MZR001; type parameters keep the benefit of the doubt) — or whose type is a **mutable
+  struct**: the classifier accepts those for node *values* because values are copied, but a
+  closure hoists the *variable* itself, so the owner mutates the same storage the stored patch
+  re-reads;
 - a read of **writable state on the enclosing object** (a non-readonly field, a settable
   property; `init` counts as immutable, and a ref-returning property counts as writable — no
   setter, but it hands out assignable live storage) — the patch re-reads it on other flows

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -179,10 +179,12 @@ Flagged, once per captured symbol per patch:
   enclosing object is captured with no member to inspect, so it is held to its type's
   sendability: hiding the read behind a helper must not evade the rule;
 - a read of **static state** that is writable or of a non-Sendable type (`const` is a
-  compile-time value) — statics are shared across every flow without any capture at all, so
+  compile-time value; a static *event* always counts as writable — subscribing mutates its
+  backing delegate) — statics are shared across every flow without any capture at all, so
   same-tree code the patch *executes* is chased for them transitively: helper methods,
-  property getters, constructors, and user-defined operators/conversions (the classifier
-  deliberately ignores statics, meaning a Sendable `this` says nothing about them). Static
+  property getters, constructors, user-defined operators/conversions, and delegates the patch
+  builds *and* invokes (the classifier deliberately ignores statics, meaning a Sendable `this`
+  says nothing about them). Static
   verdicts follow MZR003's *direct-execution* pruning: a read inside a callback the patch
   merely builds runs later, off the overlay's re-execution (closure captures keep the full
   walk — a built callback still pins them in the stored display chain);

--- a/docs/adr/0004-compile-time-data-race-diagnostics.md
+++ b/docs/adr/0004-compile-time-data-race-diagnostics.md
@@ -153,15 +153,23 @@ Flagged, once per captured symbol per patch:
   property; `init` counts as immutable) — the patch re-reads it on other flows while the owner
   mutates it freely;
 - a read of a **readonly/get-only member whose type is not Sendable** — the object handed out
-  is what gets shared. Computed get-only property bodies are not chased;
+  is what gets shared. Computed get-only property bodies are not chased. Both member verdicts
+  refine a *non-Sendable* enclosing object only: an enclosing type the classifier accepts
+  (`[Sendable]`, structurally immutable) is trusted wholesale, exactly as the runtime checker
+  and MZR001 trust it;
 - a **method-group patch's receiver** (`ctx.Apply(state, helper.Patch)`, directly or stored in
   a delegate variable first) — the receiver is captured into the stored delegate even when the
-  method body lives in metadata and cannot be walked;
+  method body lives in metadata and cannot be walked. A *mutable struct* receiver is flagged
+  when the referenced method is non-readonly: the Sendable verdict for a value type rests on
+  copy semantics, but the delegate stores one boxed copy that a non-readonly method mutates in
+  place;
 - a **bare `this`** handed to a helper (`x => ReadCounter()`, `Use(this)`) — the whole
   enclosing object is captured with no member to inspect, so it is held to its type's
   sendability: hiding the read behind a helper must not evade the rule;
 - a read of **static state** that is writable or of a non-Sendable type (`const` is a
-  compile-time value) — statics are shared across every flow without any capture at all.
+  compile-time value) — statics are shared across every flow without any capture at all, so
+  same-tree helper methods the patch calls are chased for them transitively (the classifier
+  deliberately ignores statics, meaning a Sendable `this` says nothing about them).
 
 Reads of Sendable-typed captures stay unflagged: capturing the action payload or other
 immutable snapshots is the idiomatic pattern. Captured-state **writes** inside a patch are

--- a/docs/adr/0007-transitions-pending-and-optimistic-state.md
+++ b/docs/adr/0007-transitions-pending-and-optimistic-state.md
@@ -1,7 +1,8 @@
 # ADR 0007 — Transitions, `IsPending`, and optimistic state with automatic rollback
 
 - Status: Proposed (phases 1–4 implemented, including the optimistic-todo sample app with bUnit
-  component tests; phase 5 open)
+  component tests; of phase 5, the patch-purity analyzer (MZR004) is implemented — the
+  `WriteBatch` decision and actor-engine parity remain open)
 - Date: 2026-07-15
 - Deciders: MemoizR maintainers
 - Inspiration: Solid 2.0's async architecture (deferred stabilization, `isPending`,
@@ -263,17 +264,16 @@ Where the landed code deliberately deviates from the sketches above:
   notifications carry the faulted update's generation token and are gated by the same
   threshold rule as commits, so an old in-flight failure cannot fault a newer wavefront whose
   superseding update is still owed a commit.
-- Known strict-mode gap, deferred to the phase-5 analyzers: optimistic patch DELEGATES are not
-  runtime-validated. A patch runs inside the view's computation on whichever flow pulls, so a
-  lambda closing over mutable state crosses flows — but closure display classes always carry
-  writable fields, so a structural runtime check would reject every capturing lambda, including
-  harmless immutable captures. This is exactly MZR002-shaped compile-time work: an analyzer
-  rule flagging optimistic patches that capture mutable state (the payload type itself IS
-  checked — `CreateAction` gates `TPayload` through the strict Sendable bar). Action BODIES
-  are deliberately not classified as MZR002 computation hosts: they are user-driven process
-  code whose runs overlap only when the caller overlaps them, and the common
-  one-run-at-a-time pattern legitimately writes captured state — if wanted, that is a
-  separate, lower-severity rule.
+- The strict-mode gap for optimistic patch DELEGATES (a patch runs inside the view's
+  computation on whichever flow pulls, so a lambda closing over mutable state crosses flows,
+  but closure display classes always carry writable fields, so a structural RUNTIME check
+  would reject every capturing lambda) is closed at build time by the phase-5 analyzers:
+  **MZR004** flags non-Sendable captures and reads of writable enclosing-object state in
+  patches, and `Apply` is classified as a computation host so a captured-state WRITE in a
+  patch is MZR002's data race and a `Set` in one is MZR003's runtime throw (see ADR 0004).
+  Action BODIES remain deliberately unclassified: they are user-driven process code whose
+  runs overlap only when the caller overlaps them, and the common one-run-at-a-time pattern
+  legitimately writes captured state — if wanted, that is a separate, lower-severity rule.
 - Phase 4 landed as `MemoizR.Blazor`: `BlazorDispatcherExecutor` (the exact
   `WpfDispatcherExecutor` mirror), a component-agnostic `ReactionBinder` (the render-snapshot
   pattern: apply-into-field plus `StateHasChanged`, both marshalled through `InvokeAsync`),


### PR DESCRIPTION
Closes the strict-mode gap recorded in ADR 0007 (follow-up to #152/#155): optimistic patch delegates could not be runtime-validated — closure display classes always carry writable fields, so a structural runtime check would reject every capturing lambda, immutable captures included. This lands the build-time answer.

## MZR004 — the closure-capture mirror of MZR001

A patch passed to `OptimisticActionContext.Apply` is stored in the overlay and **re-executed by the view's computation on whichever flow pulls** the optimistic state, so everything its closure captures crosses flows exactly like a node value. The new `OptimisticPatchCaptureAnalyzer` flags, once per captured symbol per patch:

- captured **locals/parameters whose type is not Sendable** (same `SendableSymbolClassifier` verdicts as MZR001; type parameters keep the benefit of the doubt)
- reads of **writable state on the enclosing object** (non-readonly fields, settable properties) — the patch re-reads them on other flows while the owner mutates them freely
- reads of **readonly/get-only members of non-Sendable types** — the object handed out is what gets shared

Reads of Sendable-typed captures stay unflagged: capturing the action payload or other immutable snapshots is the idiomatic pattern (the sample app's patches pass untouched).

## `Apply` is now a computation host

Instead of duplicating mutation detection, `Apply` joins `FactoryMethods`' host classifications — semantically exact, since the patch is genuinely engine-executed (unlike action *bodies*, which remain deliberately unclassified per the ADR). That extends two existing rules for free:

- a captured-state **write** inside a patch is MZR002's data race
- a **`Set`** inside a patch is MZR003's flagged runtime throw (patches run inside the view memo's recompute, whose flow holds the evaluation lock)

`IsDeclaredOutside` moved from `CapturedMutationAnalyzer` to `ComputationLambdas` so both rules share the capture-scope test.

## Docs

- ADR 0004 gains the MZR004 rule section (what is flagged, what deliberately is not, and why the runtime cannot do this)
- ADR 0007's status + strict-mode gap note record the closure; remaining phase-5 items are the `WriteBatch` decision and actor-engine parity
- README rule table gains MZR004 (and MZR003's row now mentions `Invalidate`); `AnalyzerReleases.Unshipped.md` tracks the new rule

## Verification

- 8 new analyzer tests: 5 for MZR004 (flag/no-flag matrix incl. the once-per-symbol dedupe), 2 for MZR002-on-patches, 1 for MZR003-in-patches
- Full solution green: 349 + 67 + 5 + 3 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FcJVUrrWsXMKY5TqUnYeM

---
_Generated by [Claude Code](https://claude.ai/code/session_019FcJVUrrWsXMKY5TqUnYeM)_